### PR TITLE
[Feature] Allow to use advisors directly without serialization

### DIFF
--- a/src/Go/Aop/Framework/AbstractJoinpoint.php
+++ b/src/Go/Aop/Framework/AbstractJoinpoint.php
@@ -76,7 +76,7 @@ abstract class AbstractJoinpoint implements Joinpoint
     public static function sortAdvices(array $advices)
     {
         $sortedAdvices = $advices;
-        usort($sortedAdvices, function (Advice $first, Advice $second) {
+        uasort($sortedAdvices, function(Advice $first, Advice $second) {
             switch (true) {
                 case $first instanceof AdviceBefore && !($second instanceof AdviceBefore):
                     return -1;

--- a/src/Go/Aop/Framework/BaseInterceptor.php
+++ b/src/Go/Aop/Framework/BaseInterceptor.php
@@ -21,18 +21,11 @@ use Go\Aop\Intercept\Interceptor;
 class BaseInterceptor extends BaseAdvice implements Interceptor, Serializable
 {
     /**
-     * Name of the aspect
-     *
-     * @var string
-     */
-    public $aspectName = '';
-
-    /**
      * Pointcut instance
      *
      * @var null|Pointcut
      */
-    public $pointcut = null;
+    protected $pointcut = null;
 
     /**
      * Advice to call

--- a/src/Go/Core/AdviceMatcher.php
+++ b/src/Go/Core/AdviceMatcher.php
@@ -89,7 +89,7 @@ class AdviceMatcher
             $this->loadAdvisorsAndPointcuts();
         }
 
-        foreach ($this->container->getByTag('advisor') as $advisor) {
+        foreach ($this->container->getByTag('advisor') as $advisorId => $advisor) {
 
             if ($advisor instanceof Aop\PointcutAdvisor) {
 
@@ -98,7 +98,7 @@ class AdviceMatcher
                 if ($isFunctionAdvisor && $pointcut->getClassFilter()->matches($namespace)) {
                     $advices = array_merge_recursive(
                         $advices,
-                        $this->getFunctionAdvicesFromAdvisor($namespace, $advisor, $pointcut)
+                        $this->getFunctionAdvicesFromAdvisor($namespace, $advisor, $advisorId, $pointcut)
                     );
                 }
             }
@@ -133,7 +133,7 @@ class AdviceMatcher
             $originalClass = $class;
         }
 
-        foreach ($this->container->getByTag('advisor') as $advisor) {
+        foreach ($this->container->getByTag('advisor') as $advisorId => $advisor) {
 
             if ($advisor instanceof Aop\PointcutAdvisor) {
 
@@ -141,7 +141,7 @@ class AdviceMatcher
                 if ($pointcut->getClassFilter()->matches($class)) {
                     $classAdvices = array_merge_recursive(
                         $classAdvices,
-                        $this->getAdvicesFromAdvisor($originalClass, $advisor, $pointcut)
+                        $this->getAdvicesFromAdvisor($originalClass, $advisor, $advisorId, $pointcut)
                     );
                 }
             }
@@ -150,7 +150,7 @@ class AdviceMatcher
                 if ($advisor->getClassFilter()->matches($class)) {
                     $classAdvices = array_merge_recursive(
                         $classAdvices,
-                        $this->getIntroductionFromAdvisor($originalClass, $advisor)
+                        $this->getIntroductionFromAdvisor($originalClass, $advisor, $advisorId)
                     );
                 }
             }
@@ -168,7 +168,7 @@ class AdviceMatcher
      *
      * @return array
      */
-    private function getAdvicesFromAdvisor($class, Aop\PointcutAdvisor $advisor, Aop\PointFilter $filter)
+    private function getAdvicesFromAdvisor($class, Aop\PointcutAdvisor $advisor, $advisorId, Aop\PointFilter $filter)
     {
         $classAdvices = array();
 
@@ -180,7 +180,7 @@ class AdviceMatcher
                 /** @var $method ReflectionMethod| */
                 if ($method->getDeclaringClass()->name == $class->name && $filter->matches($method)) {
                     $prefix = $method->isStatic() ? AspectContainer::STATIC_METHOD_PREFIX : AspectContainer::METHOD_PREFIX;
-                    $classAdvices[$prefix][$method->name][] = $advisor->getAdvice();
+                    $classAdvices[$prefix][$method->name][$advisorId] = $advisor->getAdvice();
                 }
             }
         }
@@ -191,7 +191,7 @@ class AdviceMatcher
             foreach ($class->getProperties($mask) as $property) {
                 /** @var $property ReflectionProperty */
                 if ($filter->matches($property)) {
-                    $classAdvices[AspectContainer::PROPERTY_PREFIX][$property->name][] = $advisor->getAdvice();
+                    $classAdvices[AspectContainer::PROPERTY_PREFIX][$property->name][$advisorId] = $advisor->getAdvice();
                 }
             }
         }
@@ -207,7 +207,7 @@ class AdviceMatcher
      *
      * @return array
      */
-    private function getIntroductionFromAdvisor($class, $advisor)
+    private function getIntroductionFromAdvisor($class, $advisor, $advisorId)
     {
         // Do not make introduction for traits
         if ($class->isTrait()) {
@@ -217,9 +217,8 @@ class AdviceMatcher
         /** @var $advice Aop\IntroductionInfo */
         $advice = $advisor->getAdvice();
 
-        return array(
-            AspectContainer::INTRODUCTION_TRAIT_PREFIX => array($advice)
-        );
+        $classAdvices[AspectContainer::INTRODUCTION_TRAIT_PREFIX][$advisorId] = $advice;
+        return $classAdvices;
     }
 
     /**
@@ -251,7 +250,7 @@ class AdviceMatcher
      *
      * @return array
      */
-    private function getFunctionAdvicesFromAdvisor($namespace, $advisor, $pointcut)
+    private function getFunctionAdvicesFromAdvisor($namespace, $advisor, $advisorId, $pointcut)
     {
         $functions = array();
         $advices   = array();
@@ -265,7 +264,7 @@ class AdviceMatcher
 
         foreach ($functions as $functionName=>$function) {
             if ($pointcut->matches($function)) {
-                $advices[AspectContainer::FUNCTION_PREFIX][$functionName][] = $advisor->getAdvice();
+                $advices[AspectContainer::FUNCTION_PREFIX][$functionName][$advisorId] = $advisor->getAdvice();
             }
         }
 

--- a/src/Go/Core/AdviceMatcher.php
+++ b/src/Go/Core/AdviceMatcher.php
@@ -40,13 +40,6 @@ class AdviceMatcher
     protected $container;
 
     /**
-     * List of resources that was loaded
-     *
-     * @var array
-     */
-    protected $loadedResources = array();
-
-    /**
      * Flag to enable/disable support of global function interception
      *
      * @var bool
@@ -85,9 +78,7 @@ class AdviceMatcher
 
         $advices = array();
 
-        if ($this->loadedResources != $this->container->getResources()) {
-            $this->loadAdvisorsAndPointcuts();
-        }
+        $this->loader->loadAdvisorsAndPointcuts();
 
         foreach ($this->container->getByTag('advisor') as $advisorId => $advisor) {
 
@@ -116,9 +107,7 @@ class AdviceMatcher
      */
     public function getAdvicesForClass($class)
     {
-        if ($this->loadedResources != $this->container->getResources()) {
-            $this->loadAdvisorsAndPointcuts();
-        }
+        $this->loader->loadAdvisorsAndPointcuts();
 
         $classAdvices = array();
         if (!$class instanceof ReflectionClass && !$class instanceof ParsedReflectionClass) {
@@ -219,26 +208,6 @@ class AdviceMatcher
 
         $classAdvices[AspectContainer::INTRODUCTION_TRAIT_PREFIX][$advisorId] = $advice;
         return $classAdvices;
-    }
-
-    /**
-     * Load pointcuts into container
-     *
-     * There is no need to always load pointcuts, so we delay loading
-     */
-    private function loadAdvisorsAndPointcuts()
-    {
-        $containerResources = $this->container->getResources();
-        $resourcesToLoad    = array_diff($containerResources, $this->loadedResources);
-
-        // TODO: maybe this is a task for the AspectLoader?
-        foreach ($this->container->getByTag('aspect') as $aspect) {
-            $ref = new ReflectionClass($aspect);
-            if (in_array($ref->getFileName(), $resourcesToLoad)) {
-                $this->loader->load($aspect);
-            }
-        }
-        $this->loadedResources = $containerResources;
     }
 
     /**

--- a/src/Go/Core/AdviceMatcher.php
+++ b/src/Go/Core/AdviceMatcher.php
@@ -62,7 +62,6 @@ class AdviceMatcher
     }
 
     /**
-     *
      * Returns list of function advices for namespace
      *
      * @param ReflectionFileNamespace $namespace
@@ -153,6 +152,7 @@ class AdviceMatcher
      *
      * @param ReflectionClass|ParsedReflectionClass $class Class to inject advices
      * @param Aop\PointcutAdvisor $advisor Advisor for class
+     * @param string $advisorId Identifier of advisor
      * @param Aop\PointFilter $filter Filter for points
      *
      * @return array
@@ -193,6 +193,7 @@ class AdviceMatcher
      *
      * @param ReflectionClass|ParsedReflectionClass $class Class to inject advices
      * @param Aop\IntroductionAdvisor $advisor Advisor for class
+     * @param string $advisorId Identifier of advisor
      *
      * @return array
      */
@@ -215,6 +216,7 @@ class AdviceMatcher
      *
      * @param ReflectionFileNamespace $namespace
      * @param Aop\PointcutAdvisor $advisor Advisor for class
+     * @param string $advisorId Identifier of advisor
      * @param Aop\PointFilter $pointcut Filter for points
      *
      * @return array

--- a/src/Go/Core/AspectLoader.php
+++ b/src/Go/Core/AspectLoader.php
@@ -77,7 +77,7 @@ class AspectLoader
      *
      * @param \Go\Aop\Aspect $aspect
      */
-    final public function load(Aspect $aspect)
+    public function load(Aspect $aspect)
     {
         $refAspect = new \ReflectionClass($aspect);
 

--- a/src/Go/Core/CachedAspectLoader.php
+++ b/src/Go/Core/CachedAspectLoader.php
@@ -1,0 +1,97 @@
+<?php
+/**
+ * Go! AOP framework
+ *
+ * @copyright Copyright 2014, Lisachenko Alexander <lisachenko.it@gmail.com>
+ *
+ * This source file is subject to the license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Go\Core;
+
+use Doctrine\Common\Annotations\Reader;
+use Go\Aop\Aspect;
+use ReflectionClass;
+
+/**
+ * Cached loader is responsible for faster initialization of pointcuts/advisors for concrete aspect
+ */
+class CachedAspectLoader extends AspectLoader
+{
+
+    protected $cacheDir;
+
+    /**
+     * {@inheritdoc}
+     * @param array $options
+     */
+    public function __construct(AspectContainer $container, Reader $reader, array $options = array())
+    {
+        parent::__construct($container, $reader);
+        $this->cacheDir = $options['cacheDir'];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function load(Aspect $aspect)
+    {
+        $refAspect = new ReflectionClass($aspect);
+        $fileName  = $this->cacheDir . '/_aspect/' . sha1($refAspect->getName());
+
+        // If cache is present and actual, then use it
+        if (file_exists($fileName) && filemtime($fileName) >= filemtime($refAspect->getFileName())) {
+            $this->loadFromCache($fileName);
+            $this->loadedResources[] = $refAspect->getFileName();
+
+            return;
+        }
+
+        $pointcutsBefore = $this->container->getByTag('pointcut');
+        $advisorsBefore  = $this->container->getByTag('advisor');
+        parent::load($aspect);
+        $pointcutsAfter = $this->container->getByTag('pointcut');
+        $advisorsAfter  = $this->container->getByTag('advisor');
+
+        $newPointcuts = array_diff_key($pointcutsAfter, $pointcutsBefore);
+        $newAdvisors  = array_diff_key($advisorsAfter, $advisorsBefore);
+
+        if ($this->cacheDir) {
+            $content = serialize($newPointcuts + $newAdvisors);
+            if (!is_dir(dirname($fileName))) {
+                mkdir(dirname($fileName));
+            }
+            file_put_contents($fileName, $content);
+        }
+
+    }
+
+    /**
+     * Loads pointcuts and advisors from the file
+     *
+     * @param string $fileName Name of the file with cache
+     *
+     * @throws \InvalidArgumentException
+     */
+    protected function loadFromCache($fileName)
+    {
+        $content = file_get_contents($fileName);
+        $items   = unserialize($content);
+        foreach ($items as $itemName => $value) {
+            list($itemType, $itemName) = explode('.', $itemName, 2);
+            switch ($itemType) {
+                case 'pointcut':
+                    $this->container->registerPointcut($value, $itemName);
+                    break;
+
+                case 'advisor':
+                    $this->container->registerAdvisor($value, $itemName);
+                    break;
+
+                default:
+                    throw new \InvalidArgumentException("Unknown item type {$itemType}");
+            }
+        }
+    }
+}

--- a/src/Go/Core/CachedAspectLoader.php
+++ b/src/Go/Core/CachedAspectLoader.php
@@ -29,7 +29,7 @@ class CachedAspectLoader extends AspectLoader
     public function __construct(AspectContainer $container, Reader $reader, array $options = array())
     {
         parent::__construct($container, $reader);
-        $this->cacheDir = $options['cacheDir'];
+        $this->cacheDir = isset($options['cacheDir']) ? $options['cacheDir'] : null;
     }
 
     /**

--- a/src/Go/Core/Container.php
+++ b/src/Go/Core/Container.php
@@ -91,6 +91,18 @@ class Container
     }
 
     /**
+     * Checks if item with specified id is present in the container
+     *
+     * @param string $id Identifier
+     *
+     * @return bool
+     */
+    public function has($id)
+    {
+        return isset($this->values[$id]);
+    }
+
+    /**
      * Return list of service tagged with marker
      *
      * @param string $tag Tag to select

--- a/src/Go/Core/GoAspectContainer.php
+++ b/src/Go/Core/GoAspectContainer.php
@@ -49,8 +49,7 @@ class GoAspectContainer extends Container implements AspectContainer
         $this->share('aspect.loader', function ($container) {
             $aspectLoader = new AspectLoader(
                 $container,
-                $container->get('aspect.annotation.reader'),
-                $container->get('kernel.options')
+                $container->get('aspect.annotation.reader')
             );
             $lexer  = $container->get('aspect.pointcut.lexer');
             $parser = $container->get('aspect.pointcut.parser');

--- a/src/Go/Core/GoAspectContainer.php
+++ b/src/Go/Core/GoAspectContainer.php
@@ -62,6 +62,13 @@ class GoAspectContainer extends Container implements AspectContainer
             return $aspectLoader;
         });
 
+        $this->share('aspect.advisor.accessor', function ($container) {
+            return new LazyAdvisorAccessor(
+                $container,
+                $container->get('aspect.loader')
+            );
+        });
+
         $this->share('aspect.advice_matcher', function ($container) {
             return new AdviceMatcher(
                 $container->get('aspect.loader'),

--- a/src/Go/Core/GoAspectContainer.php
+++ b/src/Go/Core/GoAspectContainer.php
@@ -47,9 +47,10 @@ class GoAspectContainer extends Container implements AspectContainer
     {
         // Register all services in the container
         $this->share('aspect.loader', function ($container) {
-            $aspectLoader = new AspectLoader(
+            $aspectLoader = new CachedAspectLoader(
                 $container,
-                $container->get('aspect.annotation.reader')
+                $container->get('aspect.annotation.reader'),
+                $container->get('kernel.options')
             );
             $lexer  = $container->get('aspect.pointcut.lexer');
             $parser = $container->get('aspect.pointcut.parser');

--- a/src/Go/Core/GoAspectContainer.php
+++ b/src/Go/Core/GoAspectContainer.php
@@ -47,7 +47,7 @@ class GoAspectContainer extends Container implements AspectContainer
     {
         // Register all services in the container
         $this->share('aspect.loader', function ($container) {
-            $aspectLoader = new CachedAspectLoader(
+            $aspectLoader = new AspectLoader(
                 $container,
                 $container->get('aspect.annotation.reader'),
                 $container->get('kernel.options')
@@ -62,10 +62,19 @@ class GoAspectContainer extends Container implements AspectContainer
             return $aspectLoader;
         });
 
+        $this->share('aspect.cached.loader', function ($container) {
+            $cachedAspectLoader = new CachedAspectLoader(
+                $container,
+                'aspect.loader',
+                $container->get('kernel.options')
+            );
+            return $cachedAspectLoader;
+        });
+
         $this->share('aspect.advisor.accessor', function ($container) {
             return new LazyAdvisorAccessor(
                 $container,
-                $container->get('aspect.loader')
+                $container->get('aspect.cached.loader')
             );
         });
 

--- a/src/Go/Core/LazyAdvisorAccessor.php
+++ b/src/Go/Core/LazyAdvisorAccessor.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * Go! AOP framework
+ *
+ * @copyright Copyright 2014, Lisachenko Alexander <lisachenko.it@gmail.com>
+ *
+ * This source file is subject to the license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+
+namespace Go\Core;
+
+/**
+ * Provides an interface for loading of advisors from the container
+ */
+class LazyAdvisorAccessor
+{
+    /**
+     * @var AspectContainer|Container
+     */
+    protected $container;
+
+    /**
+     * Aspect loader instance
+     *
+     * @var AspectLoader
+     */
+    protected $loader;
+
+    /**
+     * Accessor constructor
+     *
+     * @param AspectContainer $container
+     * @param AspectLoader $loader
+     */
+    public function __construct(AspectContainer $container, AspectLoader $loader)
+    {
+        $this->container = $container;
+        $this->loader    = $loader;
+    }
+
+    /**
+     * Magic accessor
+     *
+     * @param string $name Key name
+     *
+     * @return mixed
+     */
+    public function __get($name)
+    {
+        if ($this->container->has($name)) {
+            return $this->container->get($name);
+        } else {
+            list(, $advisorName) = explode('.', $name);
+            list($aspect)        = explode('->', $advisorName);
+            $aspectInstance      = $this->container->getAspect($aspect);
+            $this->loader->load($aspectInstance);
+
+            return $this->container->get($name);
+        }
+    }
+}

--- a/src/Go/Proxy/AbstractProxy.php
+++ b/src/Go/Proxy/AbstractProxy.php
@@ -326,16 +326,15 @@ abstract class AbstractProxy
      */
     private function flattenAdvices($advices)
     {
-        foreach ($advices as &$typedAdvices) {
-            foreach ($typedAdvices as $name=>&$concreteAdvices) {
+        $flattenAdvices = array();
+        foreach ($advices as $type => $typedAdvices) {
+            foreach ($typedAdvices as $name => $concreteAdvices) {
                 if (is_array($concreteAdvices)) {
-                    $concreteAdvices = array_keys($concreteAdvices);
-                } else {
-                    unset($typedAdvices[$name]);
+                    $flattenAdvices[$type][$name] = array_keys($concreteAdvices);
                 }
             }
         }
 
-        return $advices;
+        return $flattenAdvices;
     }
 }

--- a/src/Go/Proxy/AbstractProxy.php
+++ b/src/Go/Proxy/AbstractProxy.php
@@ -99,7 +99,7 @@ abstract class AbstractProxy
         if (!$parentClass instanceof ReflectionClass && !$parentClass instanceof ParsedClass) {
             throw new \InvalidArgumentException("Invalid argument for class");
         }
-        $this->advices = $advices;
+        $this->advices = $this->flattenAdvices($advices);
         $this->class   = $parentClass;
         $this->name    = $thisName;
 
@@ -315,5 +315,27 @@ abstract class AbstractProxy
         );
 
         return $code;
+    }
+
+    /**
+     * Replace concrete advices with list of ids
+     *
+     * @param $advices
+     *
+     * @return array flatten list of advices
+     */
+    private function flattenAdvices($advices)
+    {
+        foreach ($advices as &$typedAdvices) {
+            foreach ($typedAdvices as $name=>&$concreteAdvices) {
+                if (is_array($concreteAdvices)) {
+                    $concreteAdvices = array_keys($concreteAdvices);
+                } else {
+                    unset($typedAdvices[$name]);
+                }
+            }
+        }
+
+        return $advices;
     }
 }

--- a/src/Go/Proxy/ClassProxy.php
+++ b/src/Go/Proxy/ClassProxy.php
@@ -274,7 +274,6 @@ class ClassProxy extends AbstractProxy
         if ($this->isFieldsIntercepted && (!$ctor || !$ctor->isPrivate())) {
             $this->addFieldInterceptorsCode($ctor);
         }
-        //$serialized = serialize($this->advices);
         $serialized = json_encode($this->advices);
 
         ksort($this->methodsCode);

--- a/src/Go/Proxy/ClassProxy.php
+++ b/src/Go/Proxy/ClassProxy.php
@@ -172,6 +172,11 @@ class ClassProxy extends AbstractProxy
                 continue;
             }
             foreach ($typedAdvices as $joinPointName => $advices) {
+                $advices = array_map(function ($v, $k) {
+                    $advice = AspectKernel::getInstance()->getContainer()->get($k)->getAdvice();
+                    return $advice;
+                }, $advices, array_keys($advices));
+
                 $joinpoint = new self::$invocationClassMap[$joinPointType]($className, $joinPointName, $advices);
                 $joinPoints["$joinPointType:$joinPointName"] = $joinpoint;
             }
@@ -265,7 +270,8 @@ class ClassProxy extends AbstractProxy
         if ($this->isFieldsIntercepted && (!$ctor || !$ctor->isPrivate())) {
             $this->addFieldInterceptorsCode($ctor);
         }
-        $serialized = serialize($this->advices);
+        //$serialized = serialize($this->advices);
+        $serialized = json_encode($this->advices);
 
         ksort($this->methodsCode);
         ksort($this->propertiesCode);
@@ -287,7 +293,7 @@ class ClassProxy extends AbstractProxy
             . PHP_EOL
             . '\\' . __CLASS__ . "::injectJoinPoints('"
                 . $this->class->name . "',"
-                . " unserialize(" . var_export($serialized, true) . "));";
+                . " json_decode(" . var_export($serialized, true) . ", true));";
     }
 
     /**

--- a/src/Go/Proxy/ClassProxy.php
+++ b/src/Go/Proxy/ClassProxy.php
@@ -177,9 +177,9 @@ class ClassProxy extends AbstractProxy
                 continue;
             }
             foreach ($typedAdvices as $joinPointName => $advices) {
-                $advices = array_map(function ($v, $k) use ($accessor) {
-                    return $accessor->__get($k)->getAdvice();
-                }, $advices, array_keys($advices));
+                $advices = array_map(function ($advisorName) use ($accessor) {
+                    return $accessor->__get($advisorName)->getAdvice();
+                }, $advices);
 
                 $joinpoint = new self::$invocationClassMap[$joinPointType]($className, $joinPointName, $advices);
                 $joinPoints["$joinPointType:$joinPointName"] = $joinpoint;
@@ -274,7 +274,6 @@ class ClassProxy extends AbstractProxy
         if ($this->isFieldsIntercepted && (!$ctor || !$ctor->isPrivate())) {
             $this->addFieldInterceptorsCode($ctor);
         }
-        $serialized = json_encode($this->advices);
 
         ksort($this->methodsCode);
         ksort($this->propertiesCode);
@@ -296,7 +295,7 @@ class ClassProxy extends AbstractProxy
             . PHP_EOL
             . '\\' . __CLASS__ . "::injectJoinPoints('"
                 . $this->class->name . "',"
-                . " json_decode(" . var_export($serialized, true) . ", true));";
+                . var_export($this->advices, true) . ");";
     }
 
     /**

--- a/src/Go/Proxy/FunctionProxy.php
+++ b/src/Go/Proxy/FunctionProxy.php
@@ -121,11 +121,13 @@ class FunctionProxy
         }
 
         $advices = self::$functionAdvices[$namespace][AspectContainer::FUNCTION_PREFIX][$joinPointName];
-        $advices = array_map(function ($advisorName) use ($accessor) {
-            return $accessor->__get($advisorName)->getAdvice();
-        }, $advices);
 
-        return new ReflectionFunctionInvocation($joinPointName, $advices);
+        $filledAdvices = array();
+        foreach ($advices as $advisorName) {
+            $filledAdvices[] = $accessor->$advisorName;
+        }
+
+        return new ReflectionFunctionInvocation($joinPointName, $filledAdvices);
     }
 
     /**

--- a/src/Go/Proxy/TraitProxy.php
+++ b/src/Go/Proxy/TraitProxy.php
@@ -10,6 +10,8 @@
 
 namespace Go\Proxy;
 
+use Go\Core\AspectKernel;
+use Go\Core\LazyAdvisorAccessor;
 use ReflectionClass;
 use ReflectionMethod as Method;
 use ReflectionParameter as Parameter;
@@ -89,10 +91,13 @@ class TraitProxy extends ClassProxy
         }
 
         $advices   = self::$traitAdvices[$traitName][$joinPointType][$pointName];
-        $advices = array_map(function ($v, $k) {
-            $advice = AspectKernel::getInstance()->getContainer()->get($k)->getAdvice();
-            return $advice;
+        /** @var LazyAdvisorAccessor $accessor */
+        $accessor  = AspectKernel::getInstance()->getContainer()->get('aspect.advisor.accessor');
+
+        $advices = array_map(function ($v, $k) use ($accessor) {
+            return $accessor->__get($k)->getAdvice();
         }, $advices, array_keys($advices));
+
         $joinpoint = new self::$invocationClassMap[$joinPointType]($className, $pointName . '➩', $advices);
 
         return $joinpoint;

--- a/src/Go/Proxy/TraitProxy.php
+++ b/src/Go/Proxy/TraitProxy.php
@@ -89,6 +89,10 @@ class TraitProxy extends ClassProxy
         }
 
         $advices   = self::$traitAdvices[$traitName][$joinPointType][$pointName];
+        $advices = array_map(function ($v, $k) {
+            $advice = AspectKernel::getInstance()->getContainer()->get($k)->getAdvice();
+            return $advice;
+        }, $advices, array_keys($advices));
         $joinpoint = new self::$invocationClassMap[$joinPointType]($className, $pointName . '➩', $advices);
 
         return $joinpoint;
@@ -131,7 +135,8 @@ BODY;
      */
     public function __toString()
     {
-        $serialized = serialize($this->advices);
+        //$serialized = serialize($this->advices);
+        $serialized = json_encode($this->advices);
         ksort($this->methodsCode);
         $classCode = sprintf("%s\ntrait %s\n{\n%s\n\n%s\n}",
             $this->class->getDocComment(),
@@ -148,7 +153,7 @@ BODY;
             . PHP_EOL
             . '\\' . __CLASS__ . "::injectJoinPoints('"
                 . $this->class->name . "',"
-                . " unserialize(" . var_export($serialized, true) . "));";
+                . " json_decode(" . var_export($serialized, true) . ", true));";
     }
 
     private function getMethodAliasesCode()

--- a/src/Go/Proxy/TraitProxy.php
+++ b/src/Go/Proxy/TraitProxy.php
@@ -140,7 +140,6 @@ BODY;
      */
     public function __toString()
     {
-        //$serialized = serialize($this->advices);
         $serialized = json_encode($this->advices);
         ksort($this->methodsCode);
         $classCode = sprintf("%s\ntrait %s\n{\n%s\n\n%s\n}",

--- a/src/Go/Proxy/TraitProxy.php
+++ b/src/Go/Proxy/TraitProxy.php
@@ -94,9 +94,9 @@ class TraitProxy extends ClassProxy
         /** @var LazyAdvisorAccessor $accessor */
         $accessor  = AspectKernel::getInstance()->getContainer()->get('aspect.advisor.accessor');
 
-        $advices = array_map(function ($v, $k) use ($accessor) {
-            return $accessor->__get($k)->getAdvice();
-        }, $advices, array_keys($advices));
+        $advices = array_map(function ($advisorName) use ($accessor) {
+            return $accessor->__get($advisorName)->getAdvice();
+        }, $advices);
 
         $joinpoint = new self::$invocationClassMap[$joinPointType]($className, $pointName . '➩', $advices);
 
@@ -140,7 +140,6 @@ BODY;
      */
     public function __toString()
     {
-        $serialized = json_encode($this->advices);
         ksort($this->methodsCode);
         $classCode = sprintf("%s\ntrait %s\n{\n%s\n\n%s\n}",
             $this->class->getDocComment(),
@@ -157,7 +156,7 @@ BODY;
             . PHP_EOL
             . '\\' . __CLASS__ . "::injectJoinPoints('"
                 . $this->class->name . "',"
-                . " json_decode(" . var_export($serialized, true) . ", true));";
+                . var_export($this->advices, true) . ");";
     }
 
     private function getMethodAliasesCode()

--- a/tests/Go/Aop/Framework/AbstractJoinpointTest.php
+++ b/tests/Go/Aop/Framework/AbstractJoinpointTest.php
@@ -15,10 +15,9 @@ class AbstractJoinpointTest extends \PHPUnit_Framework_TestCase
     public function testSortingLogic($advices, array $order = array())
     {
         $advices = AbstractJoinpoint::sortAdvices($advices);
-        foreach ($advices as $index => $advice) {
-            if (isset($order[$index])) {
-                $this->assertInstanceOf($order[$index], $advice);
-            }
+        foreach ($advices as $advice) {
+            $expected = array_shift($order);
+            $this->assertInstanceOf($expected, $advice);
         }
     }
 

--- a/tests/Go/Instrument/Transformer/WeavingTransformerTest.php
+++ b/tests/Go/Instrument/Transformer/WeavingTransformerTest.php
@@ -221,7 +221,7 @@ class WeavingTransformerTest extends \PHPUnit_Framework_TestCase
     protected function normalizeWhitespaces($value)
     {
         return strtr(
-            preg_replace('/^\s+$/m', '', $value),
+            preg_replace('/\s+$/m', '', $value),
             array(
                 "\r\n" => PHP_EOL,
                 "\n"   => PHP_EOL,
@@ -275,7 +275,8 @@ class WeavingTransformerTest extends \PHPUnit_Framework_TestCase
                 $this->returnCallback(function (\TokenReflection\ReflectionClass $refClass) {
                     $advices  = array();
                     foreach ($refClass->getMethods() as $method) {
-                        $advices[AspectContainer::METHOD_PREFIX][$method->name] = true;
+                        $advisorId = "advisor.{$refClass->name}->{$method->name}";
+                        $advices[AspectContainer::METHOD_PREFIX][$method->name][$advisorId] = true;
                     }
                     return $advices;
                 })

--- a/tests/Go/Instrument/Transformer/_files/class-woven.php
+++ b/tests/Go/Instrument/Transformer/_files/class-woven.php
@@ -65,4 +65,4 @@ class TestClass extends TestClass__AopProxied implements \Go\Aop\Proxy
     }
 
 }
-\Go\Proxy\ClassProxy::injectJoinPoints('Test\ns1\TestClass', unserialize('a:1:{s:6:"method";a:6:{s:12:"publicMethod";b:1;s:15:"protectedMethod";b:1;s:18:"publicStaticMethod";b:1;s:21:"protectedStaticMethod";b:1;s:28:"publicMethodDynamicArguments";b:1;s:26:"publicMethodFixedArguments";b:1;}}'));
+\Go\Proxy\ClassProxy::injectJoinPoints('Test\ns1\TestClass', json_decode('{"method":{"publicMethod":true,"protectedMethod":true,"publicStaticMethod":true,"protectedStaticMethod":true,"publicMethodDynamicArguments":true,"publicMethodFixedArguments":true}}', true));

--- a/tests/Go/Instrument/Transformer/_files/class-woven.php
+++ b/tests/Go/Instrument/Transformer/_files/class-woven.php
@@ -65,4 +65,32 @@ class TestClass extends TestClass__AopProxied implements \Go\Aop\Proxy
     }
 
 }
-\Go\Proxy\ClassProxy::injectJoinPoints('Test\ns1\TestClass', json_decode('{"method":{"publicMethod":true,"protectedMethod":true,"publicStaticMethod":true,"protectedStaticMethod":true,"publicMethodDynamicArguments":true,"publicMethodFixedArguments":true}}', true));
+\Go\Proxy\ClassProxy::injectJoinPoints('Test\ns1\TestClass',array (
+  'method' =>
+  array (
+    'publicMethod' =>
+    array (
+      0 => 'advisor.Test\\ns1\\TestClass->publicMethod',
+    ),
+    'protectedMethod' =>
+    array (
+      0 => 'advisor.Test\\ns1\\TestClass->protectedMethod',
+    ),
+    'publicStaticMethod' =>
+    array (
+      0 => 'advisor.Test\\ns1\\TestClass->publicStaticMethod',
+    ),
+    'protectedStaticMethod' =>
+    array (
+      0 => 'advisor.Test\\ns1\\TestClass->protectedStaticMethod',
+    ),
+    'publicMethodDynamicArguments' =>
+    array (
+      0 => 'advisor.Test\\ns1\\TestClass->publicMethodDynamicArguments',
+    ),
+    'publicMethodFixedArguments' =>
+    array (
+      0 => 'advisor.Test\\ns1\\TestClass->publicMethodFixedArguments',
+    ),
+  ),
+));

--- a/tests/Go/Instrument/Transformer/_files/final-class-woven.php
+++ b/tests/Go/Instrument/Transformer/_files/final-class-woven.php
@@ -41,4 +41,24 @@ final class TestFinalClass extends TestFinalClass__AopProxied implements \Go\Aop
     }
 
 }
-\Go\Proxy\ClassProxy::injectJoinPoints('Test\ns1\TestFinalClass', json_decode('{"method":{"publicMethod":true,"protectedMethod":true,"publicStaticMethod":true,"protectedStaticMethod":true}}', true));
+\Go\Proxy\ClassProxy::injectJoinPoints('Test\ns1\TestFinalClass',array (
+  'method' =>
+  array (
+    'publicMethod' =>
+    array (
+      0 => 'advisor.Test\\ns1\\TestFinalClass->publicMethod',
+    ),
+    'protectedMethod' =>
+    array (
+      0 => 'advisor.Test\\ns1\\TestFinalClass->protectedMethod',
+    ),
+    'publicStaticMethod' =>
+    array (
+      0 => 'advisor.Test\\ns1\\TestFinalClass->publicStaticMethod',
+    ),
+    'protectedStaticMethod' =>
+    array (
+      0 => 'advisor.Test\\ns1\\TestFinalClass->protectedStaticMethod',
+    ),
+  ),
+));

--- a/tests/Go/Instrument/Transformer/_files/final-class-woven.php
+++ b/tests/Go/Instrument/Transformer/_files/final-class-woven.php
@@ -41,4 +41,4 @@ final class TestFinalClass extends TestFinalClass__AopProxied implements \Go\Aop
     }
 
 }
-\Go\Proxy\ClassProxy::injectJoinPoints('Test\ns1\TestFinalClass', unserialize('a:1:{s:6:"method";a:4:{s:12:"publicMethod";b:1;s:15:"protectedMethod";b:1;s:18:"publicStaticMethod";b:1;s:21:"protectedStaticMethod";b:1;}}'));
+\Go\Proxy\ClassProxy::injectJoinPoints('Test\ns1\TestFinalClass', json_decode('{"method":{"publicMethod":true,"protectedMethod":true,"publicStaticMethod":true,"protectedStaticMethod":true}}', true));

--- a/tests/Go/Instrument/Transformer/_files/multiple-classes-woven.php
+++ b/tests/Go/Instrument/Transformer/_files/multiple-classes-woven.php
@@ -20,7 +20,15 @@ class TestClass1 extends TestClass1__AopProxied implements \Go\Aop\Proxy
     }
 
 }
-\Go\Proxy\ClassProxy::injectJoinPoints('Test\ns3\TestClass1', json_decode('{"method":{"test":true}}', true));
+\Go\Proxy\ClassProxy::injectJoinPoints('Test\ns3\TestClass1',array (
+  'method' =>
+  array (
+    'test' =>
+    array (
+      0 => 'advisor.Test\\ns3\\TestClass1->test',
+    ),
+  ),
+));
 
 TestClass1::test();
 
@@ -42,7 +50,15 @@ class TestClass11 extends TestClass11__AopProxied implements \Go\Aop\Proxy
     }
 
 }
-\Go\Proxy\ClassProxy::injectJoinPoints('Test\ns3\TestClass11', json_decode('{"method":{"test":true}}', true));
+\Go\Proxy\ClassProxy::injectJoinPoints('Test\ns3\TestClass11',array (
+  'method' =>
+  array (
+    'test' =>
+    array (
+      0 => 'advisor.Test\\ns3\\TestClass11->test',
+    ),
+  ),
+));
 
 TestClass11::test();
 
@@ -64,6 +80,14 @@ class TestClass2 extends TestClass2__AopProxied implements \Go\Aop\Proxy
     }
 
 }
