### PR TITLE
Add tricky implementation for ReflectionMethod->getClosure for HHVM

### DIFF
--- a/src/Aop/Support/AnnotatedReflectionMethod.php
+++ b/src/Aop/Support/AnnotatedReflectionMethod.php
@@ -60,4 +60,24 @@ class AnnotatedReflectionMethod extends ReflectionMethod
 
         return self::$annotationReader;
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getClosure($object)
+    {
+        if (!defined('HHVM_VERSION')) {
+            return parent::getClosure($object);
+        }
+
+        $className  = $this->getDeclaringClass()->name;
+        $methodName = $this->name;
+        $closure = function (...$args) use ($methodName, $className) {
+            $result = forward_static_call_array(array($className, $methodName), $args);
+
+            return $result;
+        };
+
+        return $closure->bindTo($object, $this->class);
+    }
 }

--- a/tests/Go/Aop/Framework/DynamicClosureMethodInvocationTest.php
+++ b/tests/Go/Aop/Framework/DynamicClosureMethodInvocationTest.php
@@ -17,16 +17,6 @@ class DynamicClosureMethodInvocationTest extends \PHPUnit_Framework_TestCase
     protected static $invocationClass = DynamicClosureMethodInvocation::class;
 
     /**
-     * {@inheritdoc}
-     */
-    protected function setUp()
-    {
-        if (defined('HHVM_VERSION')) {
-            $this->markTestSkipped("Skipped due to the bug https://github.com/facebook/hhvm/issues/1203");
-        }
-    }
-
-    /**
      * Tests dynamic method invocations
      *
      * @dataProvider dynamicMethodsBatch
@@ -42,6 +32,10 @@ class DynamicClosureMethodInvocationTest extends \PHPUnit_Framework_TestCase
 
     public function testValueChangedByReference()
     {
+        if (defined('HHVM_VERSION')) {
+            $this->markTestSkipped("Limitation of implementation https://github.com/goaop/framework/issues/250");
+        }
+
         $child      = $this->getMock(self::FIRST_CLASS_NAME, array('none'));
         $invocation = new self::$invocationClass(self::FIRST_CLASS_NAME, 'passByReference', []);
 

--- a/tests/Go/Aop/Framework/DynamicClosureSplatMethodInvocationTest.php
+++ b/tests/Go/Aop/Framework/DynamicClosureSplatMethodInvocationTest.php
@@ -24,9 +24,6 @@ class DynamicClosureSplatMethodInvocationTest extends \PHPUnit_Framework_TestCas
         if (PHP_VERSION_ID < 50600) {
             $this->markTestSkipped("Closure Method Invocation with splat works only on PHP 5.6 and greater");
         }
-        if (defined('HHVM_VERSION')) {
-            $this->markTestSkipped("Skipped due to the bug https://github.com/facebook/hhvm/issues/1203");
-        }
     }
 
     /**

--- a/tests/Go/Aop/Framework/StaticClosureMethodInvocationTest.php
+++ b/tests/Go/Aop/Framework/StaticClosureMethodInvocationTest.php
@@ -16,16 +16,6 @@ class StaticClosureMethodInvocationTest extends \PHPUnit_Framework_TestCase
     protected static $invocationClass = StaticClosureMethodInvocation::class;
 
     /**
-     * {@inheritdoc}
-     */
-    protected function setUp()
-    {
-        if (defined('HHVM_VERSION')) {
-            $this->markTestSkipped("Skipped due to the bug https://github.com/facebook/hhvm/issues/1203");
-        }
-    }
-
-    /**
      * Tests static method invocations with self
      *
      * @dataProvider staticSelfMethodsBatch


### PR DESCRIPTION
To be able to run framework under HHVM, special hack is required. This resolves #250 
