### PR TITLE
Rewrite property interceptors to be by reference

### DIFF
--- a/demos/Demo/Aspect/PropertyInterceptorAspect.php
+++ b/demos/Demo/Aspect/PropertyInterceptorAspect.php
@@ -32,10 +32,18 @@ class PropertyInterceptorAspect implements Aspect
      */
     public function aroundFieldAccess(FieldAccess $fieldAccess)
     {
-        $value = $fieldAccess->proceed();
-        echo "Calling Around Interceptor for ", $fieldAccess, ", value: ", json_encode($value), PHP_EOL;
+        $isRead = $fieldAccess->getAccessType() == FieldAccess::READ;
+        // proceed all internal advices
+        $fieldAccess->proceed();
 
-        // $value = 666; You can change the return value for read/write operations in advice!
-        return $value;
+        if ($isRead) {
+            // if you want to change original property value, then return it by reference
+            $value = /* & */$fieldAccess->getValue();
+        } else {
+            // if you want to change value to set, then return it by reference
+            $value = /* & */$fieldAccess->getValueToSet();
+        }
+
+        echo "Calling After Interceptor for ", $fieldAccess, ", value: ", json_encode($value), PHP_EOL;
     }
 }

--- a/demos/Demo/Example/PropertyDemo.php
+++ b/demos/Demo/Example/PropertyDemo.php
@@ -19,6 +19,8 @@ class PropertyDemo
 
     protected $protectedProperty = 456;
 
+    protected $indirectModificationCheck = [4, 5, 6];
+
     public function showProtected()
     {
         echo $this->protectedProperty, PHP_EOL;
@@ -27,5 +29,13 @@ class PropertyDemo
     public function setProtected($newValue)
     {
         $this->protectedProperty = $newValue;
+    }
+
+    public function __construct()
+    {
+        array_push($this->indirectModificationCheck, 7, 8, 9);
+        if (count($this->indirectModificationCheck) !== 6) {
+            throw new \RuntimeException("Indirect modification doesn't work!");
+        }
     }
 }

--- a/src/Aop/Intercept/FieldAccess.php
+++ b/src/Aop/Intercept/FieldAccess.php
@@ -42,13 +42,22 @@ interface FieldAccess extends Joinpoint
     public function getField();
 
     /**
+     * Gets the current value of property by reference
+     *
+     * @api
+     *
+     * @return mixed
+     */
+    public function &getValue();
+
+    /**
      * Gets the value that must be set to the field, applicable only for WRITE access type
      *
      * @api
      *
      * @return mixed
      */
-    public function getValueToSet();
+    public function &getValueToSet();
 
     /**
      * Returns the access type.

--- a/src/Proxy/PropertyInterceptionTrait.php
+++ b/src/Proxy/PropertyInterceptionTrait.php
@@ -1,0 +1,88 @@
+<?php
+/*
+ * Go! AOP framework
+ *
+ * @copyright Copyright 2016, Lisachenko Alexander <lisachenko.it@gmail.com>
+ *
+ * This source file is subject to the license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Go\Proxy;
+
+use Go\Aop\Framework\ClassFieldAccess;
+use Go\Aop\Intercept\FieldAccess;
+
+/**
+ * Trait that holds all general logic for working with intercepted properties
+ */
+trait PropertyInterceptionTrait
+{
+    /**
+     * Holds a collection of current values for intercepted properties
+     *
+     * @var array
+     */
+    private $__properties = [];
+
+    /**
+     * @inheritDoc
+     */
+    public function &__get($name)
+    {
+        if (\array_key_exists($name, $this->__properties)) {
+            /** @var ClassFieldAccess $fieldAccess */
+            $fieldAccess = self::$__joinPoints["prop:$name"];
+            $fieldAccess->ensureScopeRule();
+
+            $value = &$fieldAccess->__invoke($this,FieldAccess::READ, $this->__properties[$name]);
+        } elseif (\method_exists(\get_parent_class(), __FUNCTION__)) {
+            $value = parent::__get($name);
+        } else {
+            trigger_error("Trying to access undeclared property {$name}");
+
+            $value = null;
+        }
+
+        return $value;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function __set($name, $value)
+    {
+        if (\array_key_exists($name, $this->__properties)) {
+            /** @var ClassFieldAccess $fieldAccess */
+            $fieldAccess = self::$__joinPoints["prop:$name"];
+            $fieldAccess->ensureScopeRule();
+
+            $this->__properties[$name] = $fieldAccess->__invoke(
+                $this,
+                FieldAccess::WRITE,
+                $this->__properties[$name],
+                $value
+            );
+        } elseif (\method_exists(\get_parent_class(), __FUNCTION__)) {
+            parent::__set($name, $value);
+        } else {
+            $this->$name = $value;
+        }
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function __isset($name)
+    {
+        return isset($this->__properties[$name]);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function __unset($name)
+    {
+        $this->__properties[$name] = null;
+    }
+}

--- a/src/Proxy/PropertyInterceptionTrait.php
+++ b/src/Proxy/PropertyInterceptionTrait.php
@@ -35,7 +35,7 @@ trait PropertyInterceptionTrait
             $fieldAccess = self::$__joinPoints["prop:$name"];
             $fieldAccess->ensureScopeRule();
 
-            $value = &$fieldAccess->__invoke($this,FieldAccess::READ, $this->__properties[$name]);
+            $value = &$fieldAccess->__invoke($this, FieldAccess::READ, $this->__properties[$name]);
         } elseif (\method_exists(\get_parent_class(), __FUNCTION__)) {
             $value = parent::__get($name);
         } else {


### PR DESCRIPTION
This PR changes the property interception logic. Now all common logic is added by trait, additionally, all properties and methods for accessing properties now works "by reference", allowing for indirect changes and array key access.

This PR also includes a scope checker method to prevent an access to protected fields from external scope.
This should resolve #54 and #232