-\Go\Proxy\ClassProxy::injectJoinPoints('Test\ns3\TestClass2', json_decode('{"method":{"test":true}}', true));
+\Go\Proxy\ClassProxy::injectJoinPoints('Test\ns3\TestClass2',array (
+  'method' =>
+  array (
+    'test' =>
+    array (
+      0 => 'advisor.Test\\ns3\\TestClass2->test',
+    ),
+  ),
+));
 
 TestClass2::test();

--- a/tests/Go/Instrument/Transformer/_files/multiple-classes-woven.php
+++ b/tests/Go/Instrument/Transformer/_files/multiple-classes-woven.php
@@ -20,7 +20,7 @@ class TestClass1 extends TestClass1__AopProxied implements \Go\Aop\Proxy
     }
 
 }
-\Go\Proxy\ClassProxy::injectJoinPoints('Test\ns3\TestClass1', unserialize('a:1:{s:6:"method";a:1:{s:4:"test";b:1;}}'));
+\Go\Proxy\ClassProxy::injectJoinPoints('Test\ns3\TestClass1', json_decode('{"method":{"test":true}}', true));
 
 TestClass1::test();
 
@@ -42,7 +42,7 @@ class TestClass11 extends TestClass11__AopProxied implements \Go\Aop\Proxy
     }
 
 }
