### PR TITLE
Implementation of pointcut builder with closures

### DIFF
--- a/src/Aop/Support/LazyPointcutAdvisor.php
+++ b/src/Aop/Support/LazyPointcutAdvisor.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * Go! AOP framework
+ *
+ * @copyright Copyright 2014, Lisachenko Alexander <lisachenko.it@gmail.com>
+ *
+ * This source file is subject to the license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Go\Aop\Support;
+
+use Go\Aop\Advice;
+use Go\Aop\Pointcut;
+use Go\Core\AspectContainer;
+
+/**
+ * Lazy pointcut advisor is used to create a delayed pointcut only when needed
+ */
+class LazyPointcutAdvisor extends AbstractGenericPointcutAdvisor
+{
+
+    /**
+     * Pointcut expression
+     *
+     * @var string
+     */
+    private $pointcutExpression;
+
+    /**
+     * Instance of parsed pointcut
+     *
+     * @var Pointcut|null
+     */
+    private $pointcut;
+
+    /**
+     * @var AspectContainer
+     */
+    private $container;
+
+    /**
+     * Create a DefaultPointcutAdvisor, specifying Pointcut and Advice.
+     *
+     * @param AspectContainer $container Instance of container
+     * @param string $pointcutExpression The Pointcut targeting the Advice
+     * @param Advice $advice The Advice to run when Pointcut matches
+     */
+    public function __construct(AspectContainer $container, $pointcutExpression, Advice $advice)
+    {
+        $this->container          = $container;
+        $this->pointcutExpression = $pointcutExpression;
+        $this->setAdvice($advice);
+    }
+
+    /**
+     * Get the Pointcut that drives this advisor.
+     *
+     * @return Pointcut The pointcut
+     */
+    public function getPointcut()
+    {
+        if (!$this->pointcut) {
+
+            // Inject this dependencies and make them lazy!
+            // should be extracted from AbstractAspectLoaderExtension into separate class
+
+            /** @var Pointcut\PointcutLexer $lexer */
+            $lexer = $this->container->get('aspect.pointcut.lexer');
+
+            /** @var Pointcut\PointcutParser $parser */
+            $parser = $this->container->get('aspect.pointcut.parser');
+
+            $tokenStream    = $lexer->lex($this->pointcutExpression);
+            $this->pointcut = $parser->parse($tokenStream);
+        }
+
+        return $this->pointcut;
+    }
+}

--- a/src/Aop/Support/PointcutBuilder.php
+++ b/src/Aop/Support/PointcutBuilder.php
@@ -1,0 +1,125 @@
+<?php
+/**
+ * Go! AOP framework
+ *
+ * @copyright Copyright 2014, Lisachenko Alexander <lisachenko.it@gmail.com>
+ *
+ * This source file is subject to the license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Go\Aop\Support;
+
+use Go\Aop\Framework\AfterInterceptor;
+use Go\Aop\Framework\AfterThrowingInterceptor;
+use Go\Aop\Framework\AroundInterceptor;
+use Go\Aop\Framework\BeforeInterceptor;
+use Go\Aop\Framework\DeclareErrorInterceptor;
+use Go\Core\AspectContainer;
+
+/**
+ * Pointcut builder provides simple DSL for declaring pointcuts in plain PHP code
+ */
+class PointcutBuilder
+{
+    /**
+     * @var AspectContainer
+     */
+    protected $container;
+
+    /**
+     * Default constructor for the builder
+     *
+     * @param AspectContainer $container Instance of container
+     */
+    public function __construct(AspectContainer $container)
+    {
+        $this->container = $container;
+    }
+
+    /**
+     * Declares the "Before" hook for specific pointcut expression
+     *
+     * @param string $pointcutExpression Pointcut, e.g. "within(**)"
+     * @param callable $advice Advice to call
+     */
+    public function before($pointcutExpression, \Closure $advice)
+    {
+        $this->container->registerAdvisor(
+            new LazyPointcutAdvisor($this->container, $pointcutExpression, new BeforeInterceptor($advice)),
+            $this->getPointcutId($pointcutExpression)
+        );
+    }
+
+    /**
+     * Declares the "After" hook for specific pointcut expression
+     *
+     * @param string $pointcutExpression Pointcut, e.g. "within(**)"
+     * @param callable $advice Advice to call
+     */
+    public function after($pointcutExpression, \Closure $advice)
+    {
+        $this->container->registerAdvisor(
+            new LazyPointcutAdvisor($this->container, $pointcutExpression, new AfterInterceptor($advice)),
+            $this->getPointcutId($pointcutExpression)
+        );
+    }
+
+    /**
+     * Declares the "AfterThrowing" hook for specific pointcut expression
+     *
+     * @param string $pointcutExpression Pointcut, e.g. "within(**)"
+     * @param callable $advice Advice to call
+     */
+    public function afterThrowing($pointcutExpression, \Closure $advice)
+    {
+        $this->container->registerAdvisor(
+            new LazyPointcutAdvisor($this->container, $pointcutExpression, new AfterThrowingInterceptor($advice)),
+            $this->getPointcutId($pointcutExpression)
+        );
+    }
+
+    /**
+     * Declares the "Around" hook for specific pointcut expression
+     *
+     * @param string $pointcutExpression Pointcut, e.g. "within(**)"
+     * @param callable $advice Advice to call
+     */
+    public function around($pointcutExpression, \Closure $advice)
+    {
+        $this->container->registerAdvisor(
+            new LazyPointcutAdvisor($this->container, $pointcutExpression, new AroundInterceptor($advice)),
+            $this->getPointcutId($pointcutExpression)
+        );
+    }
+
+    /**
+     * Declares the error message for specific pointcut expression
+     *
+     * @param string $pointcutExpression Pointcut, e.g. "within(**)"
+     * @param string $message Error message to show
+     * @param integer $level Error level to trigger
+     */
+    public function declareError($pointcutExpression, $message, $level = E_USER_ERROR)
+    {
+        $advice = new DeclareErrorInterceptor($message, $level);
+        $this->container->registerAdvisor(
+            new LazyPointcutAdvisor($this->container, $pointcutExpression, $advice),
+            $this->getPointcutId($pointcutExpression)
+        );
+    }
+
+    /**
+     * Returns a unique name for pointcut expression
+     *
+     * @param string $pointcutExpression
+     *
+     * @return string
+     */
+    private function getPointcutId($pointcutExpression)
+    {
+        static $index = 0;
+
+        return preg_replace('/\W+/', '_', $pointcutExpression) . '.' . $index++;
+    }
+}


### PR DESCRIPTION
For annotation haters, AOP is awful slow non-intuitive tool. There are a lot of requests to support native closures for definition of advices.

This PR aims to give a tool for defining advices with native PHP syntax.

Example:

``` php
$pointcutBuilder = new PointcutBuilder($container);
$pointcutBuilder->before('execution(public **->*(*))', function (MethodInvocation $method) {
    echo $method, PHP_EOL;
});

$pointcutBuilder->after('access(* Demo\**->*)', function (ClassFieldAccess $property) {
    echo $property, PHP_EOL;
});
```
