### PR TITLE
Fixed proxy creation path.

### DIFF
--- a/src/Instrument/Transformer/WeavingTransformer.php
+++ b/src/Instrument/Transformer/WeavingTransformer.php
@@ -288,7 +288,10 @@ class WeavingTransformer extends BaseSourceTransformer
         }
         $cacheDirSuffix = '/_proxies/';
         $cacheDir       = $this->options['cacheDir'] . $cacheDirSuffix;
-        $fileName       = str_replace('\\', '/', $class->getName()) . '.php';
+        $fileName       = str_replace(
+            array('\\', $this->options['appDir'] . DIRECTORY_SEPARATOR),
+            array(DIRECTORY_SEPARATOR, ''),
+            $class->getFileName());
 
         $proxyFileName = $cacheDir . $fileName;
         $dirname       = dirname($proxyFileName);

--- a/src/Instrument/Transformer/WeavingTransformer.php
+++ b/src/Instrument/Transformer/WeavingTransformer.php
@@ -288,10 +288,7 @@ class WeavingTransformer extends BaseSourceTransformer
         }
         $cacheDirSuffix = '/_proxies/';
         $cacheDir       = $this->options['cacheDir'] . $cacheDirSuffix;
-        $fileName       = str_replace(
-            array('\\', $this->options['appDir'] . DIRECTORY_SEPARATOR),
-            array(DIRECTORY_SEPARATOR, ''),
-            $class->getFileName());
+        $fileName       = str_replace($this->options['appDir'] . DIRECTORY_SEPARATOR, '', $class->getFileName());
 
         $proxyFileName = $cacheDir . $fileName;
         $dirname       = dirname($proxyFileName);


### PR DESCRIPTION
Uses the original reflection class's filename as base for proxy class's path as not all namespaces correlate directly to filesystem path.  This ensures the correct path will be returned by the `MagicConstantTransformer` when calling `ReflectionClass->getFileName()`.

References #193 
