### PR TITLE
Use realpath() to resolve unresolved path from composer

### DIFF
--- a/src/Instrument/ClassLoading/AopComposerLoader.php
+++ b/src/Instrument/ClassLoading/AopComposerLoader.php
@@ -155,6 +155,7 @@ class AopComposerLoader
         $file = $this->original->findFile($class);
 
         if ($file) {
+            $file = realpath($file)?:$file;
             $cacheState = isset($this->cacheState[$file]) ? $this->cacheState[$file] : null;
             if ($cacheState && $isProduction) {
                 $file = $cacheState['cacheUri'] ?: $file;

--- a/src/Instrument/ClassLoading/AopComposerLoader.php
+++ b/src/Instrument/ClassLoading/AopComposerLoader.php
@@ -12,6 +12,7 @@ namespace Go\Instrument\ClassLoading;
 
 use Go\Core\AspectContainer;
 use Go\Instrument\FileSystem\Enumerator;
+use Go\Instrument\PathResolver;
 use Go\Instrument\Transformer\FilterInjectorTransformer;
 use Composer\Autoload\ClassLoader;
 use Doctrine\Common\Annotations\AnnotationRegistry;
@@ -155,7 +156,7 @@ class AopComposerLoader
         $file = $this->original->findFile($class);
 
         if ($file) {
-            $file = realpath($file)?:$file;
+            $file = PathResolver::realpath($file)?:$file;
             $cacheState = isset($this->cacheState[$file]) ? $this->cacheState[$file] : null;
             if ($cacheState && $isProduction) {
                 $file = $cacheState['cacheUri'] ?: $file;


### PR DESCRIPTION
Since PR #5174 (https://github.com/composer/composer/pull/5174) the paths from composer can have dots in the paths. This isn't handled by AopComposerLoader.
CachePathManager tries to replace a resolved appPath with an unresolved resourcePath.
e.g. /app/ .... /vendor/composer/../../app

My solution isn't optimal, because _realpath()_ is called for every included file.
