### PR TITLE
Property names documented with @property should be prefixed with a $ sign

### DIFF
--- a/src/Instrument/Transformer/StreamMetaData.php
+++ b/src/Instrument/Transformer/StreamMetaData.php
@@ -17,18 +17,18 @@ use InvalidArgumentException;
 /**
  * Stream metadata object
  *
- * @property bool timed_out TRUE if the stream timed out while waiting for data on the last call to fread() or fgets().
- * @property bool blocked TRUE if the stream is in blocking IO mode
- * @property bool eof TRUE if the stream has reached end-of-file.
- * @property int unread_bytes the number of bytes currently contained in the PHP's own internal buffer.
- * @property string stream_type a label describing the underlying implementation of the stream.
- * @property string wrapper_type a label describing the protocol wrapper implementation layered over the stream.
- * @property mixed wrapper_data wrapper specific data attached to this stream.
- * @property array filters array containing the names of any filters that have been stacked onto this stream.
- * @property string mode the type of access required for this stream
- * @property bool seekable whether the current stream can be seeked.
- * @property string uri the URI/filename associated with this stream.
- * @property string source of the stream.
+ * @property bool   $timed_out     TRUE if the stream timed out while waiting for data on the last call to fread() or fgets().
+ * @property bool   $blocked       TRUE if the stream is in blocking IO mode
+ * @property bool   $eof           TRUE if the stream has reached end-of-file.
+ * @property int    $unread_bytes  The number of bytes currently contained in the PHP's own internal buffer.
+ * @property string $stream_type   A label describing the underlying implementation of the stream.
+ * @property string $wrapper_type  A label describing the protocol wrapper implementation layered over the stream.
+ * @property mixed  $wrapper_data  Wrapper-specific data attached to this stream.
+ * @property array  $filters       Array containing the names of any filters that have been stacked onto this stream.
+ * @property string $mode          The type of access required for this stream
+ * @property bool   $seekable      Whether the current stream can be seeked.
+ * @property string $uri           The URI/filename associated with this stream.
+ * @property string $source        The contents of the stream.
  */
 class StreamMetaData extends ArrayObject
 {


### PR DESCRIPTION
I also clarified the documentation for the `source` element by suggesting that it contains the _contents_ of the stream.  But please let me know if this isn't always accurate and should be removed.
