### PR TITLE
AopComposerLoader: prevent notices if no prefixes present

### DIFF
--- a/src/Instrument/ClassLoading/AopComposerLoader.php
+++ b/src/Instrument/ClassLoading/AopComposerLoader.php
@@ -72,9 +72,11 @@ class AopComposerLoader
         $prefixes     = $original->getPrefixes();
         $excludePaths = $options['excludePaths'];
 
-        // Let's exclude core dependencies from that list
-        $excludePaths[] = $prefixes['Dissect'][0];
-        $excludePaths[] = substr($prefixes['Doctrine\\Common\\Annotations\\'][0], 0, -16);
+        if (!empty($prefixes)) {
+            // Let's exclude core dependencies from that list
+            $excludePaths[] = $prefixes['Dissect'][0];
+            $excludePaths[] = substr($prefixes['Doctrine\\Common\\Annotations\\'][0], 0, -16);
+        }
 
         $fileEnumerator       = new Enumerator($options['appDir'], $options['includePaths'], $excludePaths);
         $this->fileEnumerator = $fileEnumerator;


### PR DESCRIPTION
We're using multiple composer-generated autoloader files.
One of them doesn't have any prefixes, so this patch prevents notices such as:

```
Notice: Undefined index: Dissect in vendor/goaop/framework/src/Instrument/ClassLoading/AopComposerLoader.php on line 76
Notice: Undefined index: Doctrine\Common\Annotations\ in vendor/goaop/framework/src/Instrument/ClassLoading/AopComposerLoader.php
```
