### PR TITLE
Allow to pass an exception as a second argument to the invocation

### DIFF
--- a/src/Aop/Framework/AfterThrowingInterceptor.php
+++ b/src/Aop/Framework/AfterThrowingInterceptor.php
@@ -35,7 +35,7 @@ final class AfterThrowingInterceptor extends BaseInterceptor implements AdviceAf
             $result = $joinpoint->proceed();
         } catch (Exception $invocationException) {
             $adviceMethod = $this->adviceMethod;
-            $adviceMethod($joinpoint);
+            $adviceMethod($joinpoint, $invocationException);
 
             throw $invocationException;
         }


### PR DESCRIPTION
Allow to pass an exception as a second argument to the invocation for AfterThrowing type of adivce, resolves #302