### PR TITLE
Proposition to improve the transformer workflow

### DIFF
--- a/src/Go/Instrument/ClassLoading/SourceTransformingLoader.php
+++ b/src/Go/Instrument/ClassLoading/SourceTransformingLoader.php
@@ -29,6 +29,11 @@ class SourceTransformingLoader extends PhpStreamFilter implements LoadTimeWeaver
      */
     const FILTER_IDENTIFIER = 'go.source.transforming.loader';
 
+    /**	
+     * String buffer
+     *
+     * @var string
+     */
     protected $data = '';
     
     /**

--- a/src/Go/Instrument/ClassLoading/SourceTransformingLoader.php
+++ b/src/Go/Instrument/ClassLoading/SourceTransformingLoader.php
@@ -29,13 +29,8 @@ class SourceTransformingLoader extends PhpStreamFilter implements LoadTimeWeaver
      */
     const FILTER_IDENTIFIER = 'go.source.transforming.loader';
 
-    /**
-     * String buffer
-     *
-     * @var string
-     */
     protected $data = '';
-
+    
     /**
      * Filter bucket resource
      *
@@ -106,8 +101,9 @@ class SourceTransformingLoader extends PhpStreamFilter implements LoadTimeWeaver
 
             // $this->stream contains pointer to the source
             $metadata = new StreamMetaData($this->stream);
+            $metadata->source = $this->data;
 
-            $this->bucket->data    = $this->transformCode($this->data, $metadata);
+            $this->bucket->data    = $this->transformCode($metadata);
             $this->bucket->datalen = strlen($this->bucket->data);
             if (!empty($this->bucket->data)) {
                 stream_bucket_append($out, $this->bucket);
@@ -145,17 +141,15 @@ class SourceTransformingLoader extends PhpStreamFilter implements LoadTimeWeaver
     /**
      * Transforms source code by passing it through all transformers
      *
-     * @param string $code Source code
      * @param StreamMetaData|null $metadata Metadata from stream
      *
      * @return string Transformed source code
      */
-    protected function transformCode($code, StreamMetaData $metadata = null)
+    protected function transformCode(StreamMetaData $metadata)
     {
-        $transformedSourceCode = $code;
         foreach (self::$transformers as $transformer) {
-            $transformedSourceCode = $transformer->transform($transformedSourceCode, $metadata);
+            $transformer->transform($metadata);
         }
-        return $transformedSourceCode;
+        return $metadata->source;
     }
 }

--- a/src/Go/Instrument/ClassLoading/SourceTransformingLoader.php
+++ b/src/Go/Instrument/ClassLoading/SourceTransformingLoader.php
@@ -108,7 +108,8 @@ class SourceTransformingLoader extends PhpStreamFilter implements LoadTimeWeaver
             $metadata = new StreamMetaData($this->stream);
             $metadata->source = $this->data;
 
-            $this->bucket->data    = $this->transformCode($metadata);
+            $this->transformCode($metadata);
+            $this->bucket->data = $metadata->source;
             $this->bucket->datalen = strlen($this->bucket->data);
             if (!empty($this->bucket->data)) {
                 stream_bucket_append($out, $this->bucket);
@@ -147,14 +148,12 @@ class SourceTransformingLoader extends PhpStreamFilter implements LoadTimeWeaver
      * Transforms source code by passing it through all transformers
      *
      * @param StreamMetaData|null $metadata Metadata from stream
-     *
-     * @return string Transformed source code
+     * @return void
      */
     protected function transformCode(StreamMetaData $metadata)
     {
         foreach (self::$transformers as $transformer) {
             $transformer->transform($metadata);
         }
-        return $metadata->source;
     }
 }

--- a/src/Go/Instrument/Transformer/AopProxyTransformer.php
+++ b/src/Go/Instrument/Transformer/AopProxyTransformer.php
@@ -50,12 +50,11 @@ class AopProxyTransformer implements SourceTransformer
     /**
      * This method may transform the supplied source and return a new replacement for it
      *
-     * @param string $source Source for class
      * @param StreamMetaData $metadata Metadata for source
      *
      * @return string Transformed source
      */
-    public function transform($source, StreamMetaData $metadata)
+    public function transform(StreamMetaData $metadata)
     {
         $fileName = realpath($metadata->getResourceUri());
         if ($this->includePaths) {
@@ -67,11 +66,11 @@ class AopProxyTransformer implements SourceTransformer
                 }
             }
             if (!$found) {
-                return $source;
+                return;
             }
         }
 
-        $parsedSource = $this->broker->processString($source, $fileName, true);
+        $parsedSource = $this->broker->processString($metadata->source, $fileName, true);
 
         /** @var $namespaces ReflectionFileNamespace[] */
         $namespaces = $parsedSource->getNamespaces();
@@ -104,7 +103,7 @@ class AopProxyTransformer implements SourceTransformer
                     $newParentName = $class->getShortName() . AspectContainer::AOP_PROXIED_SUFFIX;
 
                     // Replace original class name with new
