### PR TITLE
Only add existing core dependencies path exclusions in `AopComposerLoader`

### DIFF
--- a/src/Instrument/ClassLoading/AopComposerLoader.php
+++ b/src/Instrument/ClassLoading/AopComposerLoader.php
@@ -72,9 +72,15 @@ class AopComposerLoader
         $prefixes     = $original->getPrefixes();
         $excludePaths = $options['excludePaths'];
 
-        // Let's exclude core dependencies from that list
-        $excludePaths[] = $prefixes['Dissect'][0];
-        $excludePaths[] = substr($prefixes['Doctrine\\Common\\Annotations\\'][0], 0, -16);
+        if (!empty($prefixes)) {
+            // Let's exclude core dependencies from that list
+            if (array_key_exists('Dissect', $prefixes)) {
+                $excludePaths[] = $prefixes['Dissect'][0];
+            }
+            if (array_key_exists('Doctrine\\Common\\Annotations\\', $prefixes)) {
+                $excludePaths[] = substr($prefixes['Doctrine\\Common\\Annotations\\'][0], 0, -16);
+            }
+        }
 
         $fileEnumerator       = new Enumerator($options['appDir'], $options['includePaths'], $excludePaths);
         $this->fileEnumerator = $fileEnumerator;


### PR DESCRIPTION
Only add core dependencies path exclusions in `AopComposerLoader` when they can indeed been found within the current `ClassLoader`, to avoid PHP notices in scenarios where Composer provides multiple `ClassLoader`s.

Alternative fix to #262 , which missed the case where `$prefixes` exists, but does not contain the dependencies to be excluded.
