### PR TITLE
defensive try..catch block for type hint bug of Intl ext in PHP 5.5.x

### DIFF
--- a/src/Go/Proxy/FunctionProxy.php
+++ b/src/Go/Proxy/FunctionProxy.php
@@ -297,8 +297,15 @@ BODY;
         $type = '';
         if ($parameter->isArray()) {
             $type = 'array';
-        } elseif ($parameter->getClass()) {
-            $type = '\\' . $parameter->getClass()->name;
+        } else {
+            try {
+                $cls = $parameter->getClass();
+                if ($cls) {
+                    $type = '\\' . $cls->name;
+                }
+            } catch (\ReflectionException $e) {
+                // ignore
+            }
         }
         $defaultValue = null;
         $isDefaultValueAvailable = $parameter->isDefaultValueAvailable();


### PR DESCRIPTION
Current demo of interception for internal functions will throw exception in PHP5.5 . See https://gist.github.com/hax/9479075 for the root cause.