-                    $source = $this->adjustOriginalClass($class, $source, $newParentName);
+                    $metadata->source = $this->adjustOriginalClass($class, $metadata->source, $newParentName);
 
                     // Prepare child Aop proxy
                     $child  = AopChildFactory::generate($class, $advices);
@@ -113,11 +112,10 @@ class AopProxyTransformer implements SourceTransformer
                     $child->setParentName($newParentName);
 
                     // Add child to source
-                    $source .= $child;
+                    $metadata->source .= $child;
                 }
             }
         }
-        return $source;
     }
 
     /**

--- a/src/Go/Instrument/Transformer/AopProxyTransformer.php
+++ b/src/Go/Instrument/Transformer/AopProxyTransformer.php
@@ -51,8 +51,7 @@ class AopProxyTransformer implements SourceTransformer
      * This method may transform the supplied source and return a new replacement for it
      *
      * @param StreamMetaData $metadata Metadata for source
-     *
-     * @return string Transformed source
+     * @return void
      */
     public function transform(StreamMetaData $metadata)
     {

--- a/src/Go/Instrument/Transformer/CachingTransformer.php
+++ b/src/Go/Instrument/Transformer/CachingTransformer.php
@@ -58,8 +58,7 @@ class CachingTransformer implements SourceTransformer
      * This method may transform the supplied source and return a new replacement for it
      *
      * @param StreamMetaData $metadata Metadata for source
-     *
-     * @return string Transformed source
+     * @return void
      */
     public function transform(StreamMetaData $metadata)
     {
@@ -81,7 +80,7 @@ class CachingTransformer implements SourceTransformer
         // TODO: add more accurate cache invalidation, like in Symfony2
         if ($cacheModified < $lastModified || !$container->isFresh($cacheModified)) {
             @mkdir(dirname($cacheUri), 0770, true);
-            $metadata->source = $this->processTransformers($metadata->source, $metadata);
+            $this->processTransformers($metadata);
             file_put_contents($cacheUri, $metadata->source);
             return;
         }
@@ -92,14 +91,12 @@ class CachingTransformer implements SourceTransformer
      * Iterates over transformers
      *
      * @param StreamMetaData $metadata Metadata for source code
-     *
-     * @return string
+     * @return void
      */
     private function processTransformers(StreamMetaData $metadata)
     {
         foreach ($this->transformers as $transformer) {
             $transformer->transform($metadata);
         }
-        return $metadata;
     }
 }

--- a/src/Go/Instrument/Transformer/FilterInjectorTransformer.php
+++ b/src/Go/Instrument/Transformer/FilterInjectorTransformer.php
@@ -122,8 +122,7 @@ class FilterInjectorTransformer implements SourceTransformer
      * Wrap all includes into rewrite filter
      *
      * @param StreamMetaData $metadata Metadata for source
-     *
-     * @return string Transformed source
+     * @return void
      */
     public function transform(StreamMetaData $metadata)
     {

--- a/src/Go/Instrument/Transformer/FilterInjectorTransformer.php
+++ b/src/Go/Instrument/Transformer/FilterInjectorTransformer.php
@@ -121,15 +121,14 @@ class FilterInjectorTransformer implements SourceTransformer
     /**
      * Wrap all includes into rewrite filter
      *
-     * @param string $source Source for class
      * @param StreamMetaData $metadata Metadata for source
      *
      * @return string Transformed source
      */
-    public function transform($source, StreamMetaData $metadata)
+    public function transform(StreamMetaData $metadata)
     {
-        if ((strpos($source, 'include')===false) && (strpos($source, 'require')===false)) {
-            return $source;
+        if ((strpos($metadata->source, 'include')===false) && (strpos($metadata->source, 'require')===false)) {
+            return;
         }
         static $lookFor = array(
             T_INCLUDE      => true,
@@ -137,7 +136,7 @@ class FilterInjectorTransformer implements SourceTransformer
             T_REQUIRE      => true,
             T_REQUIRE_ONCE => true
         );
-        $tokenStream       = token_get_all($source);
+        $tokenStream       = token_get_all($metadata->source);
 
         $transformedSource = '';
         $isWaitingEnd      = false;
@@ -153,6 +152,6 @@ class FilterInjectorTransformer implements SourceTransformer
                 $transformedSource  .= ' \\' . __CLASS__ . '::rewrite(';
             }
         }
-        return $transformedSource;
+        $metadata->source = $transformedSource;
     }
 }

--- a/src/Go/Instrument/Transformer/MagicConstantTransformer.php
+++ b/src/Go/Instrument/Transformer/MagicConstantTransformer.php
@@ -45,31 +45,30 @@ class MagicConstantTransformer implements SourceTransformer
     /**
      * This method may transform the supplied source and return a new replacement for it
      *
-     * @param string $source Source for class
      * @param StreamMetaData $metadata Metadata for source
      *
      * @return string Transformed source
      */
