### PR TITLE
[Refactoring] Return advices from matcher

### DIFF
--- a/src/Aop/Pointcut/PointcutGrammar.php
+++ b/src/Aop/Pointcut/PointcutGrammar.php
@@ -170,7 +170,7 @@ class PointcutGrammar extends Grammar
         $this('pointcutReference')
             ->is('namespaceName', '->', 'namePatternPart')
             ->call(function ($className, $_0, $name) use ($container) {
-                return $container->getPointcut("{$className}->{$name}");
+                return new PointcutReference($container, "{$className}->{$name}");
             });
 
         $this('propertyAccessReference')

--- a/src/Aop/Pointcut/PointcutReference.php
+++ b/src/Aop/Pointcut/PointcutReference.php
@@ -1,0 +1,117 @@
+<?php
+/**
+ * Go! AOP framework
+ *
+ * @copyright Copyright 2015, Lisachenko Alexander <lisachenko.it@gmail.com>
+ *
+ * This source file is subject to the license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Go\Aop\Pointcut;
+
+use Go\Aop\Pointcut;
+use Go\Aop\PointFilter;
+use Go\Core\AspectContainer;
+use Go\Core\AspectKernel;
+
+/**
+ * Reference to the pointcut holds an id of pointcut to fetch when needed
+ */
+class PointcutReference implements Pointcut
+{
+    /**
+     * @var Pointcut
+     */
+    protected $pointcut = null;
+
+    /**
+     * Name of the pointcut to fetch from the container
+     *
+     * @var string
+     */
+    private $pointcutName;
+
+    /**
+     * Instance of aspect container
+     *
+     * @var AspectContainer
+     */
+    private $container;
+
+    /**
+     * Pointcut reference constructor
+     *
+     * @param AspectContainer $container Instance of container
+     * @param string $pointcutName Referenced pointcut
+     */
+    public function __construct(AspectContainer $container, $pointcutName)
+    {
+        $this->container    = $container;
+        $this->pointcutName = $pointcutName;
+    }
+
+    /**
+     * Performs matching of point of code
+     *
+     * @param mixed $point Specific part of code, can be any Reflection class
+     * @param object|string|null $instance [Optional] Instance for dynamic matching
+     * @param array $arguments [Optional] Extra arguments for dynamic matching
+     *
+     * @return bool
+     */
+    public function matches($point, $instance = null, array $arguments = null)
+    {
+        return $this->getPointcut()->matches($point, $instance, $arguments);
+    }
+
+    /**
+     * Returns the kind of point filter
+     *
+     * @return integer
+     */
+    public function getKind()
+    {
+        return $this->getPointcut()->getKind();
+    }
+
+    /**
+     * Return the class filter for this pointcut.
+     *
+     * @return PointFilter
+     */
+    public function getClassFilter()
+    {
+        return $this->getPointcut()->getClassFilter();
+    }
+
+    /**
+     * Returns a real pointcut from the container
+     *
+     * @return Pointcut
+     */
+    public function getPointcut()
+    {
+        if (!$this->pointcut) {
+            $this->pointcut = $this->container->getPointcut($this->pointcutName);
+        }
+
+        return $this->pointcut;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function __sleep()
+    {
+        return array('pointcutName');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function __wakeup()
+    {
+        $this->container = AspectKernel::getInstance()->getContainer();
+    }
+}

--- a/src/Aop/Support/DefaultPointcutAdvisor.php
+++ b/src/Aop/Support/DefaultPointcutAdvisor.php
@@ -11,7 +11,9 @@
 namespace Go\Aop\Support;
 
 use Go\Aop\Advice;
+use Go\Aop\Framework\DynamicInvocationMatcherInterceptor;
 use Go\Aop\Pointcut;
+use Go\Aop\PointFilter;
 
 /**
  * Convenient Pointcut-driven Advisor implementation.
@@ -40,6 +42,23 @@ class DefaultPointcutAdvisor extends AbstractGenericPointcutAdvisor
         $this->pointcut = $pointcut;
         $this->setAdvice($advice);
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getAdvice()
+    {
+        $advice = parent::getAdvice();
+        if ($this->pointcut->getKind() & PointFilter::KIND_DYNAMIC) {
+            $advice = new DynamicInvocationMatcherInterceptor(
+                $this->pointcut,
+                $advice
+            );
+        }
+
+        return $advice;
+    }
+
 
     /**
      * Get the Pointcut that drives this advisor.

--- a/src/Core/AdviceMatcher.php
+++ b/src/Core/AdviceMatcher.php
@@ -30,13 +30,6 @@ class AdviceMatcher
     protected $loader;
 
     /**
-     * Instance of container for aspect
-     *
-     * @var AspectContainer
-     */
-    protected $container;
-
-    /**
      * Flag to enable/disable support of global function interception
      *
      * @var bool
@@ -47,13 +40,11 @@ class AdviceMatcher
      * Constructor
      *
      * @param AspectLoader $loader Instance of aspect loader
-     * @param AspectContainer $container Container
      * @param bool $isInterceptFunctions Optional flag to enable function interception
      */
-    public function __construct(AspectLoader $loader, AspectContainer $container, $isInterceptFunctions = false)
+    public function __construct(AspectLoader $loader, $isInterceptFunctions = false)
     {
-        $this->loader    = $loader;
-        $this->container = $container;
+        $this->loader = $loader;
 
         $this->isInterceptFunctions = $isInterceptFunctions;
     }
@@ -62,10 +53,11 @@ class AdviceMatcher
      * Returns list of function advices for namespace
      *
      * @param ReflectionFileNamespace $namespace
+     * @param array|Aop\Advisor[] $advisors List of advisor to match
      *
      * @return array
      */
-    public function getAdvicesForFunctions(ReflectionFileNamespace $namespace)
+    public function getAdvicesForFunctions(ReflectionFileNamespace $namespace, array $advisors)
     {
         if (!$this->isInterceptFunctions || $namespace->getName() == 'no-namespace') {
             return array();
@@ -73,9 +65,7 @@ class AdviceMatcher
 
         $advices = array();
 
-        $this->loader->loadAdvisorsAndPointcuts();
-
-        foreach ($this->container->getByTag('advisor') as $advisorId => $advisor) {
+        foreach ($advisors as $advisorId => $advisor) {
 
             if ($advisor instanceof Aop\PointcutAdvisor) {
 
@@ -97,13 +87,12 @@ class AdviceMatcher
      * Return list of advices for class
      *
      * @param ParsedReflectionClass $class Class to advise
+     * @param array|Aop\Advisor[] $advisors List of advisor to match
      *
      * @return array|Aop\Advice[] List of advices for class
      */
-    public function getAdvicesForClass(ParsedReflectionClass $class)
+    public function getAdvicesForClass(ParsedReflectionClass $class, array $advisors)
     {
-        $this->loader->loadAdvisorsAndPointcuts();
-
         $classAdvices = array();
         $parentClass  = $class->getParentClass();
 
@@ -113,7 +102,7 @@ class AdviceMatcher
             $originalClass = $class;
         }
 
-        foreach ($this->container->getByTag('advisor') as $advisorId => $advisor) {
+        foreach ($advisors as $advisorId => $advisor) {
 
             if ($advisor instanceof Aop\PointcutAdvisor) {
 

--- a/src/Core/AspectContainer.php
+++ b/src/Core/AspectContainer.php
@@ -83,6 +83,15 @@ interface AspectContainer
     public function registerPointcut(Aop\Pointcut $pointcut, $id);
 
     /**
+     * Returns an advisor by identifier
+     *
+     * @param string $id Advisor identifier
+     *
+     * @return Aop\Advisor
+     */
+    public function getAdvisor($id);
+
+    /**
      * Store the advisor in the container
      *
      * @param Aop\Advisor $advisor Instance

--- a/src/Core/AspectKernel.php
+++ b/src/Core/AspectKernel.php
@@ -247,13 +247,15 @@ abstract class AspectKernel
         $aspectKernel     = $this;
 
         $sourceTransformers = function () use ($filterInjector, $magicTransformer, $aspectKernel) {
-            $transformers   = array();
-            $transformers[] = new WeavingTransformer(
+            $aspectContainer = $aspectKernel->getContainer();
+            $transformers    = array();
+            $transformers[]  = new WeavingTransformer(
                 $aspectKernel,
                 new TokenReflection\Broker(
                     new CleanableMemory()
                 ),
-                $aspectKernel->getContainer()->get('aspect.advice_matcher')
+                $aspectContainer->get('aspect.advice_matcher'),
+                $aspectContainer->get('aspect.cached.loader')
             );
             if ($aspectKernel->hasFeature(Features::INTERCEPT_INCLUDES)) {
                 $transformers[] = $filterInjector;

--- a/src/Core/AspectLoaderExtension.php
+++ b/src/Core/AspectLoaderExtension.php
@@ -10,7 +10,9 @@
 
 namespace Go\Core;
 
+use Go\Aop\Advisor;
 use Go\Aop\Aspect;
+use Go\Aop\Pointcut;
 
 /**
  * Extension interface that defines an API for aspect loaders
@@ -73,10 +75,11 @@ interface AspectLoaderExtension
     /**
      * Loads definition from specific point of aspect into the container
      *
-     * @param AspectContainer $container Instance of container
      * @param Aspect $aspect Instance of aspect
      * @param mixed|\ReflectionClass|\ReflectionMethod|\ReflectionProperty $reflection Reflection of point
      * @param mixed|null $metaInformation Additional meta-information, e.g. annotation for method
+     *
+     * @return array|Pointcut[]|Advisor[]
      */
-    public function load(AspectContainer $container, Aspect $aspect, $reflection, $metaInformation = null);
+    public function load(Aspect $aspect, $reflection, $metaInformation = null);
 }

--- a/src/Core/GeneralAspectLoaderExtension.php
+++ b/src/Core/GeneralAspectLoaderExtension.php
@@ -93,12 +93,7 @@ class GeneralAspectLoaderExtension extends AbstractAspectLoaderExtension
 
             case ($pointcut instanceof PointFilter):
                 $advice = $this->getInterceptor($metaInformation, $adviceCallback);
-                if ($pointcut->getKind() & PointFilter::KIND_DYNAMIC) {
-                    $advice = new Framework\DynamicInvocationMatcherInterceptor(
-                        $pointcut,
-                        $advice
-                    );
-                }
+
                 $loadedItems[$methodId] = new DefaultPointcutAdvisor($pointcut, $advice);
                 break;
 

--- a/src/Core/GoAspectContainer.php
+++ b/src/Core/GoAspectContainer.php
@@ -80,7 +80,6 @@ class GoAspectContainer extends Container implements AspectContainer
         $this->share('aspect.advice_matcher', function (Container $container) {
             return new AdviceMatcher(
                 $container->get('aspect.loader'),
-                $container,
                 $container->get('kernel.interceptFunctions')
             );
         });
@@ -140,6 +139,18 @@ class GoAspectContainer extends Container implements AspectContainer
     public function registerPointcut(Aop\Pointcut $pointcut, $id)
     {
         $this->set("pointcut.{$id}", $pointcut, array('pointcut'));
+    }
+
+    /**
+     * Returns an advisor by identifier
+     *
+     * @param string $id Advisor identifier
+     *
+     * @return Aop\Advisor
+     */
+    public function getAdvisor($id)
+    {
+        return $this->get("advisor.{$id}");
     }
 
     /**

--- a/src/Core/LazyAdvisorAccessor.php
+++ b/src/Core/LazyAdvisorAccessor.php
@@ -58,7 +58,7 @@ class LazyAdvisorAccessor
             list(, $advisorName) = explode('.', $name);
             list($aspect)        = explode('->', $advisorName);
             $aspectInstance      = $this->container->getAspect($aspect);
-            $this->loader->load($aspectInstance);
+            $this->loader->loadAndRegister($aspectInstance);
 
             $advisor = $this->container->get($name);
         }


### PR DESCRIPTION
This PR is an initial point for creating an API for debug tools and CLI. Now it will be possible to get a list of advices for the concrete class without explicit registration of advices in the container.

Next step is to develop an API on top of this PR to perform static analysis in runtime, for example, which joinpoints are intercepted by an advisor, which aspects are registered in the kernel, which pointcuts are available and where they are declared.
