### PR TITLE
Fix pattern matching in the Enumerator for sub-directories

### DIFF
--- a/src/Instrument/FileSystem/Enumerator.php
+++ b/src/Instrument/FileSystem/Enumerator.php
@@ -89,7 +89,6 @@ class Enumerator
             };
 
             $fullPath = $this->getFileFullPath($file);
-            $dir      = dirname($fullPath);
             // Do not touch files that not under rootDirectory
             if (strpos($fullPath, $rootDirectory) !== 0) {
                 return false;
@@ -98,7 +97,7 @@ class Enumerator
             if (!empty($includePaths)) {
                 $found = false;
                 foreach ($includePaths as $includePattern) {
-                    if (fnmatch($includePattern, $dir)) {
+                    if (fnmatch("{$includePattern}*", $fullPath)) {
                         $found = true;
                         break;
                     }
@@ -109,7 +108,7 @@ class Enumerator
             }
 
             foreach ($excludePaths as $excludePattern) {
-                if (fnmatch($excludePattern, $dir)) {
+                if (fnmatch("{$excludePattern}*", $fullPath)) {
                     return false;
                 }
             }

--- a/tests/Go/Instrument/FileSystem/EnumeratorTest.php
+++ b/tests/Go/Instrument/FileSystem/EnumeratorTest.php
@@ -3,7 +3,6 @@
 namespace Go\Instrument;
 
 use Go\Instrument\FileSystem\Enumerator;
-use org\bovigo\vfs\vfsStream;
 use Vfs\FileSystem;
 
 class EnumeratorTest extends \PHPUnit_Framework_TestCase
@@ -57,6 +56,12 @@ class EnumeratorTest extends \PHPUnit_Framework_TestCase
                 ['vfs://base/sub/test'],
                 [],
                 ['vfs://base/sub/sub/test']
+            ],
+            [
+                // Exclude double sub folder just by base path
+                ['vfs://base/sub/test'],
+                [],
+                ['vfs://base/sub/sub']
             ],
             [
                 // Exclude all, expected shout be empty

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -8,3 +8,5 @@
  * with this source code in the file LICENSE.
  */
 ini_set('display_errors', 1);
+
+include __DIR__ . '/../vendor/autoload.php';


### PR DESCRIPTION
This PR fixes regression bug with sub-sub directories that don't match with `fnmatch()` without extra '*' symbol at the end of pattern.