### PR TITLE
Use tokenizer for inserting child class

### DIFF
--- a/tests/Go/Instrument/Transformer/WeavingTransformerTest.php
+++ b/tests/Go/Instrument/Transformer/WeavingTransformerTest.php
@@ -204,6 +204,19 @@ class WeavingTransformerTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * Testcase for multiple classes (@see https://github.com/lisachenko/go-aop-php/issues/71)
+     */
+    public function testMultipleClasses()
+    {
+        $this->metadata->source = $this->loadTest('multiple-classes');
+        $this->transformer->transform($this->metadata);
+
+        $actual   = $this->normalizeWhitespaces($this->metadata->source);
+        $expected = $this->normalizeWhitespaces($this->loadTest('multiple-classes-woven'));
+        $this->assertEquals($expected, $actual);
+    }
+
+    /**
      * Normalizes string context
      *
      * @param string $value

--- a/tests/Go/Instrument/Transformer/_files/multiple-classes-woven.php
+++ b/tests/Go/Instrument/Transformer/_files/multiple-classes-woven.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Test\ns3;
+
+class TestClass1__AopProxied {
+    public static function test() {}
+}
+
+class TestClass1 extends TestClass1__AopProxied implements \Go\Aop\Proxy
+{
+
+    /**
+     *Property was created automatically, do not change it manually
+     */
+    private static $__joinPoints = array();
+
+    public static function test()
+    {
+        return self::$__joinPoints['static:test']->__invoke(get_called_class());
+    }
+
+}
+\Go\Proxy\ClassProxy::injectJoinPoints('Test\ns3\TestClass1', unserialize('a:1:{s:11:"method:test";b:1;}'));
+
+TestClass1::test();
+
+class TestClass11__AopProxied {
+    public static function test() {}
+}
+
+class TestClass11 extends TestClass11__AopProxied implements \Go\Aop\Proxy
+{
+
+    /**
+     *Property was created automatically, do not change it manually
+     */
+    private static $__joinPoints = array();
+
+    public static function test()
+    {
+        return self::$__joinPoints['static:test']->__invoke(get_called_class());
+    }
+
+}
+\Go\Proxy\ClassProxy::injectJoinPoints('Test\ns3\TestClass11', unserialize('a:1:{s:11:"method:test";b:1;}'));
+
+TestClass11::test();
+
+class TestClass2__AopProxied {
+    public static function test() {}
+}
+
+class TestClass2 extends TestClass2__AopProxied implements \Go\Aop\Proxy
+{
+
+    /**
+     *Property was created automatically, do not change it manually
+     */
+    private static $__joinPoints = array();
+
+    public static function test()
+    {
+        return self::$__joinPoints['static:test']->__invoke(get_called_class());
+    }
+
+}
+\Go\Proxy\ClassProxy::injectJoinPoints('Test\ns3\TestClass2', unserialize('a:1:{s:11:"method:test";b:1;}'));
+
+TestClass2::test();

--- a/tests/Go/Instrument/Transformer/_files/multiple-classes.php
+++ b/tests/Go/Instrument/Transformer/_files/multiple-classes.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Test\ns3;
+
+class TestClass1 {
+    public static function test() {}
+}
+
+TestClass1::test();
+
+class TestClass11 {
+    public static function test() {}
+}
+
+TestClass11::test();
+
+class TestClass2 {
+    public static function test() {}
+}
+
+TestClass2::test();


### PR DESCRIPTION
With this change we can work with AspectMock & Yii.

Also, constructions like this:

``` php
<?php

class Classname {
    public function autoload($class) {
        include $class . '.php';
    }
}

spl_autoload_register(array('Classname', 'autoload'));
```

now processed successfully (before that patch we get a fatal error - because `Classname` was replaced with `Classname__AopProxied` and `Classname` definition appended to the end of file, after `spl_autoload_register`)
