### PR TITLE
add backslash for internalNamespaces

### DIFF
--- a/src/Go/Instrument/ClassLoading/AopComposerLoader.php
+++ b/src/Go/Instrument/ClassLoading/AopComposerLoader.php
@@ -35,10 +35,10 @@ class AopComposerLoader
      * @var array
      */
     protected $internalNamespaces = array(
-        'Go',
-        'Dissect',
-        'Doctrine\\Common',
-        'TokenReflection',
+        'Go\\',
+        'Dissect\\',
+        'Doctrine\\Common\\',
+        'TokenReflection\\',
     );
 
     /**


### PR DESCRIPTION
Without backslash,  classes begin with these words can’t be loaded.

[loadClass Method in AopComposerLoader](https://github.com/chuck911/go-aop-php/blob/600939d31449a5a46cc8e05ab06b7f1d7bfd3079/src/Go/Instrument/ClassLoading/AopComposerLoader.php#L88-L101) :

```
public function loadClass($class)
{
    if ($file = $this->original->findFile($class)) {
        $isInternal = false;
        foreach ($this->internalNamespaces as $ns) {
            if (strpos($class, $ns) === 0) {
                $isInternal = true;
                break;
            }
        }

        include ($isInternal ? $file : FilterInjectorTransformer::rewrite($file));
    }
}
```
