### PR TITLE
[Core] Implement lazy-loading for services

### DIFF
--- a/src/Go/Core/AspectKernel.php
+++ b/src/Go/Core/AspectKernel.php
@@ -8,10 +8,6 @@
 
 namespace Go\Core;
 
-use Dissect\Parser\LALR1\Parser;
-use Go\Aop\Pointcut\PointcutGrammar;
-use Go\Aop\Pointcut\PointcutLexer;
-use Go\Instrument\RawAnnotationReader;
 use Go\Instrument\ClassLoading\UniversalClassLoader;
 use Go\Instrument\ClassLoading\SourceTransformingLoader;
 use Go\Instrument\Transformer\SourceTransformer;
@@ -20,7 +16,6 @@ use Go\Instrument\Transformer\CachingTransformer;
 use Go\Instrument\Transformer\FilterInjectorTransformer;
 use Go\Instrument\Transformer\MagicConstantTransformer;
 
-use Doctrine\Common\Annotations\AnnotationReader;
 use Doctrine\Common\Annotations\AnnotationRegistry;
 
 use TokenReflection;
@@ -101,26 +96,6 @@ abstract class AspectKernel
 
         // Load application configurator
         $sourceLoaderFilter->load($this->options['appLoader']);
-
-        // Register all services in the container
-        $aspectLoader = new AspectLoader($container);
-        $container->set('aspect.loader', $aspectLoader);
-
-        // TODO: use cached annotation reader
-        $container->set('aspect.annotation.reader', new AnnotationReader());
-        $container->set('aspect.annotation.raw.reader', new RawAnnotationReader());
-
-        // Pointcut services
-        $container->set('aspect.pointcut.lexer', new PointcutLexer());
-        $container->set('aspect.pointcut.parser', new Parser(
-            new PointcutGrammar(),
-            // Include production parse table for parser
-            include __DIR__ . '/../Aop/Pointcut/PointcutParseTable.php'
-        ));
-
-        // Register general aspect loader extension
-        $aspectLoader->registerLoaderExtension(new GeneralAspectLoaderExtension());
-        $aspectLoader->registerLoaderExtension(new IntroductionAspectExtension());
 
         // Register kernel resources in the container
         $this->addKernelResourcesToContainer($container);

--- a/src/Go/Core/AspectLoader.php
+++ b/src/Go/Core/AspectLoader.php
@@ -62,9 +62,6 @@ class AspectLoader
     {
         $refAspect = new \ReflectionClass($aspect);
 
-        // Register dependency resource for aspect
-        $this->container->addResource($refAspect->getFileName());
-
         if (!empty($this->loaders[AspectLoaderExtension::TARGET_CLASS])) {
             $this->loadFrom($aspect, $refAspect, $this->loaders[AspectLoaderExtension::TARGET_CLASS]);
         }

--- a/src/Go/Core/Container.php
+++ b/src/Go/Core/Container.php
@@ -1,0 +1,81 @@
+<?php
+/**
+ * Go! OOP&AOP PHP framework
+ *
+ * @copyright     Copyright 2012, Lissachenko Alexander <lisachenko.it@gmail.com>
+ * @license       http://www.opensource.org/licenses/mit-license.php The MIT License
+ */
+
+namespace Go\Core;
+
+/**
+ * DI-container
+ */
+class Container
+{
+    /**
+     * List of services in the container
+     *
+     * @var array
+     */
+    protected $values = array();
+
+    /**
+     * Store identifiers os services by tags
+     *
+     * @var array
+     */
+    protected $tags = array();
+
+    /**
+     * Set a service into the container
+     *
+     * @param string $id Identifier
+     * @param mixed $value Value to store
+     * @param array $tags Additional tags
+     */
+    public function set($id, $value, array $tags = array())
+    {
+        $this->values[$id] = $value;
+        foreach ($tags as $tag) {
+            $this->tags[$tag][] = $id;
+        }
+    }
+
+    /**
+     * Return a service or value from the container
+     *
+     * @param string $id Identifier
+     *
+     * @return mixed
+     * @throws \OutOfBoundsException if service was not found
+     */
+    public function get($id)
+    {
+        if (!isset($this->values[$id])) {
+            throw new \OutOfBoundsException("Value {$id} is not defined in the container");
+        }
+        if (is_callable($this->values[$id])) {
+            return $this->values[$id]($this);
+        } else {
+            return $this->values[$id];
+        }
+    }
+
+    /**
+     * Return list of service tagged with marker
+     *
+     * @param string $tag Tag to select
+     * @return array
+     */
+    public function getByTag($tag)
+    {
+        $result = array();
+        if (isset($this->tags[$tag])) {
+            foreach ($this->tags[$tag] as $id) {
+                $result[$id] = $this->get($id);
+            }
+        }
+        return $result;
+    }
+}


### PR DESCRIPTION
Currently all services registered directly in the container, this can take additional time for loading.
One more thing: there is no need to load advisors from aspects, because advices are cached for class. If class need advices then we should load advisors and pointcuts and make the job.
This PR introduces a DI-container that delays services initialization.
