### PR TITLE
fix when include used with ternary operator

### DIFF
--- a/src/Go/Instrument/Transformer/FilterInjectorTransformer.php
+++ b/src/Go/Instrument/Transformer/FilterInjectorTransformer.php
@@ -151,7 +151,7 @@ class FilterInjectorTransformer implements SourceTransformer
         $transformedSource = '';
         $isWaitingEnd      = false;
         foreach ($tokenStream as $token) {
-            if ($isWaitingEnd && ($token === ';' || $token === ',')) {
+            if ($isWaitingEnd && ($token === ';' || $token === ',' || $token === ':')) {
                 $isWaitingEnd = false;
                 $transformedSource .= ', __DIR__)';
             }


### PR DESCRIPTION
fix for "$xx = ? include(xx) : 'yy'" thing (Yii2)

fix when include used with ternary operator like: https://github.com/yiisoft/yii2-framework/blob/master/yii/helpers/SecurityBase.php#L123

Yep, Go AOP was patching easier then Yii2 