-    public function transform($source, StreamMetaData $metadata)
+    public function transform(StreamMetaData $metadata)
     {
         // Make the job only when we use cache directory
         if (!self::$rewriteToPath) {
-            return $source;
+            return;
         }
 
-        $hasReflecitionFilename = strpos($source, 'getFileName') !== false;
-        $notHasMagicConsts      = (strpos($source, '__DIR__') === false) && (strpos($source, '__FILE__') === false);
+        $hasReflecitionFilename = strpos($metadata->source, 'getFileName') !== false;
+        $notHasMagicConsts      = (strpos($metadata->source, '__DIR__') === false) && (strpos($metadata->source, '__FILE__') === false);
 
         if ($notHasMagicConsts && !$hasReflecitionFilename) {
-            return $source;
+            return;
         }
 
         // Resolve magic constanst
         if (!$notHasMagicConsts) {
             $originalUri = $metadata->getResourceUri();
 
-            $source = strtr(
-                $source,
+            $metadata->source = strtr(
+                $metadata->source,
                 array(
                     '__DIR__'  => "'" . dirname($originalUri) . "'",
                     '__FILE__' => "'" . $originalUri . "'",
@@ -79,14 +78,14 @@ class MagicConstantTransformer implements SourceTransformer
 
         if ($hasReflecitionFilename) {
             // TODO: need to make more reliable solution
-            $source = preg_replace(
+            $metadata->source = preg_replace(
                 '/\$([\w\$\-\>\:\(\)]*?getFileName\(\))/S',
                 '\\' . __CLASS__ . '::resolveFileName(\$\1)',
-                $source
+                $metadata->source
             );
         }
 
-        return $source;
+        return;
     }
 
     /**

--- a/src/Go/Instrument/Transformer/MagicConstantTransformer.php
+++ b/src/Go/Instrument/Transformer/MagicConstantTransformer.php
@@ -46,8 +46,7 @@ class MagicConstantTransformer implements SourceTransformer
      * This method may transform the supplied source and return a new replacement for it
      *
      * @param StreamMetaData $metadata Metadata for source
-     *
-     * @return string Transformed source
+     * @return void
      */
     public function transform(StreamMetaData $metadata)
     {
@@ -84,8 +83,6 @@ class MagicConstantTransformer implements SourceTransformer
                 $metadata->source
             );
         }
-
-        return;
     }
 
     /**

--- a/src/Go/Instrument/Transformer/SourceTransformer.php
+++ b/src/Go/Instrument/Transformer/SourceTransformer.php
@@ -18,10 +18,9 @@ interface SourceTransformer
     /**
      * This method may transform the supplied source and return a new replacement for it
      *
-     * @param string $source Source for class
      * @param StreamMetaData $metadata Metadata for source
      *
      * @return string Transformed source
      */
-    public function transform($source, StreamMetaData $metadata);
+    public function transform(StreamMetaData $metadata);
 }

--- a/src/Go/Instrument/Transformer/SourceTransformer.php
+++ b/src/Go/Instrument/Transformer/SourceTransformer.php
@@ -19,8 +19,7 @@ interface SourceTransformer
      * This method may transform the supplied source and return a new replacement for it
      *
      * @param StreamMetaData $metadata Metadata for source
-     *
-     * @return string Transformed source
+     * @return void
      */
     public function transform(StreamMetaData $metadata);
 }

--- a/src/Go/Instrument/Transformer/StreamMetaData.php
+++ b/src/Go/Instrument/Transformer/StreamMetaData.php
@@ -25,6 +25,7 @@ use InvalidArgumentException;
  * @property string mode the type of access required for this stream
  * @property bool seekable whether the current stream can be seeked.
  * @property string uri the URI/filename associated with this stream.
+ * @property source source of the stream.
  */
 class StreamMetaData extends ArrayObject
 {
@@ -40,10 +41,10 @@ class StreamMetaData extends ArrayObject
         if (!is_resource($stream)) {
             throw new InvalidArgumentException("Stream should be valid resource");
         }
-        if($source) {
-            $this->source = $source;
-        }
         $metadata = stream_get_meta_data($stream);
+        if($source) {
+            $metadata['source'] = $source;
+        }
         parent::__construct($metadata, ArrayObject::ARRAY_AS_PROPS);
     }
 

--- a/src/Go/Instrument/Transformer/StreamMetaData.php
+++ b/src/Go/Instrument/Transformer/StreamMetaData.php
@@ -35,10 +35,13 @@ class StreamMetaData extends ArrayObject
      *
      * @throws \InvalidArgumentException for invalid stream
      */
-    public function __construct($stream)
+    public function __construct($stream, $source = null)
     {
         if (!is_resource($stream)) {
             throw new InvalidArgumentException("Stream should be valid resource");
+        }
+        if($source) {
+            $this->source = $source;
         }
         $metadata = stream_get_meta_data($stream);
         parent::__construct($metadata, ArrayObject::ARRAY_AS_PROPS);

--- a/tests/Go/Instrument/Transformer/_files/Foo.php
+++ b/tests/Go/Instrument/Transformer/_files/Foo.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace mock;
+
 class Foo
 {
 


### PR DESCRIPTION
Wrap the source with the stream metadatas. Because, someone transformer
need source, someone do not need source. With a global wrapper (the
StreamMetaData), each transform is based on only one object.