-\Go\Proxy\ClassProxy::injectJoinPoints('Test\ns3\TestClass11', unserialize('a:1:{s:6:"method";a:1:{s:4:"test";b:1;}}'));
+\Go\Proxy\ClassProxy::injectJoinPoints('Test\ns3\TestClass11', json_decode('{"method":{"test":true}}', true));
 
 TestClass11::test();
 
@@ -64,6 +64,6 @@ class TestClass2 extends TestClass2__AopProxied implements \Go\Aop\Proxy
     }
 
 }
-\Go\Proxy\ClassProxy::injectJoinPoints('Test\ns3\TestClass2', unserialize('a:1:{s:6:"method";a:1:{s:4:"test";b:1;}}'));
+\Go\Proxy\ClassProxy::injectJoinPoints('Test\ns3\TestClass2', json_decode('{"method":{"test":true}}', true));
 
 TestClass2::test();


### PR DESCRIPTION
This feature allows to specify custom interceptors with callbacks instead of aspects:

``` php
    protected function configureAop(AspectContainer $container)
    {
        $container->registerAdvisor(
            new DefaultPointcutAdvisor(
                new TrueMethodPointcut(),
                new MethodBeforeInterceptor(function (MethodInvocation $invocation) {
                    echo "Hello", $invocation->getMethod()->name;
                })
            ),
            'test'
        );
    }
```

Additionally, this PR replaces unserialization of advices with direct injection of advices if possible. If advisor is not loaded, then special aspect cache is used with serialized advisors and pointcuts per each aspect. So, no more need to analyze annotations in case when a cache of advisors is active.

After merging of this PR it will be possible to create a pointcut builder with DSL and fluent interface. Example:

``` php
    protected function configureAop(AspectContainer $container)
    {
        $builder = new PointcutBuilder($container);
        $builder->before('execution(public **->get(*)')->do(function (MethodInvocation $invocation) {
            echo "Hello", $invocation->getMethod()->name;
        });
        $builder->after('access(protected **->propertyName')->do(function (FieldAccess $access) {
            echo "Hello", $access->getField()->name;
        });
    }
```
