### PR TITLE
Only access existing prefix indexes when exluding paths.

### DIFF
--- a/src/Instrument/ClassLoading/AopComposerLoader.php
+++ b/src/Instrument/ClassLoading/AopComposerLoader.php
@@ -72,15 +72,15 @@ class AopComposerLoader
         $prefixes     = $original->getPrefixes();
         $excludePaths = $options['excludePaths'];
 
-        if(!empty($prefixes)) {
+        if (!empty($prefixes)) {
             // Let's exclude core dependencies from that list
-            if(isset($prefixes['Dissect'])) {
+            if (isset($prefixes['Dissect'])) {
                 $excludePaths[] = $prefixes['Dissect'][0];
             }
-            if(isset($prefixes['TokenReflection'])) {
+            if (isset($prefixes['TokenReflection'])) {
                 $excludePaths[] = $prefixes['TokenReflection'][0];
             }
-            if(isset($prefixes['Doctrine\\Common\\Annotations\\'])) {
+            if (isset($prefixes['Doctrine\\Common\\Annotations\\'])) {
                 $excludePaths[] = substr($prefixes['Doctrine\\Common\\Annotations\\'][0], 0, -16);
             }
         }

--- a/src/Instrument/ClassLoading/AopComposerLoader.php
+++ b/src/Instrument/ClassLoading/AopComposerLoader.php
@@ -72,10 +72,18 @@ class AopComposerLoader
         $prefixes     = $original->getPrefixes();
         $excludePaths = $options['excludePaths'];
 
-        // Let's exclude core dependencies from that list
-        $excludePaths[] = $prefixes['Dissect'][0];
-        $excludePaths[] = $prefixes['TokenReflection'][0];
-        $excludePaths[] = substr($prefixes['Doctrine\\Common\\Annotations\\'][0], 0, -16);
+        if(!empty($prefixes)) {
+            // Let's exclude core dependencies from that list
+            if(isset($prefixes['Dissect'])) {
+                $excludePaths[] = $prefixes['Dissect'][0];
+            }
+            if(isset($prefixes['TokenReflection'])) {
+                $excludePaths[] = $prefixes['TokenReflection'][0];
+            }
+            if(isset($prefixes['Doctrine\\Common\\Annotations\\'])) {
+                $excludePaths[] = substr($prefixes['Doctrine\\Common\\Annotations\\'][0], 0, -16);
+            }
+        }
 
         $fileEnumerator       = new Enumerator($options['appDir'], $options['includePaths'], $excludePaths);
         $this->fileEnumerator = $fileEnumerator;


### PR DESCRIPTION
Only add core dependencies path exclusions in `AopComposerLoader` when they can indeed been found within the current `ClassLoader`, to avoid PHP notices in scenarios where Composer provides multiple `ClassLoader`s.

Replaces #263, to target 1.x branch.
