### PR TITLE
[WIP] Change the logic of checking for dynamic pointcuts

### DIFF
--- a/src/Go/Aop/Framework/DynamicMethodMatcherInterceptor.php
+++ b/src/Go/Aop/Framework/DynamicMethodMatcherInterceptor.php
@@ -12,7 +12,7 @@ namespace Go\Aop\Framework;
 
 use Go\Aop\Intercept\MethodInvocation;
 use Go\Aop\Intercept\MethodInterceptor;
-use Go\Aop\Support\DynamicMethodMatcher;
+use Go\Aop\PointFilter;
 
 /**
  * Dynamic method matcher combines a pointcut and interceptor.
@@ -28,10 +28,10 @@ class DynamicMethodMatcherInterceptor extends BaseInterceptor implements MethodI
     /**
      * Dynamic matcher constructor
      *
-     * @param DynamicMethodMatcher $matcher Instance of dynamic matcher
+     * @param PointFilter $matcher Instance of dynamic matcher
      * @param MethodInterceptor $interceptor Instance of method interceptor to invoke
      */
-    public function __construct(DynamicMethodMatcher $matcher, MethodInterceptor $interceptor)
+    public function __construct(PointFilter $matcher, MethodInterceptor $interceptor)
     {
         $this->pointcut     = $matcher;
         $this->adviceMethod = $interceptor;

--- a/src/Go/Aop/PointFilter.php
+++ b/src/Go/Aop/PointFilter.php
@@ -22,6 +22,7 @@ interface PointFilter
     const KIND_TRAIT    = 8;
     const KIND_FUNCTION = 16;
     const KIND_ALL      = 31;
+    const KIND_DYNAMIC  = 256;
 
     /**
      * Performs matching of point of code

--- a/src/Go/Aop/Support/DynamicMethodMatcher.php
+++ b/src/Go/Aop/Support/DynamicMethodMatcher.php
@@ -37,7 +37,7 @@ abstract class DynamicMethodMatcher implements MethodMatcher
      */
     public function getKind()
     {
-        return self::KIND_METHOD;
+        return self::KIND_METHOD | self::KIND_DYNAMIC;
     }
 
 }

--- a/src/Go/Core/GeneralAspectLoaderExtension.php
+++ b/src/Go/Core/GeneralAspectLoaderExtension.php
@@ -93,7 +93,7 @@ class GeneralAspectLoaderExtension extends AbstractAspectLoaderExtension
 
             case ($isPointFilter && ($pointcut->getKind() & PointFilter::KIND_METHOD)):
                 $advice = $this->getMethodInterceptor($metaInformation, $adviceCallback);
-                if ($pointcut instanceof Support\DynamicMethodMatcher) {
+                if ($pointcut->getKind() & PointFilter::KIND_DYNAMIC) {
                     $advice = new Framework\DynamicMethodMatcherInterceptor(
                         $pointcut,
                         $advice


### PR DESCRIPTION
This fix allows to improve the checking for dynamic pointcuts by
supporting logical operators. However, logical pointcuts should also support multiple
arguments for dynamic matching via matches($point, $instance, $args)

This should fix #159 
