### PR TITLE
No more source code check for the presence of func_get_args()

### DIFF
--- a/src/Proxy/ClassProxy.php
+++ b/src/Proxy/ClassProxy.php
@@ -426,14 +426,7 @@ class ClassProxy extends AbstractProxy
         $args = $this->prepareArgsLine($method);
         $body = '';
 
-        if (($this->class->name === $method->getDeclaringClassName()) && strpos($method->getSource(), 'func_get_args') !== false) {
-            $body = '$argsList = \func_get_args();' . PHP_EOL;
-            if (empty($args)) {
-                $scope = "$scope, \$argsList";
-            } else {
-                $scope = "$scope, [$args] + \$argsList";
-            }
-        } elseif (!empty($args)) {
+        if (!empty($args)) {
             $scope = "$scope, [$args]";
         }
 

--- a/tests/Go/Instrument/Transformer/_files/class-woven.php
+++ b/tests/Go/Instrument/Transformer/_files/class-woven.php
@@ -51,8 +51,7 @@ class TestClass extends TestClass__AopProxied implements \Go\Aop\Proxy
 
     public function publicMethodDynamicArguments($a, &$b)
     {
-        $argsList = \func_get_args();
-        return self::$__joinPoints['method:publicMethodDynamicArguments']->__invoke($this, [$a, &$b] + $argsList);
+        return self::$__joinPoints['method:publicMethodDynamicArguments']->__invoke($this, [$a, &$b]);
     }
 
     public function publicMethodFixedArguments($a, $b, $c = null)


### PR DESCRIPTION
Remove old-school way of passing additional arguments via `fund_get_args()`, resolves #243
