### PR TITLE
[Feature] Enable usage of static::class in the proxy methods

### DIFF
--- a/src/Aop/Features.php
+++ b/src/Aop/Features.php
@@ -42,4 +42,9 @@ interface Features
      * This flag is usable for read-only file systems (GAE, phar, etc)
      */
     const PREBUILT_CACHE = 16;
+
+    /**
+     * Allows to use 'static::class' in the source code of proxies, available since PHP5.5
+     */
+    const USE_STATIC_FOR_LSB = 32;
 }

--- a/src/Core/AspectKernel.php
+++ b/src/Core/AspectKernel.php
@@ -137,6 +137,9 @@ abstract class AspectKernel
             $features += Features::USE_CLOSURE;
             $features += Features::USE_TRAIT;
         }
+        if (version_compare(PHP_VERSION, '5.5.0') >= 0) {
+            $features += Features::USE_STATIC_FOR_LSB;
+        }
         if (version_compare(PHP_VERSION, '5.6.0') >= 0) {
             $features += Features::USE_SPLAT_OPERATOR;
         }

--- a/src/Instrument/Transformer/WeavingTransformer.php
+++ b/src/Instrument/Transformer/WeavingTransformer.php
@@ -162,9 +162,10 @@ class WeavingTransformer extends BaseSourceTransformer
         $metadata->source = $this->adjustOriginalClass($class, $metadata->source, $newParentName);
 
         // Prepare child Aop proxy
-        $child = ($this->kernel->hasFeature(Features::USE_TRAIT) && $class->isTrait())
-            ? new TraitProxy($class, $advices)
-            : new ClassProxy($class, $advices);
+        $useStatic = $this->kernel->hasFeature(Features::USE_STATIC_FOR_LSB);
+        $child     = ($this->kernel->hasFeature(Features::USE_TRAIT) && $class->isTrait())
+            ? new TraitProxy($class, $advices, $useStatic)
+            : new ClassProxy($class, $advices, $useStatic);
 
         // Set new parent name instead of original
         $child->setParentName($newParentName);

--- a/src/Proxy/AbstractProxy.php
+++ b/src/Proxy/AbstractProxy.php
@@ -34,15 +34,24 @@ abstract class AbstractProxy
     protected $advices = array();
 
     /**
+     * PHP expression string for accessing LSB information
+     *
+     * @var string
+     */
+    protected $staticLsbExpression = '\get_called_class()';
+
+    /**
      * Constructs an abstract proxy class
      *
      * @param array $advices List of advices
-     *
-     * @throws \InvalidArgumentException for invalid classes
+     * @param bool $useStaticForLsb Should proxy use 'static::class' instead of '\get_called_class()'
      */
-    public function __construct(array $advices = array())
+    public function __construct(array $advices = array(), $useStaticForLsb = false)
     {
         $this->advices = $this->flattenAdvices($advices);
+        if ($useStaticForLsb) {
+            $this->staticLsbExpression = 'static::class';
+        }
     }
 
     /**

--- a/src/Proxy/ClassProxy.php
+++ b/src/Proxy/ClassProxy.php
@@ -112,17 +112,18 @@ class ClassProxy extends AbstractProxy
      *
      * @param ReflectionClass|ParsedClass $parent Parent class reflection
      * @param array|Advice[] $classAdvices List of advices for class
+     * @param bool $useStaticForLsb Should proxy use 'static::class' instead of '\get_called_class()'
      *
      * @throws \InvalidArgumentException if there are unknown type of advices
      * @return ClassProxy
      */
-    public function __construct($parent, array $classAdvices)
+    public function __construct($parent, array $classAdvices, $useStaticForLsb = false)
     {
         if (!$parent instanceof ReflectionClass && !$parent instanceof ParsedClass) {
             throw new \InvalidArgumentException("Invalid argument for class");
         }
 
-        parent::__construct($classAdvices);
+        parent::__construct($classAdvices, $useStaticForLsb);
 
         $this->class           = $parent;
         $this->name            = $parent->getShortName();
@@ -411,7 +412,7 @@ class ClassProxy extends AbstractProxy
     protected function getJoinpointInvocationBody($method)
     {
         $isStatic = $method->isStatic();
-        $scope    = $isStatic ? '\get_called_class()' : '$this';
+        $scope    = $isStatic ? $this->staticLsbExpression : '$this';
         $prefix   = $isStatic ? AspectContainer::STATIC_METHOD_PREFIX : AspectContainer::METHOD_PREFIX;
 
         $args = join(', ', array_map(function ($param) {


### PR DESCRIPTION
This PR enables usage of `static::class` expression for PHP>=5.5 instead of `get_called_class()` function.
Details available in the #166
