### PR TITLE
Rewrite framework with PHP7.0 features

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-  - 5.6
   - 7.0
   - 7.1
   - hhvm

--- a/bin/aspect
+++ b/bin/aspect
@@ -1,5 +1,6 @@
 #!/usr/bin/env php
 <?php
+declare(strict_types = 1);
 /*
  * Go! AOP framework
  *

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     "license": "MIT",
 
     "require": {
-        "php": ">=5.6.0",
+        "php": ">=7.0.0",
         "jakubledl/dissect": "~1.0",
         "doctrine/annotations": "~1.0",
         "goaop/parser-reflection": "~1.2"
@@ -53,7 +53,7 @@
     "minimum-stability": "stable",
     "extra": {
         "branch-alias": {
-            "dev-master": "2.0-dev"
+            "dev-master": "3.0-dev"
         }
     }
 }

--- a/demos/Demo/Annotation/Cacheable.php
+++ b/demos/Demo/Annotation/Cacheable.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 /*
  * Go! AOP framework
  *

--- a/demos/Demo/Annotation/Deprecated.php
+++ b/demos/Demo/Annotation/Deprecated.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 /*
  * Go! AOP framework
  *

--- a/demos/Demo/Annotation/Loggable.php
+++ b/demos/Demo/Annotation/Loggable.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 /*
  * Go! AOP framework
  *

--- a/demos/Demo/Aspect/AwesomeAspectKernel.php
+++ b/demos/Demo/Aspect/AwesomeAspectKernel.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 /*
  * Go! AOP framework
  *

--- a/demos/Demo/Aspect/AwesomeAspectKernel.php
+++ b/demos/Demo/Aspect/AwesomeAspectKernel.php
@@ -23,8 +23,6 @@ class AwesomeAspectKernel extends AspectKernel
      * Configure an AspectContainer with advisors, aspects and pointcuts
      *
      * @param AspectContainer $container
-     *
-     * @return void
      */
     protected function configureAop(AspectContainer $container)
     {

--- a/demos/Demo/Aspect/CachingAspect.php
+++ b/demos/Demo/Aspect/CachingAspect.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 /*
  * Go! AOP framework
  *

--- a/demos/Demo/Aspect/DeclareErrorAspect.php
+++ b/demos/Demo/Aspect/DeclareErrorAspect.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 /*
  * Go! AOP framework
  *

--- a/demos/Demo/Aspect/DynamicMethodsAspect.php
+++ b/demos/Demo/Aspect/DynamicMethodsAspect.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 /*
  * Go! AOP framework
  *

--- a/demos/Demo/Aspect/FluentInterface.php
+++ b/demos/Demo/Aspect/FluentInterface.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 /*
  * Go! AOP framework
  *

--- a/demos/Demo/Aspect/FluentInterfaceAspect.php
+++ b/demos/Demo/Aspect/FluentInterfaceAspect.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 /*
  * Go! AOP framework
  *

--- a/demos/Demo/Aspect/FunctionInterceptorAspect.php
+++ b/demos/Demo/Aspect/FunctionInterceptorAspect.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 /*
  * Go! AOP framework
  *

--- a/demos/Demo/Aspect/HealthyLiveAspect.php
+++ b/demos/Demo/Aspect/HealthyLiveAspect.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 /*
  * Go! AOP framework
  *

--- a/demos/Demo/Aspect/Introduce/SerializableImpl.php
+++ b/demos/Demo/Aspect/Introduce/SerializableImpl.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 /*
  * Go! AOP framework
  *

--- a/demos/Demo/Aspect/IntroductionAspect.php
+++ b/demos/Demo/Aspect/IntroductionAspect.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 /*
  * Go! AOP framework
  *

--- a/demos/Demo/Aspect/LoggingAspect.php
+++ b/demos/Demo/Aspect/LoggingAspect.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 /*
  * Go! AOP framework
  *

--- a/demos/Demo/Aspect/PropertyInterceptorAspect.php
+++ b/demos/Demo/Aspect/PropertyInterceptorAspect.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 /*
  * Go! AOP framework
  *

--- a/demos/Demo/Example/CacheableDemo.php
+++ b/demos/Demo/Example/CacheableDemo.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 /*
  * Go! AOP framework
  *

--- a/demos/Demo/Example/CacheableDemo.php
+++ b/demos/Demo/Example/CacheableDemo.php
@@ -32,7 +32,7 @@ class CacheableDemo
     public function getReport($from)
     {
         // long calculation for 100ms
-        usleep(0.1 * 1e6);
+        usleep(100 * 1000);
 
         return $from;
     }

--- a/demos/Demo/Example/CacheableDemo.php
+++ b/demos/Demo/Example/CacheableDemo.php
@@ -29,7 +29,7 @@ class CacheableDemo
      *
      * @return string
      */
-    public function getReport($from)
+    public function getReport(string $from) : string
     {
         // long calculation for 100ms
         usleep(100 * 1000);

--- a/demos/Demo/Example/DynamicMethodsDemo.php
+++ b/demos/Demo/Example/DynamicMethodsDemo.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 /*
  * Go! AOP framework
  *

--- a/demos/Demo/Example/DynamicMethodsDemo.php
+++ b/demos/Demo/Example/DynamicMethodsDemo.php
@@ -27,7 +27,7 @@ class DynamicMethodsDemo
      * @param string $name Method name
      * @param array $args Method arguments
      */
-    public function __call($name, array $args)
+    public function __call(string $name, array $args)
     {
         echo "I'm method: {$name}", PHP_EOL;
     }
@@ -38,7 +38,7 @@ class DynamicMethodsDemo
      * @param string $name Method name
      * @param array $args Method arguments
      */
-    public static function __callStatic($name, array $args)
+    public static function __callStatic(string $name, array $args)
     {
         echo "I'm static method: {$name}", PHP_EOL;
     }

--- a/demos/Demo/Example/ErrorDemo.php
+++ b/demos/Demo/Example/ErrorDemo.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 /*
  * Go! AOP framework
  *

--- a/demos/Demo/Example/ErrorDemo.php
+++ b/demos/Demo/Example/ErrorDemo.php
@@ -32,7 +32,7 @@ class ErrorDemo
     /**
      * Method that is very tricky and should generate a notice
      */
-    public function notSoGoodMethod()
+    public function notSoGoodMethod() : float
     {
         $value = round(microtime(true)) % 3; // Sometimes this equal to 0
 

--- a/demos/Demo/Example/FunctionDemo.php
+++ b/demos/Demo/Example/FunctionDemo.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 /*
  * Go! AOP framework
  *

--- a/demos/Demo/Example/FunctionDemo.php
+++ b/demos/Demo/Example/FunctionDemo.php
@@ -22,7 +22,7 @@ class FunctionDemo
      *
      * @param array $data Incoming array
      *
-     * @return array|mixed Outcoming array
+     * @return array Outcoming array
      */
     public function testArrayFunctions(array $data = [])
     {

--- a/demos/Demo/Example/HumanDemo.php
+++ b/demos/Demo/Example/HumanDemo.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 /*
  * Go! AOP framework
  *

--- a/demos/Demo/Example/IntroductionDemo.php
+++ b/demos/Demo/Example/IntroductionDemo.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 /*
  * Go! AOP framework
  *

--- a/demos/Demo/Example/LoggingDemo.php
+++ b/demos/Demo/Example/LoggingDemo.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 /*
  * Go! AOP framework
  *

--- a/demos/Demo/Example/LoggingDemo.php
+++ b/demos/Demo/Example/LoggingDemo.php
@@ -23,9 +23,9 @@ class LoggingDemo
      * Executes a task and logs all incoming arguments
      *
      * @Loggable
-     * @param mixed $task Some specific argument
+     * @param string $task Some specific argument
      */
-    public function execute($task)
+    public function execute(string $task)
     {
         $this->perform($task, 'first');
         $this->perform($task, 'second');
@@ -36,10 +36,10 @@ class LoggingDemo
      *
      * @Loggable
      *
-     * @param mixed $task Specific task
+     * @param string $task Specific task
      * @param string $level
      */
-    protected function perform($task, $level)
+    protected function perform(string $task, string $level)
     {
         // some logic here
     }
@@ -51,7 +51,7 @@ class LoggingDemo
      *
      * @param string $task Some specific argument
      */
-    public static function runByName($task)
+    public static function runByName(string $task)
     {
         $instance = new static(); // Go! AOP requires LSB to work correctly
         $instance->execute($task);

--- a/demos/Demo/Example/PropertyDemo.php
+++ b/demos/Demo/Example/PropertyDemo.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 /*
  * Go! AOP framework
  *

--- a/demos/Demo/Example/UserFluentDemo.php
+++ b/demos/Demo/Example/UserFluentDemo.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 /*
  * Go! AOP framework
  *

--- a/demos/Demo/Example/UserFluentDemo.php
+++ b/demos/Demo/Example/UserFluentDemo.php
@@ -22,19 +22,19 @@ class UserFluentDemo implements FluentInterface
     protected $surname;
     protected $password;
 
-    public function setName($name)
+    public function setName(string $name)
     {
         echo "Set user name to ", $name, PHP_EOL;
         $this->name = $name;
     }
 
-    public function setSurname($surname)
+    public function setSurname(string $surname)
     {
         echo "Set user surname to ", $surname, PHP_EOL;
         $this->surname = $surname;
     }
 
-    public function setPassword($password)
+    public function setPassword(string $password)
     {
         if (!$password) {
             throw new \InvalidArgumentException("Password shouldn't be empty");

--- a/demos/Demo/Highlighter.php
+++ b/demos/Demo/Highlighter.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 /*
  * Go! AOP framework
  *

--- a/demos/autoload_aspect.php
+++ b/demos/autoload_aspect.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 /*
  * Go! AOP framework
  *

--- a/demos/autoload_aspect.php
+++ b/demos/autoload_aspect.php
@@ -15,10 +15,10 @@ use Go\Aop\Features;
 include __DIR__ . '/../vendor/autoload.php';
 
 // Initialize demo aspect container
-AwesomeAspectKernel::getInstance()->init(array(
+AwesomeAspectKernel::getInstance()->init([
     'debug'    => true,
     'appDir'   => __DIR__ . '/../demos',
     'cacheDir' => __DIR__ . '/cache',
 
     'features' => Features::INTERCEPT_FUNCTIONS,
-));
+]);

--- a/demos/index.php
+++ b/demos/index.php
@@ -171,14 +171,14 @@ switch ($showCase) {
         $example = new DynamicMethodsDemo();
         $example->saveById(123); // intercept magic dynamic method
         $example->load(456); // notice, that advice for this magic method is not called
-        DynamicMethodsDemo::find(array('id' =>124)); //intercept magic static method
+        DynamicMethodsDemo::find(['id' =>124]); //intercept magic static method
         break;
 
     case 'function-interceptor':
         $aspectName = 'Demo\Aspect\FunctionInterceptorAspect';
 
         $example = new FunctionDemo();
-        $example->testArrayFunctions(array('test' => 1, 'code' => 2, 'more' => 1));
+        $example->testArrayFunctions(['test' => 1, 'code' => 2, 'more' => 1]);
         $example->testFileContent();
         break;
 

--- a/demos/index.php
+++ b/demos/index.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 /*
  * Go! AOP framework
  *

--- a/demos/index.php
+++ b/demos/index.php
@@ -140,10 +140,10 @@ switch ($showCase) {
         $aspectName = 'Demo\Aspect\CachingAspect';
 
         $example = new CacheableDemo();
-        $result  = $example->getReport(12345); // First call will take 0.1 second
+        $result  = $example->getReport('Test'); // First call will take 0.1 second
         echo "Result is: ", $result, PHP_EOL;
 
-        $result = $example->getReport(12346); // This call is cached and result should be '12345'
+        $result = $example->getReport('Test1'); // This call is cached and result should be 'Test'
         echo "Result is: ", $result, PHP_EOL;
         break;
 

--- a/src/Aop/Advice.php
+++ b/src/Aop/Advice.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 /*
  * Go! AOP framework
  *

--- a/src/Aop/AdviceAfter.php
+++ b/src/Aop/AdviceAfter.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 /*
  * Go! AOP framework
  *

--- a/src/Aop/AdviceAround.php
+++ b/src/Aop/AdviceAround.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 /*
  * Go! AOP framework
  *

--- a/src/Aop/AdviceBefore.php
+++ b/src/Aop/AdviceBefore.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 /*
  * Go! AOP framework
  *

--- a/src/Aop/Advisor.php
+++ b/src/Aop/Advisor.php
@@ -20,8 +20,6 @@ interface Advisor
      * Return the advice part of this aspect. An advice may be an interceptor, a before advice, a throws advice, etc.
      *
      * @api
-     *
-     * @return Advice The advice that should apply if the pointcut matches
      */
     public function getAdvice() : Advice;
 }

--- a/src/Aop/Advisor.php
+++ b/src/Aop/Advisor.php
@@ -23,5 +23,5 @@ interface Advisor
      *
      * @return Advice The advice that should apply if the pointcut matches
      */
-    public function getAdvice();
+    public function getAdvice() : Advice;
 }

--- a/src/Aop/Advisor.php
+++ b/src/Aop/Advisor.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 /*
  * Go! AOP framework
  *

--- a/src/Aop/Aspect.php
+++ b/src/Aop/Aspect.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 /*
  * Go! AOP framework
  *

--- a/src/Aop/AspectException.php
+++ b/src/Aop/AspectException.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 /*
  * Go! AOP framework
  *

--- a/src/Aop/Features.php
+++ b/src/Aop/Features.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 /*
  * Go! AOP framework
  *

--- a/src/Aop/Framework/AbstractInvocation.php
+++ b/src/Aop/Framework/AbstractInvocation.php
@@ -27,17 +27,16 @@ abstract class AbstractInvocation extends AbstractJoinpoint implements Invocatio
 
     /**
      * Get the arguments as an array object.
-     * It is possible to change element values within this array to change the arguments
-     *
-     * @return array the arguments of the invocation
      */
-    public function getArguments()
+    public function getArguments() : array
     {
         return $this->arguments;
     }
 
     /**
      * Sets the arguments for current invocation
+     *
+     * @api
      *
      * @param array $arguments New list of arguments
      */

--- a/src/Aop/Framework/AbstractInvocation.php
+++ b/src/Aop/Framework/AbstractInvocation.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 /*
  * Go! AOP framework
  *

--- a/src/Aop/Framework/AbstractJoinpoint.php
+++ b/src/Aop/Framework/AbstractJoinpoint.php
@@ -73,7 +73,7 @@ abstract class AbstractJoinpoint implements Joinpoint
      * @param array|Advice[] $advices
      * @return array|Advice[] Sorted list of advices
      */
-    public static function sortAdvices(array $advices)
+    public static function sortAdvices(array $advices) : array
     {
         $sortedAdvices = $advices;
         uasort($sortedAdvices, function(Advice $first, Advice $second) {

--- a/src/Aop/Framework/AbstractJoinpoint.php
+++ b/src/Aop/Framework/AbstractJoinpoint.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 /*
  * Go! AOP framework
  *

--- a/src/Aop/Framework/AbstractMethodInvocation.php
+++ b/src/Aop/Framework/AbstractMethodInvocation.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 /*
  * Go! AOP framework
  *

--- a/src/Aop/Framework/AbstractMethodInvocation.php
+++ b/src/Aop/Framework/AbstractMethodInvocation.php
@@ -49,7 +49,7 @@ abstract class AbstractMethodInvocation extends AbstractInvocation implements Me
      * @param string $methodName Method to invoke
      * @param $advices array List of advices for this invocation
      */
-    public function __construct($className, $methodName, array $advices)
+    public function __construct(string $className, string $methodName, array $advices)
     {
         parent::__construct($advices);
         $this->className        = $className;
@@ -102,9 +102,9 @@ abstract class AbstractMethodInvocation extends AbstractInvocation implements Me
     /**
      * Gets the method being called.
      *
-     * @return AnnotatedReflectionMethod the method being called.
+     * @return ReflectionMethod|AnnotatedReflectionMethod the method being called.
      */
-    public function getMethod()
+    public function getMethod() : ReflectionMethod
     {
         return $this->reflectionMethod;
     }

--- a/src/Aop/Framework/AbstractMethodInvocation.php
+++ b/src/Aop/Framework/AbstractMethodInvocation.php
@@ -72,7 +72,7 @@ abstract class AbstractMethodInvocation extends AbstractInvocation implements Me
      */
     final public function __invoke($instance = null, array $arguments = [], array $variadicArguments = [])
     {
-        if ($this->level) {
+        if ($this->level > 0) {
             $this->stackFrames[] = [$this->arguments, $this->instance, $this->current];
         }
 
@@ -92,7 +92,7 @@ abstract class AbstractMethodInvocation extends AbstractInvocation implements Me
             --$this->level;
         }
 
-        if ($this->level) {
+        if ($this->level > 0) {
             list($this->arguments, $this->instance, $this->current) = array_pop($this->stackFrames);
         }
 

--- a/src/Aop/Framework/AfterInterceptor.php
+++ b/src/Aop/Framework/AfterInterceptor.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 /*
  * Go! AOP framework
  *

--- a/src/Aop/Framework/AfterThrowingInterceptor.php
+++ b/src/Aop/Framework/AfterThrowingInterceptor.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 /*
  * Go! AOP framework
  *

--- a/src/Aop/Framework/AroundInterceptor.php
+++ b/src/Aop/Framework/AroundInterceptor.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 /*
  * Go! AOP framework
  *

--- a/src/Aop/Framework/BaseAdvice.php
+++ b/src/Aop/Framework/BaseAdvice.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 /*
  * Go! AOP framework
  *

--- a/src/Aop/Framework/BaseAdvice.php
+++ b/src/Aop/Framework/BaseAdvice.php
@@ -52,7 +52,7 @@ abstract class BaseAdvice implements OrderedAdvice
     /**
      * Local cache of advices for faster unserialization on big projects
      *
-     * @var array|Closure[]
+     * @var Closure[]
      */
     protected static $localAdvicesCache = [];
 
@@ -71,7 +71,7 @@ abstract class BaseAdvice implements OrderedAdvice
      *
      * @return array
      */
-    public static function serializeAdvice(Closure $adviceMethod)
+    public static function serializeAdvice(Closure $adviceMethod) : array
     {
         $refAdvice = new ReflectionFunction($adviceMethod);
 
@@ -88,7 +88,7 @@ abstract class BaseAdvice implements OrderedAdvice
      *
      * @return Closure
      */
-    public static function unserializeAdvice(array $adviceData)
+    public static function unserializeAdvice(array $adviceData) : Closure
     {
         $aspectName = $adviceData['aspect'];
         $methodName = $adviceData['method'];

--- a/src/Aop/Framework/BaseAdvice.php
+++ b/src/Aop/Framework/BaseAdvice.php
@@ -58,10 +58,8 @@ abstract class BaseAdvice implements OrderedAdvice
 
     /**
      * Returns the advice order
-     *
-     * @return int
      */
-    public function getAdviceOrder()
+    public function getAdviceOrder() : int
     {
         return $this->order;
     }

--- a/src/Aop/Framework/BaseInterceptor.php
+++ b/src/Aop/Framework/BaseInterceptor.php
@@ -50,8 +50,6 @@ abstract class BaseInterceptor extends BaseAdvice implements Interceptor, Serial
 
     /**
      * Getter for extracting the advice closure from Interceptor
-     *
-     * @return Closure
      */
     public function getRawAdvice() : Closure
     {

--- a/src/Aop/Framework/BaseInterceptor.php
+++ b/src/Aop/Framework/BaseInterceptor.php
@@ -41,7 +41,7 @@ abstract class BaseInterceptor extends BaseAdvice implements Interceptor, Serial
      * @param integer $order Order of interceptor
      * @param string $pointcutExpression Pointcut expression or advice name
      */
-    public function __construct(Closure $adviceMethod, $order = 0, $pointcutExpression = '')
+    public function __construct(Closure $adviceMethod, int $order = 0, string $pointcutExpression = '')
     {
         $this->adviceMethod       = $adviceMethod;
         $this->order              = $order;
@@ -51,9 +51,9 @@ abstract class BaseInterceptor extends BaseAdvice implements Interceptor, Serial
     /**
      * Getter for extracting the advice closure from Interceptor
      *
-     * @return callable|null
+     * @return Closure
      */
-    public function getRawAdvice()
+    public function getRawAdvice() : Closure
     {
         return $this->adviceMethod;
     }

--- a/src/Aop/Framework/BaseInterceptor.php
+++ b/src/Aop/Framework/BaseInterceptor.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 /*
  * Go! AOP framework
  *

--- a/src/Aop/Framework/BeforeInterceptor.php
+++ b/src/Aop/Framework/BeforeInterceptor.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 /*
  * Go! AOP framework
  *

--- a/src/Aop/Framework/ClassFieldAccess.php
+++ b/src/Aop/Framework/ClassFieldAccess.php
@@ -167,7 +167,7 @@ class ClassFieldAccess extends AbstractJoinpoint implements FieldAccess
      */
     final public function &__invoke($instance, $accessType, &$originalValue, $newValue = NAN)
     {
-        if ($this->level) {
+        if ($this->level > 0) {
             array_push($this->stackFrames, [$this->instance, $this->accessType, &$this->value, &$this->newValue]);
         }
 
@@ -183,7 +183,7 @@ class ClassFieldAccess extends AbstractJoinpoint implements FieldAccess
 
         --$this->level;
 
-        if ($this->level) {
+        if ($this->level > 0) {
             list($this->instance, $this->accessType, $this->value, $this->newValue) = array_pop($this->stackFrames);
         }
 

--- a/src/Aop/Framework/ClassFieldAccess.php
+++ b/src/Aop/Framework/ClassFieldAccess.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 /*
  * Go! AOP framework
  *

--- a/src/Aop/Framework/ClassFieldAccess.php
+++ b/src/Aop/Framework/ClassFieldAccess.php
@@ -64,7 +64,7 @@ class ClassFieldAccess extends AbstractJoinpoint implements FieldAccess
      * @param string $fieldName Field name
      * @param $advices array List of advices for this invocation
      */
-    public function __construct($className, $fieldName, array $advices)
+    public function __construct(string $className, string $fieldName, array $advices)
     {
         parent::__construct($advices);
 
@@ -77,20 +77,16 @@ class ClassFieldAccess extends AbstractJoinpoint implements FieldAccess
 
     /**
      * Returns the access type.
-     *
-     * @return integer
      */
-    public function getAccessType()
+    public function getAccessType() : int
     {
         return $this->accessType;
     }
 
     /**
      * Gets the field being accessed.
-     *
-     * @return ReflectionProperty the field being accessed.
      */
-    public function getField()
+    public function getField() : ReflectionProperty
     {
         return $this->reflectionProperty;
     }
@@ -123,8 +119,6 @@ class ClassFieldAccess extends AbstractJoinpoint implements FieldAccess
      * Checks scope rules for accessing property
      *
      * @param int $stackLevel Stack level for check
-     *
-     * @return true if access is OK
      */
     public function ensureScopeRule($stackLevel = 2)
     {
@@ -136,13 +130,11 @@ class ClassFieldAccess extends AbstractJoinpoint implements FieldAccess
             $propertyClass = $property->class;
             if (isset($accessor['class'])) {
                 if ($accessor['class'] === $propertyClass || is_subclass_of($accessor['class'], $propertyClass)) {
-                    return true;
+                    return;
                 }
             }
             throw new AspectException("Cannot access protected property {$propertyClass}::{$property->name}");
         }
-
-        return true;
     }
 
     /**

--- a/src/Aop/Framework/DeclareErrorInterceptor.php
+++ b/src/Aop/Framework/DeclareErrorInterceptor.php
@@ -41,9 +41,9 @@ class DeclareErrorInterceptor extends BaseInterceptor
      *
      * @param string $message Text message for error
      * @param int $level Level of error
-     * @param string|null $pointcutExpression Pointcut expression
+     * @param string $pointcutExpression Pointcut expression
      */
-    public function __construct($message, $level, $pointcutExpression)
+    public function __construct(string $message, int $level, string $pointcutExpression)
     {
         $adviceMethod  = self::getDeclareErrorAdvice();
         $this->message = $message;
@@ -80,28 +80,6 @@ class DeclareErrorInterceptor extends BaseInterceptor
     }
 
     /**
-     * Returns an advice
-     *
-     * @return \Closure
-     */
-    private static function getDeclareErrorAdvice()
-    {
-        static $adviceMethod = null;
-        if (!$adviceMethod) {
-            $adviceMethod = function($object, $reflectorName, $message, $level = E_USER_NOTICE) {
-                $class   = is_string($object) ? $object : get_class($object);
-                $message = vsprintf('[AOP Declare Error]: %s has an error: "%s"', [
-                    $class . '->' . $reflectorName,
-                    $message
-                ]);
-                trigger_error($message, $level);
-            };
-        }
-
-        return $adviceMethod;
-    }
-
-    /**
      * Implement this method to perform extra treatments before and
      * after the invocation. Polite implementations would certainly
      * like to invoke {@link Joinpoint::proceed()}.
@@ -121,5 +99,25 @@ class DeclareErrorInterceptor extends BaseInterceptor
         $adviceMethod($joinpoint->getThis(), $reflectorName, $this->message, $this->level);
 
         return $joinpoint->proceed();
+    }
+
+    /**
+     * Returns an advice
+     */
+    private static function getDeclareErrorAdvice() : \Closure
+    {
+        static $adviceMethod = null;
+        if (!$adviceMethod) {
+            $adviceMethod = function($object, $reflectorName, $message, $level = E_USER_NOTICE) {
+                $class   = is_string($object) ? $object : get_class($object);
+                $message = vsprintf('[AOP Declare Error]: %s has an error: "%s"', [
+                    $class . '->' . $reflectorName,
+                    $message
+                ]);
+                trigger_error($message, $level);
+            };
+        }
+
+        return $adviceMethod;
     }
 }

--- a/src/Aop/Framework/DeclareErrorInterceptor.php
+++ b/src/Aop/Framework/DeclareErrorInterceptor.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 /*
  * Go! AOP framework
  *

--- a/src/Aop/Framework/DeclareErrorInterceptor.php
+++ b/src/Aop/Framework/DeclareErrorInterceptor.php
@@ -90,10 +90,10 @@ class DeclareErrorInterceptor extends BaseInterceptor
         if (!$adviceMethod) {
             $adviceMethod = function($object, $reflectorName, $message, $level = E_USER_NOTICE) {
                 $class   = is_string($object) ? $object : get_class($object);
-                $message = vsprintf('[AOP Declare Error]: %s has an error: "%s"', array(
+                $message = vsprintf('[AOP Declare Error]: %s has an error: "%s"', [
                     $class . '->' . $reflectorName,
                     $message
-                ));
+                ]);
                 trigger_error($message, $level);
             };
         }

--- a/src/Aop/Framework/DynamicClosureMethodInvocation.php
+++ b/src/Aop/Framework/DynamicClosureMethodInvocation.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 /*
  * Go! AOP framework
  *

--- a/src/Aop/Framework/DynamicInvocationMatcherInterceptor.php
+++ b/src/Aop/Framework/DynamicInvocationMatcherInterceptor.php
@@ -11,11 +11,10 @@ declare(strict_types = 1);
 
 namespace Go\Aop\Framework;
 
-use Go\Aop\PointFilter;
 use Go\Aop\Intercept\Interceptor;
 use Go\Aop\Intercept\Invocation;
 use Go\Aop\Intercept\Joinpoint;
-use Serializable;
+use Go\Aop\PointFilter;
 
 /**
  * Dynamic invocation matcher combines a pointcut and interceptor.
@@ -23,7 +22,7 @@ use Serializable;
  * For each invocation interceptor asks the pointcut if it matches the invocation.
  * Matcher will receive reflection point, object instance and invocation arguments to make a decision
  */
-class DynamicInvocationMatcherInterceptor implements Interceptor, Serializable
+class DynamicInvocationMatcherInterceptor implements Interceptor
 {
     /**
      * Instance of pointcut to dynamically match joinpoints with args
@@ -49,27 +48,6 @@ class DynamicInvocationMatcherInterceptor implements Interceptor, Serializable
     {
         $this->pointFilter = $pointFilter;
         $this->interceptor = $interceptor;
-    }
-
-    /**
-     * Serializes an interceptor into string representation
-     *
-     * @return string the string representation of the object or null
-     */
-    public function serialize()
-    {
-        return serialize([$this->pointFilter, $this->interceptor]);
-    }
-
-    /**
-     * Unserialize an interceptor from the string
-     *
-     * @param string $serialized The string representation of the object.
-     * @return void
-     */
-    public function unserialize($serialized)
-    {
-        list($this->pointFilter, $this->interceptor) = unserialize($serialized);
     }
 
     /**

--- a/src/Aop/Framework/DynamicInvocationMatcherInterceptor.php
+++ b/src/Aop/Framework/DynamicInvocationMatcherInterceptor.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 /*
  * Go! AOP framework
  *

--- a/src/Aop/Framework/OrderedAdvice.php
+++ b/src/Aop/Framework/OrderedAdvice.php
@@ -20,8 +20,6 @@ interface OrderedAdvice extends Advice
 {
     /**
      * Returns the advice order
-     *
-     * @return int
      */
-    public function getAdviceOrder();
+    public function getAdviceOrder() : int;
 }

--- a/src/Aop/Framework/OrderedAdvice.php
+++ b/src/Aop/Framework/OrderedAdvice.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 /*
  * Go! AOP framework
  *

--- a/src/Aop/Framework/ReflectionConstructorInvocation.php
+++ b/src/Aop/Framework/ReflectionConstructorInvocation.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 /*
  * Go! AOP framework
  *

--- a/src/Aop/Framework/ReflectionConstructorInvocation.php
+++ b/src/Aop/Framework/ReflectionConstructorInvocation.php
@@ -53,10 +53,10 @@ class ReflectionConstructorInvocation extends AbstractInvocation implements Cons
      * Constructor for constructor invocation :)
      *
      * @param string $className Class name
-     * @param $advices array List of advices for this invocation
      * @param string $type
+     * @param $advices array List of advices for this invocation
      */
-    public function __construct($className, $type, array $advices)
+    public function __construct(string $className, string $type, array $advices)
     {
         $this->class       = new ReflectionClass($className);
         $this->constructor = $constructor = $this->class->getConstructor();

--- a/src/Aop/Framework/ReflectionFunctionInvocation.php
+++ b/src/Aop/Framework/ReflectionFunctionInvocation.php
@@ -97,7 +97,7 @@ class ReflectionFunctionInvocation extends AbstractInvocation implements Functio
      */
     final public function __invoke(array $arguments = [], array $variadicArguments = [])
     {
-        if ($this->level) {
+        if ($this->level > 0) {
             array_push($this->stackFrames, [$this->arguments, $this->current]);
         }
 
@@ -114,7 +114,7 @@ class ReflectionFunctionInvocation extends AbstractInvocation implements Functio
 
         --$this->level;
 
-        if ($this->level) {
+        if ($this->level > 0) {
             list($this->arguments, $this->current) = array_pop($this->stackFrames);
         }
 

--- a/src/Aop/Framework/ReflectionFunctionInvocation.php
+++ b/src/Aop/Framework/ReflectionFunctionInvocation.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 /*
  * Go! AOP framework
  *

--- a/src/Aop/Framework/ReflectionFunctionInvocation.php
+++ b/src/Aop/Framework/ReflectionFunctionInvocation.php
@@ -59,10 +59,8 @@ class ReflectionFunctionInvocation extends AbstractInvocation implements Functio
 
     /**
      * Gets the function being called.
-     *
-     * @return ReflectionFunction the method being called.
      */
-    public function getFunction()
+    public function getFunction() : ReflectionFunction
     {
         return $this->reflectionFunction;
     }

--- a/src/Aop/Framework/StaticClosureMethodInvocation.php
+++ b/src/Aop/Framework/StaticClosureMethodInvocation.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 /*
  * Go! AOP framework
  *

--- a/src/Aop/Framework/StaticClosureMethodInvocation.php
+++ b/src/Aop/Framework/StaticClosureMethodInvocation.php
@@ -11,6 +11,8 @@ declare(strict_types = 1);
 
 namespace Go\Aop\Framework;
 
+use Closure;
+
 /**
  * Static closure method invocation is responsible to call static methods via closure
  */
@@ -19,7 +21,7 @@ final class StaticClosureMethodInvocation extends AbstractMethodInvocation
     /**
      * Closure to use
      *
-     * @var \Closure
+     * @var Closure
      */
     protected $closureToCall = null;
 
@@ -65,9 +67,9 @@ final class StaticClosureMethodInvocation extends AbstractMethodInvocation
      * @param string $className Class name to forward request
      * @param string $method Method name to call
      *
-     * @return \Closure
+     * @return Closure
      */
-    protected static function getStaticInvoker($className, $method)
+    protected static function getStaticInvoker($className, $method) : Closure
     {
         return function(array $args) use ($className, $method) {
             return forward_static_call_array([$className, $method], $args);

--- a/src/Aop/Framework/StaticInitializationJoinpoint.php
+++ b/src/Aop/Framework/StaticInitializationJoinpoint.php
@@ -34,7 +34,7 @@ class StaticInitializationJoinpoint extends AbstractJoinpoint
      *
      * @internal param ReflectionClass $reflectionClass Reflection of class
      */
-    public function __construct($className, $type, array $advices)
+    public function __construct(string $className, string $type, array $advices)
     {
         if (strpos($className, AspectContainer::AOP_PROXIED_SUFFIX)) {
             $originalClass = substr($className, 0, -strlen(AspectContainer::AOP_PROXIED_SUFFIX));

--- a/src/Aop/Framework/StaticInitializationJoinpoint.php
+++ b/src/Aop/Framework/StaticInitializationJoinpoint.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 /*
  * Go! AOP framework
  *

--- a/src/Aop/Framework/TraitIntroductionInfo.php
+++ b/src/Aop/Framework/TraitIntroductionInfo.php
@@ -50,7 +50,7 @@ class TraitIntroductionInfo implements IntroductionInfo
      *
      * @return array|string[] introduced interfaces
      */
-    public function getInterfaces()
+    public function getInterfaces() : array
     {
         return $this->introducedInterfaces;
     }
@@ -60,7 +60,7 @@ class TraitIntroductionInfo implements IntroductionInfo
      *
      * @return array|string[] trait implementations
      */
-    public function getTraits()
+    public function getTraits() : array
     {
         return $this->introducedTraits;
     }

--- a/src/Aop/Framework/TraitIntroductionInfo.php
+++ b/src/Aop/Framework/TraitIntroductionInfo.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 /*
  * Go! AOP framework
  *

--- a/src/Aop/Framework/TraitIntroductionInfo.php
+++ b/src/Aop/Framework/TraitIntroductionInfo.php
@@ -46,9 +46,7 @@ class TraitIntroductionInfo implements IntroductionInfo
     }
 
     /**
-     * Return the additional interfaces introduced by this Advisor or Advice.
-     *
-     * @return array|string[] introduced interfaces
+     * Returns the list of additional interface names introduced by this Advisor or Advice.
      */
     public function getInterfaces() : array
     {
@@ -56,9 +54,7 @@ class TraitIntroductionInfo implements IntroductionInfo
     }
 
     /**
-     * Return the list of traits with realization of introduced interfaces
-     *
-     * @return array|string[] trait implementations
+     * Returns the list of trait names with realization of introduced interfaces
      */
     public function getTraits() : array
     {

--- a/src/Aop/Intercept/ConstructorInvocation.php
+++ b/src/Aop/Intercept/ConstructorInvocation.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 /*
  * Go! AOP framework
  *

--- a/src/Aop/Intercept/FieldAccess.php
+++ b/src/Aop/Intercept/FieldAccess.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 /*
  * Go! AOP framework
  *

--- a/src/Aop/Intercept/FieldAccess.php
+++ b/src/Aop/Intercept/FieldAccess.php
@@ -37,10 +37,8 @@ interface FieldAccess extends Joinpoint
      * Gets the field being accessed.
      *
      * @api
-     *
-     * @return ReflectionProperty the field being accessed.
      */
-    public function getField();
+    public function getField() : ReflectionProperty;
 
     /**
      * Gets the current value of property by reference
@@ -64,8 +62,6 @@ interface FieldAccess extends Joinpoint
      * Returns the access type.
      *
      * @api
-     *
-     * @return integer
      */
-    public function getAccessType();
+    public function getAccessType() : int;
 }

--- a/src/Aop/Intercept/FunctionInvocation.php
+++ b/src/Aop/Intercept/FunctionInvocation.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 /*
  * Go! AOP framework
  *

--- a/src/Aop/Intercept/FunctionInvocation.php
+++ b/src/Aop/Intercept/FunctionInvocation.php
@@ -25,10 +25,8 @@ interface FunctionInvocation extends Invocation
 
     /**
      * Gets the function being called.
-     *
-     * @return ReflectionFunction the function being called.
      */
-    public function getFunction();
+    public function getFunction() : ReflectionFunction;
 
     /**
      * Invokes current function invocation with all interceptors

--- a/src/Aop/Intercept/Interceptor.php
+++ b/src/Aop/Intercept/Interceptor.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 /*
  * Go! AOP framework
  *

--- a/src/Aop/Intercept/Invocation.php
+++ b/src/Aop/Intercept/Invocation.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 /*
  * Go! AOP framework
  *

--- a/src/Aop/Intercept/Invocation.php
+++ b/src/Aop/Intercept/Invocation.php
@@ -24,13 +24,13 @@ interface Invocation extends Joinpoint
      * Get the arguments of invocation as an array.
      *
      * @api
-     *
-     * @return array the arguments of the invocation
      */
-    public function getArguments();
+    public function getArguments() : array;
 
     /**
      * Sets the arguments for current invocation
+     *
+     * @api
      *
      * @param array $arguments New list of arguments
      */

--- a/src/Aop/Intercept/Joinpoint.php
+++ b/src/Aop/Intercept/Joinpoint.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 /*
  * Go! AOP framework
  *

--- a/src/Aop/Intercept/MethodInvocation.php
+++ b/src/Aop/Intercept/MethodInvocation.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 /*
  * Go! AOP framework
  *

--- a/src/Aop/Intercept/MethodInvocation.php
+++ b/src/Aop/Intercept/MethodInvocation.php
@@ -29,7 +29,7 @@ interface MethodInvocation extends Invocation
      *
      * @return ReflectionMethod|AnnotatedReflectionMethod the method being called.
      */
-    public function getMethod();
+    public function getMethod() : ReflectionMethod;
 
     /**
      * Invokes current method invocation with all interceptors

--- a/src/Aop/IntroductionAdvisor.php
+++ b/src/Aop/IntroductionAdvisor.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 /*
  * Go! AOP framework
  *

--- a/src/Aop/IntroductionAdvisor.php
+++ b/src/Aop/IntroductionAdvisor.php
@@ -29,7 +29,7 @@ interface IntroductionAdvisor extends Advisor
      *
      * @return PointFilter The class filter
      */
-    public function getClassFilter();
+    public function getClassFilter() : PointFilter;
 
     /**
      * Can the advised interfaces be implemented by the introduction advice?

--- a/src/Aop/IntroductionAdvisor.php
+++ b/src/Aop/IntroductionAdvisor.php
@@ -26,8 +26,6 @@ interface IntroductionAdvisor extends Advisor
      * Return the filter determining which target classes this introduction should apply to.
      *
      * This represents the class part of a pointcut. Note that method matching doesn't make sense to introductions.
-     *
-     * @return PointFilter The class filter
      */
     public function getClassFilter() : PointFilter;
 

--- a/src/Aop/IntroductionInfo.php
+++ b/src/Aop/IntroductionInfo.php
@@ -26,12 +26,12 @@ interface IntroductionInfo extends Advice
      *
      * @return array|string[] the introduced interfaces
      */
-    public function getInterfaces();
+    public function getInterfaces() : array;
 
     /**
      * Return the list of traits with realization of introduced interfaces
      *
      * @return array|string[] the implementations
      */
-    public function getTraits();
+    public function getTraits() : array;
 }

--- a/src/Aop/IntroductionInfo.php
+++ b/src/Aop/IntroductionInfo.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 /*
  * Go! AOP framework
  *

--- a/src/Aop/IntroductionInfo.php
+++ b/src/Aop/IntroductionInfo.php
@@ -22,16 +22,12 @@ interface IntroductionInfo extends Advice
 {
 
     /**
-     * Return the additional interfaces introduced by this Advisor or Advice.
-     *
-     * @return array|string[] the introduced interfaces
+     * Returns the list of additional interface names introduced by this Advisor or Advice.
      */
     public function getInterfaces() : array;
 
     /**
-     * Return the list of traits with realization of introduced interfaces
-     *
-     * @return array|string[] the implementations
+     * Returns the list of trait names with realization of introduced interfaces
      */
     public function getTraits() : array;
 }

--- a/src/Aop/PointFilter.php
+++ b/src/Aop/PointFilter.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 /*
  * Go! AOP framework
  *

--- a/src/Aop/PointFilter.php
+++ b/src/Aop/PointFilter.php
@@ -48,14 +48,12 @@ interface PointFilter
      * @param null|string|object $instance Invocation instance or string for static calls
      * @param null|array $arguments Dynamic arguments for method
      *
-     * @return bool
+     * @return bool True if point matches
      */
-    public function matches($point, $context = null, $instance = null, array $arguments = null);
+    public function matches($point, $context = null, $instance = null, array $arguments = null) : bool;
 
     /**
      * Returns the kind of point filter
-     *
-     * @return integer
      */
-    public function getKind();
+    public function getKind() : int;
 }

--- a/src/Aop/Pointcut.php
+++ b/src/Aop/Pointcut.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 /*
  * Go! AOP framework
  *

--- a/src/Aop/Pointcut.php
+++ b/src/Aop/Pointcut.php
@@ -22,8 +22,6 @@ interface Pointcut extends PointFilter
 {
     /**
      * Return the class filter for this pointcut.
-     *
-     * @return PointFilter
      */
     public function getClassFilter() : PointFilter;
 }

--- a/src/Aop/Pointcut.php
+++ b/src/Aop/Pointcut.php
@@ -25,5 +25,5 @@ interface Pointcut extends PointFilter
      *
      * @return PointFilter
      */
-    public function getClassFilter();
+    public function getClassFilter() : PointFilter;
 }

--- a/src/Aop/Pointcut/AndPointcut.php
+++ b/src/Aop/Pointcut/AndPointcut.php
@@ -64,7 +64,7 @@ class AndPointcut implements Pointcut
      *
      * @return bool
      */
-    public function matches($point, $context = null, $instance = null, array $arguments = null)
+    public function matches($point, $context = null, $instance = null, array $arguments = null) : bool
     {
         return $this->matchPart($this->first, $point, $context, $instance, $arguments)
             && $this->matchPart($this->second, $point, $context, $instance, $arguments);
@@ -72,10 +72,8 @@ class AndPointcut implements Pointcut
 
     /**
      * Returns the kind of point filter
-     *
-     * @return integer
      */
-    public function getKind()
+    public function getKind() : int
     {
         return $this->kind;
     }

--- a/src/Aop/Pointcut/AndPointcut.php
+++ b/src/Aop/Pointcut/AndPointcut.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 /*
  * Go! AOP framework
  *

--- a/src/Aop/Pointcut/AnnotationPointcut.php
+++ b/src/Aop/Pointcut/AnnotationPointcut.php
@@ -77,7 +77,7 @@ class AnnotationPointcut implements Pointcut
      * @param Reader $reader Reader of annotations
      * @param string $annotationName Annotation class name to match
      */
-    public function __construct($filterKind, Reader $reader, $annotationName)
+    public function __construct(int $filterKind, Reader $reader, string $annotationName)
     {
         if (!isset(self::$mappings[$filterKind])) {
             throw new \InvalidArgumentException("Unsupported filter kind {$filterKind}");
@@ -90,10 +90,9 @@ class AnnotationPointcut implements Pointcut
     }
 
     /**
-     * @param ReflectionClass|ReflectionMethod|ReflectionProperty $point
      * {@inheritdoc}
      */
-    public function matches($point, $context = null, $instance = null, array $arguments = null)
+    public function matches($point, $context = null, $instance = null, array $arguments = null) : bool
     {
         $expectedClass = $this->expectedClass;
         if (!$point instanceof $expectedClass) {
@@ -107,10 +106,8 @@ class AnnotationPointcut implements Pointcut
 
     /**
      * Returns the kind of point filter
-     *
-     * @return integer
      */
-    public function getKind()
+    public function getKind() : int
     {
         return $this->filterKind;
     }

--- a/src/Aop/Pointcut/AnnotationPointcut.php
+++ b/src/Aop/Pointcut/AnnotationPointcut.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 /*
  * Go! AOP framework
  *

--- a/src/Aop/Pointcut/CFlowBelowMethodPointcut.php
+++ b/src/Aop/Pointcut/CFlowBelowMethodPointcut.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 /*
  * Go! AOP framework
  *

--- a/src/Aop/Pointcut/CFlowBelowMethodPointcut.php
+++ b/src/Aop/Pointcut/CFlowBelowMethodPointcut.php
@@ -62,7 +62,7 @@ class CFlowBelowMethodPointcut implements PointFilter, Pointcut
      *
      * @return bool
      */
-    public function matches($point, $context = null, $instance = null, array $arguments = null)
+    public function matches($point, $context = null, $instance = null, array $arguments = null) : bool
     {
         // With single parameter (statically) always matches
         if (!$instance) {
@@ -89,10 +89,8 @@ class CFlowBelowMethodPointcut implements PointFilter, Pointcut
 
     /**
      * Returns the kind of point filter
-     *
-     * @return integer
      */
-    public function getKind()
+    public function getKind() : int
     {
         return PointFilter::KIND_METHOD | PointFilter::KIND_DYNAMIC;
     }

--- a/src/Aop/Pointcut/ClassMemberReference.php
+++ b/src/Aop/Pointcut/ClassMemberReference.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 /*
  * Go! AOP framework
  *

--- a/src/Aop/Pointcut/ClassMemberReference.php
+++ b/src/Aop/Pointcut/ClassMemberReference.php
@@ -59,7 +59,7 @@ class ClassMemberReference
         PointFilter $classFilter,
         ModifierMatcherFilter $visibilityFilter,
         ModifierMatcherFilter $accessTypeFilter,
-        $memberNamePattern)
+        string $memberNamePattern)
     {
         $this->classFilter       = $classFilter;
         $this->visibilityFilter  = $visibilityFilter;
@@ -67,34 +67,22 @@ class ClassMemberReference
         $this->memberNamePattern = $memberNamePattern;
     }
 
-    /**
-     * @return PointFilter
-     */
-    public function getClassFilter()
+    public function getClassFilter() : PointFilter
     {
         return $this->classFilter;
     }
 
-    /**
-     * @return ModifierMatcherFilter
-     */
-    public function getVisibilityFilter()
+    public function getVisibilityFilter() : ModifierMatcherFilter
     {
         return $this->visibilityFilter;
     }
 
-    /**
-     * @return ModifierMatcherFilter
-     */
-    public function getAccessTypeFilter()
+    public function getAccessTypeFilter() : ModifierMatcherFilter
     {
         return $this->accessTypeFilter;
     }
 
-    /**
-     * @return string
-     */
-    public function getMemberNamePattern()
+    public function getMemberNamePattern() : string
     {
         return $this->memberNamePattern;
     }

--- a/src/Aop/Pointcut/FunctionPointcut.php
+++ b/src/Aop/Pointcut/FunctionPointcut.php
@@ -44,7 +44,7 @@ class FunctionPointcut implements Pointcut
      *
      * @param string $functionName Name of the function to match or glob pattern
      */
-    public function __construct($functionName)
+    public function __construct(string $functionName)
     {
         $this->functionName = $functionName;
         $this->regexp       = strtr(preg_quote($this->functionName, '/'), [
@@ -63,7 +63,7 @@ class FunctionPointcut implements Pointcut
      *
      * @return bool
      */
-    public function matches($function, $context = null, $instance = null, array $arguments = null)
+    public function matches($function, $context = null, $instance = null, array $arguments = null) : bool
     {
         if (!$function instanceof ReflectionFunction) {
             return false;
@@ -74,10 +74,8 @@ class FunctionPointcut implements Pointcut
 
     /**
      * Returns the kind of point filter
-     *
-     * @return integer
      */
-    public function getKind()
+    public function getKind() : int
     {
         return self::KIND_FUNCTION;
     }

--- a/src/Aop/Pointcut/FunctionPointcut.php
+++ b/src/Aop/Pointcut/FunctionPointcut.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 /*
  * Go! AOP framework
  *

--- a/src/Aop/Pointcut/FunctionPointcut.php
+++ b/src/Aop/Pointcut/FunctionPointcut.php
@@ -84,8 +84,6 @@ class FunctionPointcut implements Pointcut
 
     /**
      * Return the class filter for this pointcut.
-     *
-     * @return PointFilter
      */
     public function getClassFilter() : PointFilter
     {

--- a/src/Aop/Pointcut/FunctionPointcut.php
+++ b/src/Aop/Pointcut/FunctionPointcut.php
@@ -47,10 +47,10 @@ class FunctionPointcut implements Pointcut
     public function __construct($functionName)
     {
         $this->functionName = $functionName;
-        $this->regexp       = strtr(preg_quote($this->functionName, '/'), array(
+        $this->regexp       = strtr(preg_quote($this->functionName, '/'), [
             '\\*' => '.*?',
             '\\?' => '.'
-        ));
+        ]);
     }
 
     /**

--- a/src/Aop/Pointcut/FunctionPointcut.php
+++ b/src/Aop/Pointcut/FunctionPointcut.php
@@ -87,7 +87,7 @@ class FunctionPointcut implements Pointcut
      *
      * @return PointFilter
      */
-    public function getClassFilter()
+    public function getClassFilter() : PointFilter
     {
         return $this->nsFilter;
     }

--- a/src/Aop/Pointcut/MagicMethodPointcut.php
+++ b/src/Aop/Pointcut/MagicMethodPointcut.php
@@ -53,11 +53,11 @@ class MagicMethodPointcut implements PointFilter, Pointcut
     public function __construct($methodName, PointFilter $modifierFilter = null)
     {
         $this->methodName     = $methodName;
-        $this->regexp         = strtr(preg_quote($this->methodName, '/'), array(
+        $this->regexp         = strtr(preg_quote($this->methodName, '/'), [
             '\\*' => '.*?',
             '\\?' => '.',
             '\\|' => '|'
-        ));
+        ]);
         $this->modifierFilter = $modifierFilter;
     }
 

--- a/src/Aop/Pointcut/MagicMethodPointcut.php
+++ b/src/Aop/Pointcut/MagicMethodPointcut.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 /*
  * Go! AOP framework
  *

--- a/src/Aop/Pointcut/MagicMethodPointcut.php
+++ b/src/Aop/Pointcut/MagicMethodPointcut.php
@@ -50,7 +50,7 @@ class MagicMethodPointcut implements PointFilter, Pointcut
      * @param string $methodName Name of the dynamic method to match or glob pattern
      * @param PointFilter $modifierFilter Method modifier filter (static or not)
      */
-    public function __construct($methodName, PointFilter $modifierFilter = null)
+    public function __construct(string $methodName, PointFilter $modifierFilter)
     {
         $this->methodName     = $methodName;
         $this->regexp         = strtr(preg_quote($this->methodName, '/'), [
@@ -71,7 +71,7 @@ class MagicMethodPointcut implements PointFilter, Pointcut
      *
      * @return bool
      */
-    public function matches($point, $context = null, $instance = null, array $arguments = null)
+    public function matches($point, $context = null, $instance = null, array $arguments = null) : bool
     {
         // With single parameter (statically) always matches for __call, __callStatic
         if (!$instance) {
@@ -90,10 +90,8 @@ class MagicMethodPointcut implements PointFilter, Pointcut
 
     /**
      * Returns the kind of point filter
-     *
-     * @return integer
      */
-    public function getKind()
+    public function getKind() : int
     {
         return PointFilter::KIND_METHOD | PointFilter::KIND_DYNAMIC;
     }

--- a/src/Aop/Pointcut/MatchInheritedPointcut.php
+++ b/src/Aop/Pointcut/MatchInheritedPointcut.php
@@ -31,7 +31,7 @@ class MatchInheritedPointcut implements Pointcut
      *
      * @return bool
      */
-    public function matches($point, $context = null, $instance = null, array $arguments = null)
+    public function matches($point, $context = null, $instance = null, array $arguments = null) : bool
     {
         if (!$context instanceof \ReflectionClass) {
             return false;
@@ -48,10 +48,8 @@ class MatchInheritedPointcut implements Pointcut
 
     /**
      * Returns the kind of point filter
-     *
-     * @return integer
      */
-    public function getKind()
+    public function getKind() : int
     {
         return PointFilter::KIND_METHOD | PointFilter::KIND_PROPERTY;
     }

--- a/src/Aop/Pointcut/MatchInheritedPointcut.php
+++ b/src/Aop/Pointcut/MatchInheritedPointcut.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 /*
  * Go! AOP framework
  *

--- a/src/Aop/Pointcut/NotPointcut.php
+++ b/src/Aop/Pointcut/NotPointcut.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 /*
  * Go! AOP framework
  *

--- a/src/Aop/Pointcut/NotPointcut.php
+++ b/src/Aop/Pointcut/NotPointcut.php
@@ -53,7 +53,7 @@ class NotPointcut implements Pointcut
      *
      * @return bool
      */
-    public function matches($point, $context = null, $instance = null, array $arguments = null)
+    public function matches($point, $context = null, $instance = null, array $arguments = null) : bool
     {
         $isMatchesPre = $this->pointcut->getClassFilter()->matches($context);
         if (!$isMatchesPre) {
@@ -69,10 +69,8 @@ class NotPointcut implements Pointcut
 
     /**
      * Returns the kind of point filter
-     *
-     * @return integer
      */
-    public function getKind()
+    public function getKind() : int
     {
         return $this->kind;
     }

--- a/src/Aop/Pointcut/OrPointcut.php
+++ b/src/Aop/Pointcut/OrPointcut.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 /*
  * Go! AOP framework
  *

--- a/src/Aop/Pointcut/OrPointcut.php
+++ b/src/Aop/Pointcut/OrPointcut.php
@@ -46,7 +46,7 @@ class OrPointcut extends AndPointcut
      *
      * @return bool
      */
-    public function matches($point, $context = null, $instance = null, array $arguments = null)
+    public function matches($point, $context = null, $instance = null, array $arguments = null) : bool
     {
         return $this->matchPart($this->first, $point, $context, $instance, $arguments)
             || $this->matchPart($this->second, $point, $context, $instance, $arguments);

--- a/src/Aop/Pointcut/PointcutClassFilterTrait.php
+++ b/src/Aop/Pointcut/PointcutClassFilterTrait.php
@@ -41,8 +41,6 @@ trait PointcutClassFilterTrait
 
     /**
      * Return the class filter for this pointcut.
-     *
-     * @return PointFilter
      */
     public function getClassFilter() : PointFilter
     {

--- a/src/Aop/Pointcut/PointcutClassFilterTrait.php
+++ b/src/Aop/Pointcut/PointcutClassFilterTrait.php
@@ -44,7 +44,7 @@ trait PointcutClassFilterTrait
      *
      * @return PointFilter
      */
-    public function getClassFilter()
+    public function getClassFilter() : PointFilter
     {
         if (!$this->classFilter) {
             $this->classFilter = TruePointFilter::getInstance();

--- a/src/Aop/Pointcut/PointcutClassFilterTrait.php
+++ b/src/Aop/Pointcut/PointcutClassFilterTrait.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 /*
  * Go! AOP framework
  *

--- a/src/Aop/Pointcut/PointcutGrammar.php
+++ b/src/Aop/Pointcut/PointcutGrammar.php
@@ -11,6 +11,7 @@ declare(strict_types = 1);
 
 namespace Go\Aop\Pointcut;
 
+use Closure;
 use Dissect\Lexer\Token;
 use Dissect\Parser\Grammar;
 use Doctrine\Common\Annotations\Reader;
@@ -312,14 +313,12 @@ class PointcutGrammar extends Grammar
 
     /**
      * Returns callable for converting node(s) to the string
-     *
-     * @return \Closure
      */
-    private function getNodeToStringConverter()
+    private function getNodeToStringConverter() : Closure
     {
-        return function() {
+        return function(...$arguments) {
             $value = '';
-            foreach (func_get_args() as $node) {
+            foreach ($arguments as $node) {
                 if (is_scalar($node)) {
                     $value .= $node;
                 } else {
@@ -333,10 +332,8 @@ class PointcutGrammar extends Grammar
 
     /**
      * Returns callable for converting node value for modifiers to the constant value
-     *
-     * @return \Closure
      */
-    private function getModifierConverter()
+    private function getModifierConverter() : Closure
     {
         return function(Token $token) {
             $name = strtoupper($token->getValue());

--- a/src/Aop/Pointcut/PointcutGrammar.php
+++ b/src/Aop/Pointcut/PointcutGrammar.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 /*
  * Go! AOP framework
  *

--- a/src/Aop/Pointcut/PointcutLexer.php
+++ b/src/Aop/Pointcut/PointcutLexer.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 /*
  * Go! AOP framework
  *

--- a/src/Aop/Pointcut/PointcutParseTable.php
+++ b/src/Aop/Pointcut/PointcutParseTable.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 /*
  * Go! AOP framework
  *

--- a/src/Aop/Pointcut/PointcutParser.php
+++ b/src/Aop/Pointcut/PointcutParser.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 /*
  * Go! AOP framework
  *

--- a/src/Aop/Pointcut/PointcutReference.php
+++ b/src/Aop/Pointcut/PointcutReference.php
@@ -82,7 +82,7 @@ class PointcutReference implements Pointcut
      *
      * @return PointFilter
      */
-    public function getClassFilter()
+    public function getClassFilter() : PointFilter
     {
         return $this->getPointcut()->getClassFilter();
     }

--- a/src/Aop/Pointcut/PointcutReference.php
+++ b/src/Aop/Pointcut/PointcutReference.php
@@ -106,7 +106,7 @@ class PointcutReference implements Pointcut
      */
     public function __sleep()
     {
-        return array('pointcutName');
+        return ['pointcutName'];
     }
 
     /**

--- a/src/Aop/Pointcut/PointcutReference.php
+++ b/src/Aop/Pointcut/PointcutReference.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 /*
  * Go! AOP framework
  *

--- a/src/Aop/Pointcut/PointcutReference.php
+++ b/src/Aop/Pointcut/PointcutReference.php
@@ -46,7 +46,7 @@ class PointcutReference implements Pointcut
      * @param AspectContainer $container Instance of container
      * @param string $pointcutName Referenced pointcut
      */
-    public function __construct(AspectContainer $container, $pointcutName)
+    public function __construct(AspectContainer $container, string $pointcutName)
     {
         $this->container    = $container;
         $this->pointcutName = $pointcutName;
@@ -62,17 +62,15 @@ class PointcutReference implements Pointcut
      *
      * @return bool
      */
-    public function matches($point, $context = null, $instance = null, array $arguments = null)
+    public function matches($point, $context = null, $instance = null, array $arguments = null) : bool
     {
         return $this->getPointcut()->matches($point, $context, $instance, $arguments);
     }
 
     /**
      * Returns the kind of point filter
-     *
-     * @return integer
      */
-    public function getKind()
+    public function getKind() : int
     {
         return $this->getPointcut()->getKind();
     }
@@ -83,20 +81,6 @@ class PointcutReference implements Pointcut
     public function getClassFilter() : PointFilter
     {
         return $this->getPointcut()->getClassFilter();
-    }
-
-    /**
-     * Returns a real pointcut from the container
-     *
-     * @return Pointcut
-     */
-    public function getPointcut()
-    {
-        if (!$this->pointcut) {
-            $this->pointcut = $this->container->getPointcut($this->pointcutName);
-        }
-
-        return $this->pointcut;
     }
 
     /**
@@ -113,5 +97,17 @@ class PointcutReference implements Pointcut
     public function __wakeup()
     {
         $this->container = AspectKernel::getInstance()->getContainer();
+    }
+
+    /**
+     * Returns a real pointcut from the container
+     */
+    private function getPointcut() : Pointcut
+    {
+        if (!$this->pointcut) {
+            $this->pointcut = $this->container->getPointcut($this->pointcutName);
+        }
+
+        return $this->pointcut;
     }
 }

--- a/src/Aop/Pointcut/PointcutReference.php
+++ b/src/Aop/Pointcut/PointcutReference.php
@@ -79,8 +79,6 @@ class PointcutReference implements Pointcut
 
     /**
      * Return the class filter for this pointcut.
-     *
-     * @return PointFilter
      */
     public function getClassFilter() : PointFilter
     {

--- a/src/Aop/Pointcut/SignaturePointcut.php
+++ b/src/Aop/Pointcut/SignaturePointcut.php
@@ -56,7 +56,7 @@ class SignaturePointcut implements Pointcut
      * @param string $name Name of the entity to match or glob pattern
      * @param PointFilter $modifierFilter Method modifier filter
      */
-    public function __construct($filterKind, $name, PointFilter $modifierFilter)
+    public function __construct(int $filterKind, string $name, PointFilter $modifierFilter)
     {
         $this->filterKind = $filterKind;
         $this->name       = $name;
@@ -79,7 +79,7 @@ class SignaturePointcut implements Pointcut
      *
      * @return bool
      */
-    public function matches($point, $context = null, $instance = null, array $arguments = null)
+    public function matches($point, $context = null, $instance = null, array $arguments = null) : bool
     {
         if (!$this->modifierFilter->matches($point, $context)) {
             return false;
@@ -90,10 +90,8 @@ class SignaturePointcut implements Pointcut
 
     /**
      * Returns the kind of point filter
-     *
-     * @return integer
      */
-    public function getKind()
+    public function getKind() : int
     {
         return $this->filterKind;
     }

--- a/src/Aop/Pointcut/SignaturePointcut.php
+++ b/src/Aop/Pointcut/SignaturePointcut.php
@@ -60,12 +60,12 @@ class SignaturePointcut implements Pointcut
     {
         $this->filterKind = $filterKind;
         $this->name       = $name;
-        $this->regexp     = strtr(preg_quote($this->name, '/'), array(
+        $this->regexp     = strtr(preg_quote($this->name, '/'), [
             '\\*'    => '[^\\\\]+?',
             '\\*\\*' => '.+?',
             '\\?'    => '.',
             '\\|'    => '|'
-        ));
+        ]);
         $this->modifierFilter = $modifierFilter;
     }
 

--- a/src/Aop/Pointcut/SignaturePointcut.php
+++ b/src/Aop/Pointcut/SignaturePointcut.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 /*
  * Go! AOP framework
  *

--- a/src/Aop/Pointcut/TruePointcut.php
+++ b/src/Aop/Pointcut/TruePointcut.php
@@ -25,14 +25,14 @@ class TruePointcut implements Pointcut
      *
      * @var int
      */
-    protected $filterKind = 0;
+    protected $filterKind;
 
     /**
      * Default constructor can be used to specify concrete filter kind
      *
      * @param int $filterKind Kind of filter, e.g. KIND_METHOD
      */
-    public function __construct($filterKind = self::KIND_ALL)
+    public function __construct(int $filterKind = self::KIND_ALL)
     {
         $this->filterKind = $filterKind;
     }
@@ -47,17 +47,15 @@ class TruePointcut implements Pointcut
      *
      * @return bool
      */
-    public function matches($point, $context = null, $instance = null, array $arguments = null)
+    public function matches($point, $context = null, $instance = null, array $arguments = null) : bool
     {
         return true;
     }
 
     /**
      * Returns the kind of point filter
-     *
-     * @return integer
      */
-    public function getKind()
+    public function getKind() : int
     {
         return $this->filterKind;
     }

--- a/src/Aop/Pointcut/TruePointcut.php
+++ b/src/Aop/Pointcut/TruePointcut.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 /*
  * Go! AOP framework
  *

--- a/src/Aop/PointcutAdvisor.php
+++ b/src/Aop/PointcutAdvisor.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 /*
  * Go! AOP framework
  *

--- a/src/Aop/PointcutAdvisor.php
+++ b/src/Aop/PointcutAdvisor.php
@@ -20,8 +20,6 @@ interface PointcutAdvisor extends Advisor
 {
     /**
      * Get the Pointcut that drives this advisor.
-     *
-     * @return Pointcut The pointcut
      */
-    public function getPointcut();
+    public function getPointcut() : Pointcut;
 }

--- a/src/Aop/Proxy.php
+++ b/src/Aop/Proxy.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 /*
  * Go! AOP framework
  *

--- a/src/Aop/Support/AbstractGenericAdvisor.php
+++ b/src/Aop/Support/AbstractGenericAdvisor.php
@@ -12,12 +12,12 @@ declare(strict_types = 1);
 namespace Go\Aop\Support;
 
 use Go\Aop\Advice;
-use Go\Aop\PointcutAdvisor;
+use Go\Aop\Advisor;
 
 /**
  * Abstract generic PointcutAdvisor that allows for any Advice to be configured.
  */
-abstract class AbstractGenericPointcutAdvisor implements PointcutAdvisor
+abstract class AbstractGenericAdvisor implements Advisor
 {
     /**
      * Instance of advice

--- a/src/Aop/Support/AbstractGenericPointcutAdvisor.php
+++ b/src/Aop/Support/AbstractGenericPointcutAdvisor.php
@@ -38,8 +38,6 @@ abstract class AbstractGenericPointcutAdvisor implements PointcutAdvisor
 
     /**
      * Returns an advice to apply
-     *
-     * @return Advice
      */
     public function getAdvice() : Advice
     {

--- a/src/Aop/Support/AbstractGenericPointcutAdvisor.php
+++ b/src/Aop/Support/AbstractGenericPointcutAdvisor.php
@@ -39,9 +39,9 @@ abstract class AbstractGenericPointcutAdvisor implements PointcutAdvisor
     /**
      * Returns an advice to apply
      *
-     * @return Advice|null
+     * @return Advice
      */
-    public function getAdvice()
+    public function getAdvice() : Advice
     {
         return $this->advice;
     }

--- a/src/Aop/Support/AbstractGenericPointcutAdvisor.php
+++ b/src/Aop/Support/AbstractGenericPointcutAdvisor.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 /*
  * Go! AOP framework
  *

--- a/src/Aop/Support/AbstractGenericPointcutAdvisor.php
+++ b/src/Aop/Support/AbstractGenericPointcutAdvisor.php
@@ -43,16 +43,4 @@ abstract class AbstractGenericPointcutAdvisor implements PointcutAdvisor
     {
         return $this->advice;
     }
-
-    /**
-     * Return string representation of object
-     *
-     * @return string
-     */
-    public function __toString()
-    {
-        $adviceClass = get_class($this->getAdvice());
-
-        return get_called_class() . ": advice [{$adviceClass}]";
-    }
 }

--- a/src/Aop/Support/AndPointFilter.php
+++ b/src/Aop/Support/AndPointFilter.php
@@ -24,21 +24,21 @@ class AndPointFilter implements PointFilter
      *
      * @var int
      */
-    private $kind = 0;
+    private $kind;
 
     /**
      * First part of filter
      *
-     * @var PointFilter|null
+     * @var PointFilter
      */
-    private $first = null;
+    private $first;
 
     /**
      * Second part of filter
      *
-     * @var PointFilter|null
+     * @var PointFilter
      */
-    private $second = null;
+    private $second;
 
     /**
      * And constructor
@@ -63,17 +63,15 @@ class AndPointFilter implements PointFilter
      *
      * @return bool
      */
-    public function matches($point, $context = null, $instance = null, array $arguments = null)
+    public function matches($point, $context = null, $instance = null, array $arguments = null) : bool
     {
         return $this->first->matches($point, $context) && $this->second->matches($point, $context);
     }
 
     /**
      * Returns the kind of point filter
-     *
-     * @return integer
      */
-    public function getKind()
+    public function getKind() : int
     {
         return $this->kind;
     }

--- a/src/Aop/Support/AndPointFilter.php
+++ b/src/Aop/Support/AndPointFilter.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 /*
  * Go! AOP framework
  *

--- a/src/Aop/Support/AnnotatedReflectionMethod.php
+++ b/src/Aop/Support/AnnotatedReflectionMethod.php
@@ -74,7 +74,7 @@ class AnnotatedReflectionMethod extends ReflectionMethod
         $className  = $this->getDeclaringClass()->name;
         $methodName = $this->name;
         $closure = function (...$args) use ($methodName, $className) {
-            $result = forward_static_call_array(array($className, $methodName), $args);
+            $result = forward_static_call_array([$className, $methodName], $args);
 
             return $result;
         };

--- a/src/Aop/Support/AnnotatedReflectionMethod.php
+++ b/src/Aop/Support/AnnotatedReflectionMethod.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 /*
  * Go! AOP framework
  *

--- a/src/Aop/Support/AnnotatedReflectionMethod.php
+++ b/src/Aop/Support/AnnotatedReflectionMethod.php
@@ -33,27 +33,23 @@ class AnnotatedReflectionMethod extends ReflectionMethod
      * @param string $annotationName The name of the annotation.
      * @return mixed The Annotation or NULL, if the requested annotation does not exist.
      */
-    public function getAnnotation($annotationName)
+    public function getAnnotation(string $annotationName)
     {
         return self::getReader()->getMethodAnnotation($this, $annotationName);
     }
 
     /**
      * Gets the annotations applied to a method.
-     *
-     * @return array An array of Annotations.
      */
-    public function getAnnotations()
+    public function getAnnotations() : array
     {
         return self::getReader()->getMethodAnnotations($this);
     }
 
     /**
      * Returns an annotation reader
-     *
-     * @return Reader $reader
      */
-    private static function getReader()
+    private static function getReader() : Reader
     {
         if (!self::$annotationReader) {
             self::$annotationReader = AspectKernel::getInstance()->getContainer()->get('aspect.annotation.reader');

--- a/src/Aop/Support/DeclareParentsAdvisor.php
+++ b/src/Aop/Support/DeclareParentsAdvisor.php
@@ -104,17 +104,4 @@ class DeclareParentsAdvisor implements IntroductionAdvisor
     {
         $this->classFilter = $classFilter;
     }
-
-    /**
-     * Return string representation of object
-     *
-     * @return string
-     */
-    public function __toString()
-    {
-        $adviceClass      = get_class($this->advice);
-        $interfaceClasses = join(',', $this->advice->getInterfaces());
-
-        return get_called_class() . ": advice [{$adviceClass}]; interfaces [{$interfaceClasses}] ";
-    }
 }

--- a/src/Aop/Support/DeclareParentsAdvisor.php
+++ b/src/Aop/Support/DeclareParentsAdvisor.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 /*
  * Go! AOP framework
  *

--- a/src/Aop/Support/DeclareParentsAdvisor.php
+++ b/src/Aop/Support/DeclareParentsAdvisor.php
@@ -14,6 +14,7 @@ namespace Go\Aop\Support;
 use Go\Aop\Advice;
 use Go\Aop\IntroductionAdvisor;
 use Go\Aop\IntroductionInfo;
+use Go\Aop\Pointcut\PointcutClassFilterTrait;
 use Go\Aop\PointFilter;
 use ReflectionClass;
 
@@ -22,6 +23,7 @@ use ReflectionClass;
  */
 class DeclareParentsAdvisor implements IntroductionAdvisor
 {
+    use PointcutClassFilterTrait;
 
     /**
      * Introduction information
@@ -29,13 +31,6 @@ class DeclareParentsAdvisor implements IntroductionAdvisor
      * @var IntroductionInfo
      */
     private $advice = null;
-
-    /**
-     * Type pattern the introduction is restricted to
-     *
-     * @var PointFilter
-     */
-    private $classFilter;
 
     /**
      * Creates an advisor for declaring mixins via traits and interfaces.
@@ -83,25 +78,5 @@ class DeclareParentsAdvisor implements IntroductionAdvisor
     public function getAdvice() : Advice
     {
         return $this->advice;
-    }
-
-    /**
-     * Return the filter determining which target classes this introduction should apply to.
-     *
-     * This represents the class part of a pointcut. Note that method matching doesn't make sense to introductions.
-     */
-    public function getClassFilter() : PointFilter
-    {
-        return $this->classFilter;
-    }
-
-    /**
-     * Set the class filter for advisor
-     *
-     * @param PointFilter $classFilter Filter for classes
-     */
-    public function setClassFilter(PointFilter $classFilter)
-    {
-        $this->classFilter = $classFilter;
     }
 }

--- a/src/Aop/Support/DeclareParentsAdvisor.php
+++ b/src/Aop/Support/DeclareParentsAdvisor.php
@@ -11,12 +11,11 @@ declare(strict_types = 1);
 
 namespace Go\Aop\Support;
 
-use InvalidArgumentException;
-use ReflectionClass;
 use Go\Aop\Advice;
-use Go\Aop\PointFilter;
-use Go\Aop\IntroductionInfo;
 use Go\Aop\IntroductionAdvisor;
+use Go\Aop\IntroductionInfo;
+use Go\Aop\PointFilter;
+use ReflectionClass;
 
 /**
  * Introduction advisor delegating to the given object.
@@ -25,7 +24,9 @@ class DeclareParentsAdvisor implements IntroductionAdvisor
 {
 
     /**
-     * @var null|IntroductionInfo
+     * Introduction information
+     *
+     * @var IntroductionInfo
      */
     private $advice = null;
 
@@ -37,7 +38,10 @@ class DeclareParentsAdvisor implements IntroductionAdvisor
     private $classFilter;
 
     /**
-     * Create a DefaultIntroductionAdvisor for the given advice.
+     * Creates an advisor for declaring mixins via traits and interfaces.
+     *
+     * @param PointFilter $classFilter Class filter
+     * @param IntroductionInfo $info Introduction information
      */
     public function __construct(PointFilter $classFilter, IntroductionInfo $info)
     {
@@ -74,9 +78,9 @@ class DeclareParentsAdvisor implements IntroductionAdvisor
     /**
      * Returns an advice to apply
      *
-     * @return Advice|IntroductionInfo|null
+     * @return Advice|IntroductionInfo
      */
-    public function getAdvice()
+    public function getAdvice() : Advice
     {
         return $this->advice;
     }

--- a/src/Aop/Support/DeclareParentsAdvisor.php
+++ b/src/Aop/Support/DeclareParentsAdvisor.php
@@ -92,7 +92,7 @@ class DeclareParentsAdvisor implements IntroductionAdvisor
      *
      * @return PointFilter The class filter
      */
-    public function getClassFilter()
+    public function getClassFilter() : PointFilter
     {
         return $this->classFilter;
     }

--- a/src/Aop/Support/DeclareParentsAdvisor.php
+++ b/src/Aop/Support/DeclareParentsAdvisor.php
@@ -89,8 +89,6 @@ class DeclareParentsAdvisor implements IntroductionAdvisor
      * Return the filter determining which target classes this introduction should apply to.
      *
      * This represents the class part of a pointcut. Note that method matching doesn't make sense to introductions.
-     *
-     * @return PointFilter The class filter
      */
     public function getClassFilter() : PointFilter
     {

--- a/src/Aop/Support/DeclareParentsAdvisor.php
+++ b/src/Aop/Support/DeclareParentsAdvisor.php
@@ -21,7 +21,7 @@ use ReflectionClass;
 /**
  * Introduction advisor delegating to the given object.
  */
-class DeclareParentsAdvisor implements IntroductionAdvisor
+class DeclareParentsAdvisor extends AbstractGenericAdvisor implements IntroductionAdvisor
 {
     use PointcutClassFilterTrait;
 
@@ -30,7 +30,7 @@ class DeclareParentsAdvisor implements IntroductionAdvisor
      *
      * @var IntroductionInfo
      */
-    private $advice = null;
+    protected $advice;
 
     /**
      * Creates an advisor for declaring mixins via traits and interfaces.
@@ -41,7 +41,7 @@ class DeclareParentsAdvisor implements IntroductionAdvisor
     public function __construct(PointFilter $classFilter, IntroductionInfo $info)
     {
         $this->classFilter = $classFilter;
-        $this->advice      = $info;
+        parent::__construct($info);
     }
 
     /**
@@ -68,15 +68,5 @@ class DeclareParentsAdvisor implements IntroductionAdvisor
                 throw new \DomainException("Implementation requires method {$interfaceMethod->name}");
             }
         }
-    }
-
-    /**
-     * Returns an advice to apply
-     *
-     * @return Advice|IntroductionInfo
-     */
-    public function getAdvice() : Advice
-    {
-        return $this->advice;
     }
 }

--- a/src/Aop/Support/DefaultPointcutAdvisor.php
+++ b/src/Aop/Support/DefaultPointcutAdvisor.php
@@ -78,17 +78,4 @@ class DefaultPointcutAdvisor extends AbstractGenericPointcutAdvisor
     {
         $this->pointcut = $pointcut;
     }
-
-    /**
-     * Return string representation of object
-     *
-     * @return string
-     */
-    public function __toString()
-    {
-        $pointcutClass = get_class($this->getPointcut());
-        $adviceClass   = get_class($this->getAdvice());
-
-        return get_called_class() . ": pointcut [{$pointcutClass}]; advice [{$adviceClass}]";
-    }
 }

--- a/src/Aop/Support/DefaultPointcutAdvisor.php
+++ b/src/Aop/Support/DefaultPointcutAdvisor.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 /*
  * Go! AOP framework
  *

--- a/src/Aop/Support/DefaultPointcutAdvisor.php
+++ b/src/Aop/Support/DefaultPointcutAdvisor.php
@@ -63,10 +63,8 @@ class DefaultPointcutAdvisor extends AbstractGenericPointcutAdvisor
 
     /**
      * Get the Pointcut that drives this advisor.
-     *
-     * @return Pointcut The pointcut
      */
-    public function getPointcut()
+    public function getPointcut() : Pointcut
     {
         return $this->pointcut;
     }

--- a/src/Aop/Support/DefaultPointcutAdvisor.php
+++ b/src/Aop/Support/DefaultPointcutAdvisor.php
@@ -14,6 +14,7 @@ namespace Go\Aop\Support;
 use Go\Aop\Advice;
 use Go\Aop\Framework\DynamicInvocationMatcherInterceptor;
 use Go\Aop\Pointcut;
+use Go\Aop\PointcutAdvisor;
 use Go\Aop\PointFilter;
 
 /**
@@ -22,7 +23,7 @@ use Go\Aop\PointFilter;
  * This is the most commonly used Advisor implementation. It can be used with any pointcut and advice type,
  * except for introductions. There is normally no need to subclass this class, or to implement custom Advisors.
  */
-class DefaultPointcutAdvisor extends AbstractGenericPointcutAdvisor
+class DefaultPointcutAdvisor extends AbstractGenericAdvisor implements PointcutAdvisor
 {
 
     /**
@@ -60,22 +61,11 @@ class DefaultPointcutAdvisor extends AbstractGenericPointcutAdvisor
         return $advice;
     }
 
-
     /**
      * Get the Pointcut that drives this advisor.
      */
     public function getPointcut() : Pointcut
     {
         return $this->pointcut;
-    }
-
-    /**
-     * Specify the pointcut targeting the advice.
-     *
-     * @param Pointcut $pointcut The Pointcut targeting the Advice
-     */
-    public function setPointcut(Pointcut $pointcut)
-    {
-        $this->pointcut = $pointcut;
     }
 }

--- a/src/Aop/Support/DefaultPointcutAdvisor.php
+++ b/src/Aop/Support/DefaultPointcutAdvisor.php
@@ -47,7 +47,7 @@ class DefaultPointcutAdvisor extends AbstractGenericPointcutAdvisor
     /**
      * {@inheritdoc}
      */
-    public function getAdvice()
+    public function getAdvice() : Advice
     {
         $advice = parent::getAdvice();
         if ($this->pointcut->getKind() & PointFilter::KIND_DYNAMIC) {

--- a/src/Aop/Support/InheritanceClassFilter.php
+++ b/src/Aop/Support/InheritanceClassFilter.php
@@ -25,14 +25,14 @@ class InheritanceClassFilter implements PointFilter
      *
      * @var string
      */
-    protected $parentClass = '';
+    protected $parentClass;
 
     /**
      * Inheritance class matcher constructor
      *
      * @param string $parentClassName Name of the parent class or interface to match
      */
-    public function __construct($parentClassName)
+    public function __construct(string $parentClassName)
     {
         $this->parentClass = $parentClassName;
     }
@@ -47,7 +47,7 @@ class InheritanceClassFilter implements PointFilter
      *
      * @return bool
      */
-    public function matches($class, $context = null, $instance = null, array $arguments = null)
+    public function matches($class, $context = null, $instance = null, array $arguments = null) : bool
     {
         if (!$class instanceof ReflectionClass) {
             return false;
@@ -58,10 +58,8 @@ class InheritanceClassFilter implements PointFilter
 
     /**
      * Returns the kind of point filter
-     *
-     * @return integer
      */
-    public function getKind()
+    public function getKind() : int
     {
         return self::KIND_CLASS;
     }

--- a/src/Aop/Support/InheritanceClassFilter.php
+++ b/src/Aop/Support/InheritanceClassFilter.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 /*
  * Go! AOP framework
  *

--- a/src/Aop/Support/LazyPointcutAdvisor.php
+++ b/src/Aop/Support/LazyPointcutAdvisor.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 /*
  * Go! AOP framework
  *

--- a/src/Aop/Support/LazyPointcutAdvisor.php
+++ b/src/Aop/Support/LazyPointcutAdvisor.php
@@ -47,7 +47,7 @@ class LazyPointcutAdvisor extends AbstractGenericPointcutAdvisor
      * @param string $pointcutExpression The Pointcut targeting the Advice
      * @param Advice $advice The Advice to run when Pointcut matches
      */
-    public function __construct(AspectContainer $container, $pointcutExpression, Advice $advice)
+    public function __construct(AspectContainer $container, string $pointcutExpression, Advice $advice)
     {
         $this->container          = $container;
         $this->pointcutExpression = $pointcutExpression;
@@ -56,15 +56,12 @@ class LazyPointcutAdvisor extends AbstractGenericPointcutAdvisor
 
     /**
      * Get the Pointcut that drives this advisor.
-     *
-     * @return Pointcut The pointcut
      */
-    public function getPointcut()
+    public function getPointcut() : Pointcut
     {
         if (!$this->pointcut) {
 
             // Inject this dependencies and make them lazy!
-            // should be extracted from AbstractAspectLoaderExtension into separate class
 
             /** @var Pointcut\PointcutLexer $lexer */
             $lexer = $this->container->get('aspect.pointcut.lexer');

--- a/src/Aop/Support/LazyPointcutAdvisor.php
+++ b/src/Aop/Support/LazyPointcutAdvisor.php
@@ -13,12 +13,13 @@ namespace Go\Aop\Support;
 
 use Go\Aop\Advice;
 use Go\Aop\Pointcut;
+use Go\Aop\PointcutAdvisor;
 use Go\Core\AspectContainer;
 
 /**
  * Lazy pointcut advisor is used to create a delayed pointcut only when needed
  */
-class LazyPointcutAdvisor extends AbstractGenericPointcutAdvisor
+class LazyPointcutAdvisor extends AbstractGenericAdvisor implements PointcutAdvisor
 {
 
     /**

--- a/src/Aop/Support/ModifierMatcherFilter.php
+++ b/src/Aop/Support/ModifierMatcherFilter.php
@@ -45,7 +45,7 @@ class ModifierMatcherFilter implements PointFilter
      *
      * @param int $initialMask Default mask for "and"
      */
-    public function __construct($initialMask = 0)
+    public function __construct(int $initialMask = 0)
     {
         $this->andMask = $initialMask;
     }
@@ -60,7 +60,7 @@ class ModifierMatcherFilter implements PointFilter
      *
      * @return bool
      */
-    public function matches($point, $context = null, $instance = null, array $arguments = null)
+    public function matches($point, $context = null, $instance = null, array $arguments = null) : bool
     {
         $modifiers = $point->getModifiers();
 
@@ -74,7 +74,7 @@ class ModifierMatcherFilter implements PointFilter
      * @param integer $bitMask
      * @return $this
      */
-    public function andMatch($bitMask)
+    public function andMatch(int $bitMask)
     {
         $this->andMask |= $bitMask;
 
@@ -87,7 +87,7 @@ class ModifierMatcherFilter implements PointFilter
      * @param integer $bitMask
      * @return $this
      */
-    public function orMatch($bitMask)
+    public function orMatch(int $bitMask)
     {
         $this->orMask |= $bitMask;
 
@@ -100,7 +100,7 @@ class ModifierMatcherFilter implements PointFilter
      * @param integer $bitMask
      * @return $this
      */
-    public function notMatch($bitMask)
+    public function notMatch(int $bitMask)
     {
         $this->notMask |= $bitMask;
 
@@ -109,10 +109,8 @@ class ModifierMatcherFilter implements PointFilter
 
     /**
      * Returns the kind of point filter
-     *
-     * @return integer
      */
-    public function getKind()
+    public function getKind() : int
     {
         return self::KIND_ALL;
     }
@@ -124,7 +122,7 @@ class ModifierMatcherFilter implements PointFilter
      *
      * @return ModifierMatcherFilter
      */
-    public function merge(ModifierMatcherFilter $filter)
+    public function merge(ModifierMatcherFilter $filter) : self
     {
         $newFilter = clone $this;
         $newFilter->andMask |= $filter->andMask;

--- a/src/Aop/Support/ModifierMatcherFilter.php
+++ b/src/Aop/Support/ModifierMatcherFilter.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 /*
  * Go! AOP framework
  *

--- a/src/Aop/Support/NamespacedReflectionFunction.php
+++ b/src/Aop/Support/NamespacedReflectionFunction.php
@@ -31,7 +31,7 @@ class NamespacedReflectionFunction extends ReflectionFunction
      * @param string $namespace Name of the namespace
      * {@inheritDoc}
      */
-    public function __construct($name, $namespace = '')
+    public function __construct($name, string $namespace = '')
     {
         $this->namespace = $namespace;
         parent::__construct($name);
@@ -42,7 +42,7 @@ class NamespacedReflectionFunction extends ReflectionFunction
      */
     public function getNamespaceName()
     {
-        if ($this->namespace) {
+        if (!empty($this->namespace)) {
             return $this->namespace;
         }
 

--- a/src/Aop/Support/NamespacedReflectionFunction.php
+++ b/src/Aop/Support/NamespacedReflectionFunction.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 /*
  * Go! AOP framework
  *

--- a/src/Aop/Support/NotPointFilter.php
+++ b/src/Aop/Support/NotPointFilter.php
@@ -23,14 +23,14 @@ class NotPointFilter implements PointFilter
      *
      * @var int
      */
-    private $kind = 0;
+    private $kind;
 
     /**
      * First part of filter
      *
      * @var PointFilter|null
      */
-    private $first = null;
+    private $first;
 
     /**
      * Not constructor
@@ -53,17 +53,15 @@ class NotPointFilter implements PointFilter
      *
      * @return bool
      */
-    public function matches($point, $context = null, $instance = null, array $arguments = null)
+    public function matches($point, $context = null, $instance = null, array $arguments = null) : bool
     {
         return !$this->first->matches($point, $context);
     }
 
     /**
      * Returns the kind of point filter
-     *
-     * @return integer
      */
-    public function getKind()
+    public function getKind() : int
     {
         return $this->kind;
     }

--- a/src/Aop/Support/NotPointFilter.php
+++ b/src/Aop/Support/NotPointFilter.php
@@ -28,7 +28,7 @@ class NotPointFilter implements PointFilter
     /**
      * First part of filter
      *
-     * @var PointFilter|null
+     * @var PointFilter
      */
     private $first;
 

--- a/src/Aop/Support/NotPointFilter.php
+++ b/src/Aop/Support/NotPointFilter.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 /*
  * Go! AOP framework
  *

--- a/src/Aop/Support/OrPointFilter.php
+++ b/src/Aop/Support/OrPointFilter.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 /*
  * Go! AOP framework
  *

--- a/src/Aop/Support/OrPointFilter.php
+++ b/src/Aop/Support/OrPointFilter.php
@@ -24,21 +24,21 @@ class OrPointFilter implements PointFilter
      *
      * @var int
      */
-    private $kind = 0;
+    private $kind;
 
     /**
      * First part of filter
      *
-     * @var PointFilter|null
+     * @var PointFilter
      */
-    private $first = null;
+    private $first;
 
     /**
      * Second part of filter
      *
-     * @var PointFilter|null
+     * @var PointFilter
      */
-    private $second = null;
+    private $second;
 
     /**
      * Or constructor
@@ -63,17 +63,15 @@ class OrPointFilter implements PointFilter
      *
      * @return bool
      */
-    public function matches($point, $context = null, $instance = null, array $arguments = null)
+    public function matches($point, $context = null, $instance = null, array $arguments = null) : bool
     {
         return $this->first->matches($point, $context) || $this->second->matches($point, $context);
     }
 
     /**
      * Returns the kind of point filter
-     *
-     * @return integer
      */
-    public function getKind()
+    public function getKind() : int
     {
         return $this->kind;
     }

--- a/src/Aop/Support/PointcutBuilder.php
+++ b/src/Aop/Support/PointcutBuilder.php
@@ -46,7 +46,7 @@ class PointcutBuilder
      * @param string $pointcutExpression Pointcut, e.g. "within(**)"
      * @param Closure $advice Advice to call
      */
-    public function before($pointcutExpression, Closure $advice)
+    public function before(string $pointcutExpression, Closure $advice)
     {
         $advice = new BeforeInterceptor($advice, 0, $pointcutExpression);
         $this->registerAdviceInContainer($pointcutExpression, $advice);
@@ -58,7 +58,7 @@ class PointcutBuilder
      * @param string $pointcutExpression Pointcut, e.g. "within(**)"
      * @param Closure $advice Advice to call
      */
-    public function after($pointcutExpression, Closure $advice)
+    public function after(string $pointcutExpression, Closure $advice)
     {
         $advice = new AfterInterceptor($advice, 0, $pointcutExpression);
         $this->registerAdviceInContainer($pointcutExpression, $advice);
@@ -70,7 +70,7 @@ class PointcutBuilder
      * @param string $pointcutExpression Pointcut, e.g. "within(**)"
      * @param Closure $advice Advice to call
      */
-    public function afterThrowing($pointcutExpression, Closure $advice)
+    public function afterThrowing(string $pointcutExpression, Closure $advice)
     {
         $advice = new AfterThrowingInterceptor($advice, 0, $pointcutExpression);
         $this->registerAdviceInContainer($pointcutExpression, $advice);
@@ -82,7 +82,7 @@ class PointcutBuilder
      * @param string $pointcutExpression Pointcut, e.g. "within(**)"
      * @param Closure $advice Advice to call
      */
-    public function around($pointcutExpression, Closure $advice)
+    public function around(string $pointcutExpression, Closure $advice)
     {
         $advice = new AroundInterceptor($advice, 0, $pointcutExpression);
         $this->registerAdviceInContainer($pointcutExpression, $advice);
@@ -95,7 +95,7 @@ class PointcutBuilder
      * @param string $message Error message to show
      * @param integer $level Error level to trigger
      */
-    public function declareError($pointcutExpression, $message, $level = E_USER_ERROR)
+    public function declareError(string $pointcutExpression, string $message, int $level = E_USER_ERROR)
     {
         $advice = new DeclareErrorInterceptor($message, $level, $pointcutExpression);
         $this->registerAdviceInContainer($pointcutExpression, $advice);
@@ -108,7 +108,7 @@ class PointcutBuilder
      * @param string $pointcutExpression Pointcut expression string
      * @param Advice $advice Instance of advice
      */
-    private function registerAdviceInContainer($pointcutExpression, Advice $advice)
+    private function registerAdviceInContainer(string $pointcutExpression, Advice $advice)
     {
         $this->container->registerAdvisor(
             new LazyPointcutAdvisor($this->container, $pointcutExpression, $advice),
@@ -123,7 +123,7 @@ class PointcutBuilder
      *
      * @return string
      */
-    private function getPointcutId($pointcutExpression)
+    private function getPointcutId(string $pointcutExpression) : string
     {
         static $index = 0;
 

--- a/src/Aop/Support/PointcutBuilder.php
+++ b/src/Aop/Support/PointcutBuilder.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 /*
  * Go! AOP framework
  *

--- a/src/Aop/Support/SimpleNamespaceFilter.php
+++ b/src/Aop/Support/SimpleNamespaceFilter.php
@@ -27,7 +27,7 @@ class SimpleNamespaceFilter implements PointFilter
      *
      * @var string
      */
-    protected $nsName = '';
+    protected $nsName;
 
     /**
      * Pattern for regular expression matching
@@ -41,7 +41,7 @@ class SimpleNamespaceFilter implements PointFilter
      *
      * @param string $namespaceName Name of the namespace to match or glob pattern
      */
-    public function __construct($namespaceName)
+    public function __construct(string $namespaceName)
     {
         $namespaceName = trim($namespaceName, '\\');
         $this->nsName  = $namespaceName;
@@ -57,7 +57,7 @@ class SimpleNamespaceFilter implements PointFilter
      * {@inheritdoc}
      * @param ReflectionFileNamespace|string $ns
      */
-    public function matches($ns, $context = null, $instance = null, array $arguments = null)
+    public function matches($ns, $context = null, $instance = null, array $arguments = null) : bool
     {
         $isNamespaceIsObject = ($ns === (object) $ns);
 
@@ -72,10 +72,8 @@ class SimpleNamespaceFilter implements PointFilter
 
     /**
      * Returns the kind of point filter
-     *
-     * @return integer
      */
-    public function getKind()
+    public function getKind() : int
     {
         return 0;
     }

--- a/src/Aop/Support/SimpleNamespaceFilter.php
+++ b/src/Aop/Support/SimpleNamespaceFilter.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 /*
  * Go! AOP framework
  *

--- a/src/Aop/Support/SimpleNamespaceFilter.php
+++ b/src/Aop/Support/SimpleNamespaceFilter.php
@@ -45,12 +45,12 @@ class SimpleNamespaceFilter implements PointFilter
     {
         $namespaceName = trim($namespaceName, '\\');
         $this->nsName  = $namespaceName;
-        $this->regexp  = strtr(preg_quote($this->nsName, '/'), array(
+        $this->regexp  = strtr(preg_quote($this->nsName, '/'), [
             '\\*'    => '[^\\\\]+',
             '\\*\\*' => '.+',
             '\\?'    => '.',
             '\\|'    => '|'
-        ));
+        ]);
     }
 
     /**

--- a/src/Aop/Support/TruePointFilter.php
+++ b/src/Aop/Support/TruePointFilter.php
@@ -28,10 +28,8 @@ class TruePointFilter implements PointFilter
 
     /**
      * Singleton pattern
-     *
-     * @return self
      */
-    public static function getInstance()
+    public static function getInstance() : self
     {
         static $instance = null;
         if (!$instance) {

--- a/src/Aop/Support/TruePointFilter.php
+++ b/src/Aop/Support/TruePointFilter.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 /*
  * Go! AOP framework
  *

--- a/src/Aop/Support/TruePointFilter.php
+++ b/src/Aop/Support/TruePointFilter.php
@@ -51,17 +51,15 @@ class TruePointFilter implements PointFilter
      *
      * @return bool
      */
-    public function matches($point, $context = null, $instance = null, array $arguments = null)
+    public function matches($point, $context = null, $instance = null, array $arguments = null) : bool
     {
         return true;
     }
 
     /**
      * Returns the kind of point filter
-     *
-     * @return integer
      */
-    public function getKind()
+    public function getKind() : int
     {
         return self::KIND_ALL;
     }

--- a/src/Bridge/Doctrine/MetadataLoadInterceptor.php
+++ b/src/Bridge/Doctrine/MetadataLoadInterceptor.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 /*
  * Go! AOP framework
  *

--- a/src/Console/Command/BaseAspectCommand.php
+++ b/src/Console/Command/BaseAspectCommand.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 /*
  * Go! AOP framework
  *

--- a/src/Console/Command/CacheWarmupCommand.php
+++ b/src/Console/Command/CacheWarmupCommand.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 /*
  * Go! AOP framework
  *

--- a/src/Console/Command/DebugAdvisorCommand.php
+++ b/src/Console/Command/DebugAdvisorCommand.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 /*
  * Go! AOP framework
  *

--- a/src/Console/Command/DebugAdvisorCommand.php
+++ b/src/Console/Command/DebugAdvisorCommand.php
@@ -79,7 +79,7 @@ EOT
             $expression = '';
             try {
                 $pointcutExpression = new \ReflectionProperty($advice, 'pointcutExpression');
-                $pointcutExpression->setAccessible('true');
+                $pointcutExpression->setAccessible(true);
                 $expression = $pointcutExpression->getValue($advice);
             } catch (\ReflectionException $e) {
                 // nothing here, just ignore
@@ -117,7 +117,7 @@ EOT
             $reflectionNamespaces = $reflectionFile->getFileNamespaces();
             foreach ($reflectionNamespaces as $reflectionNamespace) {
                 foreach ($reflectionNamespace->getClasses() as $reflectionClass) {
-                    $advices = $adviceMatcher->getAdvicesForClass($reflectionClass, [$advisor]);
+                    $advices = $adviceMatcher->getAdvicesForClass($reflectionClass, [$advisorId => $advisor]);
                     if (!empty($advices)) {
                         $this->writeInfoAboutAdvices($io, $reflectionClass, $advices);
                     }

--- a/src/Console/Command/DebugAdvisorCommand.php
+++ b/src/Console/Command/DebugAdvisorCommand.php
@@ -117,7 +117,7 @@ EOT
             $reflectionNamespaces = $reflectionFile->getFileNamespaces();
             foreach ($reflectionNamespaces as $reflectionNamespace) {
                 foreach ($reflectionNamespace->getClasses() as $reflectionClass) {
-                    $advices = $adviceMatcher->getAdvicesForClass($reflectionClass, array($advisor));
+                    $advices = $adviceMatcher->getAdvicesForClass($reflectionClass, [$advisor]);
                     if (!empty($advices)) {
                         $this->writeInfoAboutAdvices($io, $reflectionClass, $advices);
                     }

--- a/src/Console/Command/DebugAspectCommand.php
+++ b/src/Console/Command/DebugAspectCommand.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 /*
  * Go! AOP framework
  *

--- a/src/Core/AbstractAspectLoaderExtension.php
+++ b/src/Core/AbstractAspectLoaderExtension.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 /*
  * Go! AOP framework
  *

--- a/src/Core/AbstractAspectLoaderExtension.php
+++ b/src/Core/AbstractAspectLoaderExtension.php
@@ -32,16 +32,16 @@ abstract class AbstractAspectLoaderExtension implements AspectLoaderExtension
     /**
      * Instance of pointcut lexer
      *
-     * @var null|Lexer
+     * @var Lexer
      */
-    protected $pointcutLexer = null;
+    protected $pointcutLexer;
 
     /**
      * Instance of pointcut parser
      *
-     * @var null|Parser
+     * @var Parser
      */
-    protected $pointcutParser = null;
+    protected $pointcutParser;
 
     /**
      * Default initialization of dependencies
@@ -65,7 +65,7 @@ abstract class AbstractAspectLoaderExtension implements AspectLoaderExtension
      * @throws \UnexpectedValueException if there was an error during parsing
      * @return Pointcut|PointFilter
      */
-    protected function parsePointcut(Aspect $aspect, $reflection, $metaInformation)
+    protected function parsePointcut(Aspect $aspect, $reflection, $metaInformation) : PointFilter
     {
         $stream = $this->makeLexicalAnalyze($aspect, $reflection, $metaInformation);
 
@@ -82,7 +82,7 @@ abstract class AbstractAspectLoaderExtension implements AspectLoaderExtension
      * @return TokenStream
      * @throws \UnexpectedValueException
      */
-    protected function makeLexicalAnalyze(Aspect $aspect, $reflection, $metaInformation)
+    protected function makeLexicalAnalyze(Aspect $aspect, $reflection, $metaInformation) : TokenStream
     {
         try {
             $resolvedThisPointcut = str_replace('$this', get_class($aspect), $metaInformation->value);
@@ -112,11 +112,11 @@ abstract class AbstractAspectLoaderExtension implements AspectLoaderExtension
      * @param ReflectionMethod|ReflectionProperty $reflection
      * @param Annotation\BaseAnnotation $metaInformation
      * @param TokenStream $stream
-     * @return Pointcut
+     * @return Pointcut|PointFilter
      *
      * @throws \UnexpectedValueException
      */
-    protected function parseTokenStream($reflection, $metaInformation, $stream)
+    protected function parseTokenStream($reflection, $metaInformation, TokenStream $stream) : PointFilter
     {
         try {
             $pointcut = $this->pointcutParser->parse($stream);

--- a/src/Core/AdviceMatcher.php
+++ b/src/Core/AdviceMatcher.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 /*
  * Go! AOP framework
  *

--- a/src/Core/AdviceMatcher.php
+++ b/src/Core/AdviceMatcher.php
@@ -43,7 +43,7 @@ class AdviceMatcher
      * @param AspectLoader $loader Instance of aspect loader
      * @param bool $isInterceptFunctions Optional flag to enable function interception
      */
-    public function __construct(AspectLoader $loader, $isInterceptFunctions = false)
+    public function __construct(AspectLoader $loader, bool $isInterceptFunctions = false)
     {
         $this->loader = $loader;
 
@@ -58,9 +58,9 @@ class AdviceMatcher
      *
      * @return array
      */
-    public function getAdvicesForFunctions(ReflectionFileNamespace $namespace, array $advisors)
+    public function getAdvicesForFunctions(ReflectionFileNamespace $namespace, array $advisors) : array
     {
-        if (!$this->isInterceptFunctions || $namespace->getName() == 'no-namespace') {
+        if (!$this->isInterceptFunctions) {
             return [];
         }
 
@@ -92,7 +92,7 @@ class AdviceMatcher
      *
      * @return array|Aop\Advice[] List of advices for class
      */
-    public function getAdvicesForClass(ReflectionClass $class, array $advisors)
+    public function getAdvicesForClass(ReflectionClass $class, array $advisors) : array
     {
         $classAdvices = [];
         $parentClass  = $class->getParentClass();
@@ -142,8 +142,8 @@ class AdviceMatcher
     private function getAdvicesFromAdvisor(
         ReflectionClass $class,
         Aop\PointcutAdvisor $advisor,
-        $advisorId,
-        Aop\PointFilter $filter)
+        string $advisorId,
+        Aop\PointFilter $filter) : array
     {
         $classAdvices = [];
         $filterKind   = $filter->getKind();
@@ -199,7 +199,7 @@ class AdviceMatcher
     private function getIntroductionFromAdvisor(
         ReflectionClass $class,
         Aop\IntroductionAdvisor $advisor,
-        $advisorId)
+        string $advisorId) : array
     {
         $classAdvices = [];
         // Do not make introduction for traits
@@ -227,8 +227,8 @@ class AdviceMatcher
     private function getFunctionAdvicesFromAdvisor(
         ReflectionFileNamespace $namespace,
         Aop\PointcutAdvisor $advisor,
-        $advisorId,
-        Aop\PointFilter $pointcut)
+        string $advisorId,
+        Aop\PointFilter $pointcut) : array
     {
         $functions = [];
         $advices   = [];

--- a/src/Core/AspectContainer.php
+++ b/src/Core/AspectContainer.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 /*
  * Go! AOP framework
  *

--- a/src/Core/AspectContainer.php
+++ b/src/Core/AspectContainer.php
@@ -11,7 +11,9 @@ declare(strict_types = 1);
 
 namespace Go\Core;
 
-use Go\Aop;
+use Go\Aop\Advisor;
+use Go\Aop\Aspect;
+use Go\Aop\Pointcut;
 
 /**
  * Aspect container interface
@@ -59,77 +61,94 @@ interface AspectContainer
     const AOP_PROXIED_SUFFIX = '__AopProxied';
 
     /**
+     * Return a service or value from the container
+     *
+     * @param string $id Identifier
+     *
+     * @return mixed
+     * @throws \OutOfBoundsException if service was not found
+     */
+    public function get(string $id);
+
+    /**
      * Return list of service tagged with marker
      *
      * @param string $tag Tag to select
      * @return array
      */
-    public function getByTag($tag);
+    public function getByTag(string $tag) : array;
 
     /**
      * Returns a pointcut by identifier
      *
      * @param string $id Pointcut identifier
      *
-     * @return Aop\Pointcut
+     * @return Pointcut
      */
-    public function getPointcut($id);
+    public function getPointcut(string $id) : Pointcut;
+
+    /**
+     * Checks if item with specified id is present in the container
+     *
+     * @param string $id Identifier
+     *
+     * @return bool
+     */
+    public function has(string $id) : bool;
 
     /**
      * Store the pointcut in the container
      *
-     * @param Aop\Pointcut $pointcut Instance
+     * @param Pointcut $pointcut Instance
      * @param string $id Key for pointcut
      */
-    public function registerPointcut(Aop\Pointcut $pointcut, $id);
+    public function registerPointcut(Pointcut $pointcut, string $id);
 
     /**
      * Returns an advisor by identifier
      *
      * @param string $id Advisor identifier
      *
-     * @return Aop\Advisor
+     * @return Advisor
      */
-    public function getAdvisor($id);
+    public function getAdvisor(string $id) : Advisor;
 
     /**
      * Store the advisor in the container
      *
-     * @param Aop\Advisor $advisor Instance
+     * @param Advisor $advisor Instance
      * @param string $id Key for advisor
      */
-    public function registerAdvisor(Aop\Advisor $advisor, $id);
+    public function registerAdvisor(Advisor $advisor, string $id);
 
     /**
      * Register an aspect in the container
      *
-     * @param Aop\Aspect $aspect Instance of concrete aspect
+     * @param Aspect $aspect Instance of concrete aspect
      */
-    public function registerAspect(Aop\Aspect $aspect);
+    public function registerAspect(Aspect $aspect);
 
     /**
      * Returns an aspect by id or class name
      *
      * @param string $aspectName Aspect name
      *
-     * @return Aop\Aspect
+     * @return Aspect
      */
-    public function getAspect($aspectName);
+    public function getAspect(string $aspectName) : Aspect;
 
     /**
      * Add an AOP resource to the container
+     * Resources is used to check the freshness of AOP cache
      *
      * @param string $resource Path to the resource
-     * Resources is used to check the freshness of AOP cache
      */
-    public function addResource($resource);
+    public function addResource(string $resource);
 
     /**
      * Returns the list of AOP resources
-     *
-     * @return array
      */
-    public function getResources();
+    public function getResources() : array;
 
     /**
      * Checks the freshness of AOP cache
@@ -138,5 +157,14 @@ interface AspectContainer
      *
      * @return bool Whether or not concrete file is fresh
      */
-    public function isFresh($timestamp);
+    public function isFresh(int $timestamp) : bool;
+
+    /**
+     * Set a service into the container
+     *
+     * @param string $id Identifier
+     * @param mixed $value Value to store
+     * @param array $tags Additional tags
+     */
+    public function set(string $id, $value, array $tags = []);
 }

--- a/src/Core/AspectKernel.php
+++ b/src/Core/AspectKernel.php
@@ -38,9 +38,9 @@ abstract class AspectKernel
      *
      * @var array
      */
-    protected $options = array(
+    protected $options = [
         'features' => 0
-    );
+    ];
 
     /**
      * Single instance of kernel
@@ -176,7 +176,7 @@ abstract class AspectKernel
      */
     protected function getDefaultOptions()
     {
-        return array(
+        return [
             'debug'                  => false,
             'appDir'                 => __DIR__ . '/../../../../../',
             'cacheDir'               => null,
@@ -186,7 +186,7 @@ abstract class AspectKernel
             'includePaths'           => [],
             'excludePaths'           => [],
             'containerClass'         => static::$containerClass,
-        );
+        ];
     }
 
 
@@ -256,9 +256,9 @@ abstract class AspectKernel
             return $transformers;
         };
 
-        return array(
+        return [
             new CachingTransformer($this, $sourceTransformers, $cacheManager)
-        );
+        ];
     }
 
     /**

--- a/src/Core/AspectKernel.php
+++ b/src/Core/AspectKernel.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 /*
  * Go! AOP framework
  *

--- a/src/Core/AspectKernel.php
+++ b/src/Core/AspectKernel.php
@@ -45,9 +45,9 @@ abstract class AspectKernel
     /**
      * Single instance of kernel
      *
-     * @var null|static
+     * @var static
      */
-    protected static $instance = null;
+    protected static $instance;
 
     /**
      * Default class name for container, can be redefined in children
@@ -66,9 +66,9 @@ abstract class AspectKernel
     /**
      * Aspect container instance
      *
-     * @var null|AspectContainer
+     * @var AspectContainer
      */
-    protected $container = null;
+    protected $container;
 
     /**
      * Protected constructor is used to prevent direct creation, but allows customization if needed
@@ -77,10 +77,8 @@ abstract class AspectKernel
 
     /**
      * Returns the single instance of kernel
-     *
-     * @return static
      */
-    public static function getInstance()
+    public static function getInstance() : self
     {
         if (!self::$instance) {
             self::$instance = new static();
@@ -131,10 +129,8 @@ abstract class AspectKernel
 
     /**
      * Returns an aspect container
-     *
-     * @return null|AspectContainer
      */
-    public function getContainer()
+    public function getContainer() : AspectContainer
     {
         return $this->container;
     }
@@ -146,17 +142,15 @@ abstract class AspectKernel
      *
      * @return bool Whether specific feature enabled or not
      */
-    public function hasFeature($featureToCheck)
+    public function hasFeature(int $featureToCheck) : bool
     {
         return ($this->options['features'] & $featureToCheck) !== 0;
     }
 
     /**
      * Returns list of kernel options
-     *
-     * @return array
      */
-    public function getOptions()
+    public function getOptions() : array
     {
         return $this->options;
     }
@@ -171,21 +165,18 @@ abstract class AspectKernel
      *   features - integer Binary mask of features
      *   includePaths - array Whitelist of directories where aspects should be applied. Empty for everywhere.
      *   excludePaths - array Blacklist of directories or files where aspects shouldn't be applied.
-     *
-     * @return array
      */
-    protected function getDefaultOptions()
+    protected function getDefaultOptions() : array
     {
         return [
-            'debug'                  => false,
-            'appDir'                 => __DIR__ . '/../../../../../',
-            'cacheDir'               => null,
-            'cacheFileMode'          => 0770 & ~umask(), // Respect user umask() policy
-            'features'               => 0,
-
-            'includePaths'           => [],
-            'excludePaths'           => [],
-            'containerClass'         => static::$containerClass,
+            'debug'          => false,
+            'appDir'         => __DIR__ . '/../../../../../',
+            'cacheDir'       => null,
+            'cacheFileMode'  => 0770 & ~umask(), // Respect user umask() policy
+            'features'       => 0,
+            'includePaths'   => [],
+            'excludePaths'   => [],
+            'containerClass' => static::$containerClass,
         ];
     }
 
@@ -197,7 +188,7 @@ abstract class AspectKernel
      *
      * @return array
      */
-    protected function normalizeOptions(array $options)
+    protected function normalizeOptions(array $options) : array
     {
         $options = array_replace($this->getDefaultOptions(), $options);
         if ($options['cacheDir']) {

--- a/src/Core/AspectLoader.php
+++ b/src/Core/AspectLoader.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 /*
  * Go! AOP framework
  *

--- a/src/Core/AspectLoader.php
+++ b/src/Core/AspectLoader.php
@@ -72,7 +72,7 @@ class AspectLoader
      */
     public function registerLoaderExtension(AspectLoaderExtension $loader)
     {
-        $targets = (array) $loader->getTarget();
+        $targets = $loader->getTargets();
         foreach ($targets as $target) {
             $this->loaders[$target][] = $loader;
         }

--- a/src/Core/AspectLoader.php
+++ b/src/Core/AspectLoader.php
@@ -16,6 +16,7 @@ use Go\Aop\Advisor;
 use Go\Aop\Aspect;
 use Go\Aop\Pointcut;
 use ReflectionClass;
+use Reflector;
 
 /**
  * Loader of aspects into the container
@@ -26,9 +27,9 @@ class AspectLoader
     /**
      * Aspect container instance
      *
-     * @var null|AspectContainer
+     * @var AspectContainer
      */
-    protected $container = null;
+    protected $container;
 
     /**
      * List of aspect loaders
@@ -40,9 +41,9 @@ class AspectLoader
     /**
      * Annotation reader for aspects
      *
-     * @var Reader|null
+     * @var Reader
      */
-    protected $annotationReader = null;
+    protected $annotationReader;
 
     /**
      * List of aspects that was loaded
@@ -87,7 +88,7 @@ class AspectLoader
      *
      * @return array|Pointcut[]|Advisor[]
      */
-    public function load(Aspect $aspect)
+    public function load(Aspect $aspect) : array
     {
         $loadedItems = [];
         $refAspect   = new \ReflectionClass($aspect);
@@ -139,7 +140,7 @@ class AspectLoader
      *
      * @return array|Aspect[]
      */
-    public function getUnloadedAspects()
+    public function getUnloadedAspects() : array
     {
         $unloadedAspects = [];
 
@@ -156,14 +157,14 @@ class AspectLoader
      * Load definitions from specific aspect part into the aspect container
      *
      * @param Aspect $aspect Aspect instance
-     * @param \ReflectionClass|\ReflectionMethod|\ReflectionProperty $refPoint Reflection instance
+     * @param Reflector $reflector Reflection instance
      * @param array|AspectLoaderExtension[] $loaders List of loaders that can produce advisors from aspect class
      *
      * @throws \InvalidArgumentException If kind of loader isn't supported
      *
      * @return array|Pointcut[]|Advisor[]
      */
-    protected function loadFrom(Aspect $aspect, $refPoint, array $loaders)
+    protected function loadFrom(Aspect $aspect, Reflector $reflector, array $loaders) : array
     {
         $loadedItems = [];
 
@@ -173,16 +174,16 @@ class AspectLoader
             switch ($loaderKind) {
 
                 case AspectLoaderExtension::KIND_REFLECTION:
-                    if ($loader->supports($aspect, $refPoint)) {
-                        $loadedItems += $loader->load($aspect, $refPoint);
+                    if ($loader->supports($aspect, $reflector)) {
+                        $loadedItems += $loader->load($aspect, $reflector);
                     }
                     break;
 
                 case AspectLoaderExtension::KIND_ANNOTATION:
-                    $annotations = $this->getAnnotations($refPoint);
+                    $annotations = $this->getAnnotations($reflector);
                     foreach ($annotations as $annotation) {
-                        if ($loader->supports($aspect, $refPoint, $annotation)) {
-                            $loadedItems += $loader->load($aspect, $refPoint, $annotation);
+                        if ($loader->supports($aspect, $reflector, $annotation)) {
+                            $loadedItems += $loader->load($aspect, $reflector, $annotation);
                         }
                     }
                     break;
@@ -199,25 +200,25 @@ class AspectLoader
     /**
      * Return list of annotations for reflection point
      *
-     * @param \ReflectionClass|\ReflectionMethod|\ReflectionProperty $refPoint Reflection instance
+     * @param Reflector $reflector Reflection instance
      *
      * @return array list of annotations
      * @throws \InvalidArgumentException if $refPoint is unsupported
      */
-    protected function getAnnotations($refPoint)
+    protected function getAnnotations(Reflector $reflector) : array
     {
         switch (true) {
-            case ($refPoint instanceof \ReflectionClass):
-                return $this->annotationReader->getClassAnnotations($refPoint);
+            case ($reflector instanceof \ReflectionClass):
+                return $this->annotationReader->getClassAnnotations($reflector);
 
-            case ($refPoint instanceof \ReflectionMethod):
-                return $this->annotationReader->getMethodAnnotations($refPoint);
+            case ($reflector instanceof \ReflectionMethod):
+                return $this->annotationReader->getMethodAnnotations($reflector);
 
-            case ($refPoint instanceof \ReflectionProperty):
-                return $this->annotationReader->getPropertyAnnotations($refPoint);
+            case ($reflector instanceof \ReflectionProperty):
+                return $this->annotationReader->getPropertyAnnotations($reflector);
 
             default:
-                throw new \InvalidArgumentException("Unsupported reflection point " . get_class($refPoint));
+                throw new \InvalidArgumentException("Unsupported reflection point " . get_class($reflector));
         }
     }
 }

--- a/src/Core/AspectLoaderExtension.php
+++ b/src/Core/AspectLoaderExtension.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 /*
  * Go! AOP framework
  *

--- a/src/Core/AspectLoaderExtension.php
+++ b/src/Core/AspectLoaderExtension.php
@@ -50,17 +50,13 @@ interface AspectLoaderExtension
      * Return kind of loader, can be one of KIND_REFLECTION or KIND_ANNOTATION
      *
      * For loader that works with annotations additional metaInformation will be passed
-     *
-     * @return string
      */
-    public function getKind();
+    public function getKind() : string;
 
     /**
      * Returns one or more target for loader, see TARGET_XXX constants
-     *
-     * @return string|array
      */
-    public function getTarget();
+    public function getTargets() : array;
 
     /**
      * Checks if loader is able to handle specific point of aspect
@@ -71,7 +67,7 @@ interface AspectLoaderExtension
      *
      * @return boolean true if extension is able to create an advisor from reflection and metaInformation
      */
-    public function supports(Aspect $aspect, $reflection, $metaInformation = null);
+    public function supports(Aspect $aspect, $reflection, $metaInformation = null) : bool;
 
     /**
      * Loads definition from specific point of aspect into the container
@@ -82,5 +78,5 @@ interface AspectLoaderExtension
      *
      * @return array|Pointcut[]|Advisor[]
      */
-    public function load(Aspect $aspect, $reflection, $metaInformation = null);
+    public function load(Aspect $aspect, $reflection, $metaInformation = null) : array;
 }

--- a/src/Core/AspectLoaderExtension.php
+++ b/src/Core/AspectLoaderExtension.php
@@ -14,6 +14,7 @@ namespace Go\Core;
 use Go\Aop\Advisor;
 use Go\Aop\Aspect;
 use Go\Aop\Pointcut;
+use Reflector;
 
 /**
  * Extension interface that defines an API for aspect loaders
@@ -73,10 +74,10 @@ interface AspectLoaderExtension
      * Loads definition from specific point of aspect into the container
      *
      * @param Aspect $aspect Instance of aspect
-     * @param mixed|\ReflectionClass|\ReflectionMethod|\ReflectionProperty $reflection Reflection of point
+     * @param Reflector $reflection Reflection of point
      * @param mixed|null $metaInformation Additional meta-information, e.g. annotation for method
      *
      * @return array|Pointcut[]|Advisor[]
      */
-    public function load(Aspect $aspect, $reflection, $metaInformation = null) : array;
+    public function load(Aspect $aspect, Reflector $reflection, $metaInformation = null) : array;
 }

--- a/src/Core/CachedAspectLoader.php
+++ b/src/Core/CachedAspectLoader.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 /*
  * Go! AOP framework
  *

--- a/src/Core/CachedAspectLoader.php
+++ b/src/Core/CachedAspectLoader.php
@@ -63,7 +63,7 @@ class CachedAspectLoader extends AspectLoader
     /**
      * {@inheritdoc}
      */
-    public function load(Aspect $aspect)
+    public function load(Aspect $aspect) : array
     {
         $refAspect = new ReflectionClass($aspect);
         $fileName  = $this->cacheDir . '/_aspect/' . sha1($refAspect->getName());

--- a/src/Core/Container.php
+++ b/src/Core/Container.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 /*
  * Go! AOP framework
  *

--- a/src/Core/Container.php
+++ b/src/Core/Container.php
@@ -11,10 +11,12 @@ declare(strict_types = 1);
 
 namespace Go\Core;
 
+use Closure;
+
 /**
  * DI-container
  */
-class Container
+abstract class Container implements AspectContainer
 {
     /**
      * List of services in the container
@@ -37,7 +39,7 @@ class Container
      * @param mixed $value Value to store
      * @param array $tags Additional tags
      */
-    public function set($id, $value, array $tags = [])
+    public function set(string $id, $value, array $tags = [])
     {
         $this->values[$id] = $value;
         foreach ($tags as $tag) {
@@ -49,16 +51,11 @@ class Container
      * Set a shared value in the container
      *
      * @param string $id Identifier
-     * @param callable $value Value to store
+     * @param Closure $value Value to store
      * @param array $tags Additional tags
-     *
-     * @throws \InvalidArgumentException if value is not callable
      */
-    public function share($id, $value, array $tags = [])
+    public function share(string $id, Closure $value, array $tags = [])
     {
-        if (!is_callable($value)) {
-            throw new \InvalidArgumentException("Only callable values can be shared in the container");
-        }
         $value = function($container) use ($value) {
             static $sharedValue;
 
@@ -79,7 +76,7 @@ class Container
      * @return mixed
      * @throws \OutOfBoundsException if service was not found
      */
-    public function get($id)
+    public function get(string $id)
     {
         if (!isset($this->values[$id])) {
             throw new \OutOfBoundsException("Value {$id} is not defined in the container");
@@ -98,7 +95,7 @@ class Container
      *
      * @return bool
      */
-    public function has($id)
+    public function has(string $id) : bool
     {
         return isset($this->values[$id]);
     }
@@ -109,7 +106,7 @@ class Container
      * @param string $tag Tag to select
      * @return array
      */
-    public function getByTag($tag)
+    public function getByTag(string $tag) : array
     {
         $result = [];
         if (isset($this->tags[$tag])) {

--- a/src/Core/GeneralAspectLoaderExtension.php
+++ b/src/Core/GeneralAspectLoaderExtension.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 /*
  * Go! AOP framework
  *

--- a/src/Core/GeneralAspectLoaderExtension.php
+++ b/src/Core/GeneralAspectLoaderExtension.php
@@ -11,14 +11,18 @@ declare(strict_types = 1);
 
 namespace Go\Core;
 
+use Closure;
 use Go\Aop\Advisor;
 use Go\Aop\Aspect;
 use Go\Aop\Framework;
+use Go\Aop\Intercept\Interceptor;
 use Go\Aop\Pointcut;
 use Go\Aop\PointFilter;
-use Go\Aop\Support;
 use Go\Aop\Support\DefaultPointcutAdvisor;
 use Go\Lang\Annotation;
+use Go\Lang\Annotation\BaseInterceptor;
+use ReflectionMethod;
+use Reflector;
 
 /**
  * General aspect loader add common support for general advices, declared as annotations
@@ -61,14 +65,14 @@ class GeneralAspectLoaderExtension extends AbstractAspectLoaderExtension
      * Loads definition from specific point of aspect into the container
      *
      * @param Aspect $aspect Instance of aspect
-     * @param mixed|\ReflectionClass|\ReflectionMethod|\ReflectionProperty $reflection Reflection of point
+     * @param Reflector|ReflectionMethod $reflection Reflection of point
      * @param mixed|null $metaInformation Additional meta-information, e.g. annotation for method
      *
      * @return array|Pointcut[]|Advisor[]
      *
      * @throws \UnexpectedValueException
      */
-    public function load(Aspect $aspect, $reflection, $metaInformation = null) : array
+    public function load(Aspect $aspect, Reflector $reflection, $metaInformation = null) : array
     {
         $loadedItems    = [];
         $pointcut       = $this->parsePointcut($aspect, $reflection, $metaInformation);
@@ -95,12 +99,15 @@ class GeneralAspectLoaderExtension extends AbstractAspectLoaderExtension
     }
 
     /**
-     * @param $metaInformation
-     * @param $adviceCallback
-     * @return \Go\Aop\Intercept\Interceptor
-     * @throws \UnexpectedValueException
+     * Returns an interceptor instance by meta-type annotation
+     *
+     * @param BaseInterceptor $metaInformation Meta-information from the annotation
+     * @param Closure $adviceCallback Advice closure
+     * @return Interceptor Instance of interceptor by meta-information
+     *
+     * @throws \UnexpectedValueException For unsupported annotations
      */
-    protected function getInterceptor($metaInformation, $adviceCallback)
+    protected function getInterceptor(BaseInterceptor $metaInformation, Closure $adviceCallback) : Interceptor
     {
         $adviceOrder        = $metaInformation->order;
         $pointcutExpression = $metaInformation->value;

--- a/src/Core/GeneralAspectLoaderExtension.php
+++ b/src/Core/GeneralAspectLoaderExtension.php
@@ -28,24 +28,18 @@ class GeneralAspectLoaderExtension extends AbstractAspectLoaderExtension
 
     /**
      * General aspect loader works with annotations from aspect
-     *
-     * For extension that works with annotations additional metaInformation will be passed
-     *
-     * @return string
      */
-    public function getKind()
+    public function getKind() : string
     {
         return self::KIND_ANNOTATION;
     }
 
     /**
      * General aspect loader works only with methods of aspect
-     *
-     * @return string|array
      */
-    public function getTarget()
+    public function getTargets() : array
     {
-        return self::TARGET_METHOD;
+        return [self::TARGET_METHOD];
     }
 
     /**
@@ -57,7 +51,7 @@ class GeneralAspectLoaderExtension extends AbstractAspectLoaderExtension
      *
      * @return boolean true if extension is able to create an advisor from reflection and metaInformation
      */
-    public function supports(Aspect $aspect, $reflection, $metaInformation = null)
+    public function supports(Aspect $aspect, $reflection, $metaInformation = null) : bool
     {
         return $metaInformation instanceof Annotation\Interceptor
                 || $metaInformation instanceof Annotation\Pointcut;
@@ -74,7 +68,7 @@ class GeneralAspectLoaderExtension extends AbstractAspectLoaderExtension
      *
      * @throws \UnexpectedValueException
      */
-    public function load(Aspect $aspect, $reflection, $metaInformation = null)
+    public function load(Aspect $aspect, $reflection, $metaInformation = null) : array
     {
         $loadedItems    = [];
         $pointcut       = $this->parsePointcut($aspect, $reflection, $metaInformation);

--- a/src/Core/GoAspectContainer.php
+++ b/src/Core/GoAspectContainer.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 /*
  * Go! AOP framework
  *

--- a/src/Core/GoAspectContainer.php
+++ b/src/Core/GoAspectContainer.php
@@ -11,19 +11,21 @@ declare(strict_types = 1);
 
 namespace Go\Core;
 
+use Doctrine\Common\Annotations\AnnotationReader;
 use Doctrine\Common\Annotations\FileCacheReader;
-use ReflectionClass;
-use Go\Aop;
-use Go\Aop\Pointcut\PointcutLexer;
+use Go\Aop\Advisor;
+use Go\Aop\Aspect;
+use Go\Aop\Pointcut;
 use Go\Aop\Pointcut\PointcutGrammar;
+use Go\Aop\Pointcut\PointcutLexer;
 use Go\Aop\Pointcut\PointcutParser;
 use Go\Instrument\ClassLoading\CachePathManager;
-use Doctrine\Common\Annotations\AnnotationReader;
+use ReflectionClass;
 
 /**
  * Aspect container contains list of all pointcuts and advisors
  */
-class GoAspectContainer extends Container implements AspectContainer
+class GoAspectContainer extends Container
 {
     /**
      * List of resources for application
@@ -126,9 +128,9 @@ class GoAspectContainer extends Container implements AspectContainer
      *
      * @param string $id Pointcut identifier
      *
-     * @return Aop\Pointcut
+     * @return Pointcut
      */
-    public function getPointcut($id)
+    public function getPointcut(string $id) : Pointcut
     {
         return $this->get("pointcut.{$id}");
     }
@@ -136,10 +138,10 @@ class GoAspectContainer extends Container implements AspectContainer
     /**
      * Store the pointcut in the container
      *
-     * @param Aop\Pointcut $pointcut Instance
+     * @param Pointcut $pointcut Instance
      * @param string $id Key for pointcut
      */
-    public function registerPointcut(Aop\Pointcut $pointcut, $id)
+    public function registerPointcut(Pointcut $pointcut, string $id)
     {
         $this->set("pointcut.{$id}", $pointcut, ['pointcut']);
     }
@@ -149,9 +151,9 @@ class GoAspectContainer extends Container implements AspectContainer
      *
      * @param string $id Advisor identifier
      *
-     * @return Aop\Advisor
+     * @return Advisor
      */
-    public function getAdvisor($id)
+    public function getAdvisor(string $id) : Advisor
     {
         return $this->get("advisor.{$id}");
     }
@@ -159,10 +161,10 @@ class GoAspectContainer extends Container implements AspectContainer
     /**
      * Store the advisor in the container
      *
-     * @param Aop\Advisor $advisor Instance
+     * @param Advisor $advisor Instance
      * @param string $id Key for advisor
      */
-    public function registerAdvisor(Aop\Advisor $advisor, $id)
+    public function registerAdvisor(Advisor $advisor, string $id)
     {
         $this->set("advisor.{$id}", $advisor, ['advisor']);
     }
@@ -172,9 +174,9 @@ class GoAspectContainer extends Container implements AspectContainer
      *
      * @param string $aspectName Aspect name
      *
-     * @return Aop\Aspect
+     * @return Aspect
      */
-    public function getAspect($aspectName)
+    public function getAspect(string $aspectName) : Aspect
     {
         return $this->get("aspect.{$aspectName}");
     }
@@ -182,9 +184,9 @@ class GoAspectContainer extends Container implements AspectContainer
     /**
      * Register an aspect in the container
      *
-     * @param Aop\Aspect $aspect Instance of concrete aspect
+     * @param Aspect $aspect Instance of concrete aspect
      */
-    public function registerAspect(Aop\Aspect $aspect)
+    public function registerAspect(Aspect $aspect)
     {
         $refAspect = new ReflectionClass($aspect);
         $this->set("aspect.{$refAspect->name}", $aspect, ['aspect']);
@@ -193,10 +195,11 @@ class GoAspectContainer extends Container implements AspectContainer
 
     /**
      * Add an AOP resource to the container
-     *
      * Resources is used to check the freshness of AOP cache
+     *
+     * @param string $resource Path to the resource
      */
-    public function addResource($resource)
+    public function addResource(string $resource)
     {
         $this->resources[]  = $resource;
         $this->maxTimestamp = 0;
@@ -204,10 +207,8 @@ class GoAspectContainer extends Container implements AspectContainer
 
     /**
      * Returns list of AOP resources
-     *
-     * @return array
      */
-    public function getResources()
+    public function getResources() : array
     {
         return $this->resources;
     }
@@ -219,7 +220,7 @@ class GoAspectContainer extends Container implements AspectContainer
      *
      * @return bool Whether or not concrete file is fresh
      */
-    public function isFresh($timestamp)
+    public function isFresh(int $timestamp) : bool
     {
         if (!$this->maxTimestamp && !empty($this->resources)) {
             $this->maxTimestamp = max(array_map('filemtime', $this->resources));

--- a/src/Core/GoAspectContainer.php
+++ b/src/Core/GoAspectContainer.php
@@ -141,7 +141,7 @@ class GoAspectContainer extends Container implements AspectContainer
      */
     public function registerPointcut(Aop\Pointcut $pointcut, $id)
     {
-        $this->set("pointcut.{$id}", $pointcut, array('pointcut'));
+        $this->set("pointcut.{$id}", $pointcut, ['pointcut']);
     }
 
     /**
@@ -164,7 +164,7 @@ class GoAspectContainer extends Container implements AspectContainer
      */
     public function registerAdvisor(Aop\Advisor $advisor, $id)
     {
-        $this->set("advisor.{$id}", $advisor, array('advisor'));
+        $this->set("advisor.{$id}", $advisor, ['advisor']);
     }
 
     /**
@@ -187,7 +187,7 @@ class GoAspectContainer extends Container implements AspectContainer
     public function registerAspect(Aop\Aspect $aspect)
     {
         $refAspect = new ReflectionClass($aspect);
-        $this->set("aspect.{$refAspect->name}", $aspect, array('aspect'));
+        $this->set("aspect.{$refAspect->name}", $aspect, ['aspect']);
         $this->addResource($refAspect->getFileName());
     }
 

--- a/src/Core/IntroductionAspectExtension.php
+++ b/src/Core/IntroductionAspectExtension.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 /*
  * Go! AOP framework
  *

--- a/src/Core/IntroductionAspectExtension.php
+++ b/src/Core/IntroductionAspectExtension.php
@@ -31,19 +31,17 @@ class IntroductionAspectExtension extends AbstractAspectLoaderExtension
      *
      * @return string
      */
-    public function getKind()
+    public function getKind() : string
     {
         return self::KIND_ANNOTATION;
     }
 
     /**
      * Introduction aspect loader works only with properties of aspect
-     *
-     * @return string|array
      */
-    public function getTarget()
+    public function getTargets() : array
     {
-        return self::TARGET_PROPERTY;
+        return [self::TARGET_PROPERTY];
     }
 
     /**
@@ -55,7 +53,7 @@ class IntroductionAspectExtension extends AbstractAspectLoaderExtension
      *
      * @return boolean true if extension is able to create an advisor from reflection and metaInformation
      */
-    public function supports(Aspect $aspect, $reflection, $metaInformation = null)
+    public function supports(Aspect $aspect, $reflection, $metaInformation = null) : bool
     {
         return
             ($metaInformation instanceof Annotation\DeclareParents) ||
@@ -73,7 +71,7 @@ class IntroductionAspectExtension extends AbstractAspectLoaderExtension
      *
      * @return array|Pointcut[]|Advisor[]
      */
-    public function load(Aspect $aspect, $reflection, $metaInformation = null)
+    public function load(Aspect $aspect, $reflection, $metaInformation = null) : array
     {
         $loadedItems = [];
         $pointcut    = $this->parsePointcut($aspect, $reflection, $metaInformation);

--- a/src/Core/IntroductionAspectExtension.php
+++ b/src/Core/IntroductionAspectExtension.php
@@ -17,6 +17,8 @@ use Go\Aop\Framework;
 use Go\Aop\Pointcut;
 use Go\Aop\Support;
 use Go\Lang\Annotation;
+use ReflectionProperty;
+use Reflector;
 
 /**
  * Introduction aspect extension
@@ -64,14 +66,14 @@ class IntroductionAspectExtension extends AbstractAspectLoaderExtension
      * Loads definition from specific point of aspect into the container
      *
      * @param Aspect $aspect Instance of aspect
-     * @param mixed|\ReflectionClass|\ReflectionMethod|\ReflectionProperty $reflection Reflection of point
+     * @param Reflector|ReflectionProperty $reflection Reflection of point
      * @param mixed|null $metaInformation Additional meta-information
      *
      * @throws \UnexpectedValueException
      *
      * @return array|Pointcut[]|Advisor[]
      */
-    public function load(Aspect $aspect, $reflection, $metaInformation = null) : array
+    public function load(Aspect $aspect, Reflector $reflection, $metaInformation = null) : array
     {
         $loadedItems = [];
         $pointcut    = $this->parsePointcut($aspect, $reflection, $metaInformation);

--- a/src/Core/LazyAdvisorAccessor.php
+++ b/src/Core/LazyAdvisorAccessor.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 /*
  * Go! AOP framework
  *

--- a/src/Core/LazyAdvisorAccessor.php
+++ b/src/Core/LazyAdvisorAccessor.php
@@ -20,7 +20,7 @@ use Go\Aop\Advisor;
 class LazyAdvisorAccessor
 {
     /**
-     * @var AspectContainer|Container
+     * @var AspectContainer
      */
     protected $container;
 

--- a/src/Instrument/ClassLoading/AopComposerLoader.php
+++ b/src/Instrument/ClassLoading/AopComposerLoader.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 /*
  * Go! AOP framework
  *

--- a/src/Instrument/ClassLoading/AopComposerLoader.php
+++ b/src/Instrument/ClassLoading/AopComposerLoader.php
@@ -29,7 +29,7 @@ class AopComposerLoader
      *
      * @var ClassLoader
      */
-    protected $original = null;
+    protected $original;
 
     /**
      * AOP kernel options
@@ -99,7 +99,7 @@ class AopComposerLoader
      *
      * @return bool was initialization sucessful or not
      */
-    public static function init(array $options = [], AspectContainer $container)
+    public static function init(array $options = [], AspectContainer $container) : bool
     {
         $loaders = spl_autoload_functions();
 
@@ -129,8 +129,10 @@ class AopComposerLoader
 
     /**
      * Autoload a class by it's name
+     *
+     * @param string $class Class name
      */
-    public function loadClass($class)
+    public function loadClass(string $class)
     {
         $file = $this->findFile($class);
 
@@ -146,7 +148,7 @@ class AopComposerLoader
      * @param string $class
      * @return string|false The path/resource if found, false otherwise.
      */
-    public function findFile($class)
+    public function findFile(string $class)
     {
         static $isAllowedFilter = null, $isProduction = false;
         if (!$isAllowedFilter) {
@@ -172,10 +174,8 @@ class AopComposerLoader
 
     /**
      * Whether or not loader was initialized
-     *
-     * @return bool
      */
-    public static function wasInitialized()
+    public static function wasInitialized() : bool
     {
         return self::$wasInitialized;
     }

--- a/src/Instrument/ClassLoading/CachePathManager.php
+++ b/src/Instrument/ClassLoading/CachePathManager.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 /*
  * Go! AOP framework
  *

--- a/src/Instrument/ClassLoading/CachePathManager.php
+++ b/src/Instrument/ClassLoading/CachePathManager.php
@@ -183,10 +183,10 @@ class CachePathManager
             $cachePath    = substr(var_export($this->cacheDir, true), 1, -1);
             $rootPath     = substr(var_export($this->appDir, true), 1, -1);
             $cacheData    = '<?php return ' . var_export($fullCacheMap, true) . ';';
-            $cacheData    = strtr($cacheData, array(
+            $cacheData    = strtr($cacheData, [
                 '\'' . $cachePath => 'AOP_CACHE_DIR . \'',
                 '\'' . $rootPath  => 'AOP_ROOT_DIR . \''
-            ));
+            ]);
             $fullCacheFileName = $this->cacheDir . self::CACHE_FILE_NAME;
             file_put_contents($fullCacheFileName, $cacheData, LOCK_EX);
             // For cache files we don't want executable bits by default

--- a/src/Instrument/ClassLoading/CachePathManager.php
+++ b/src/Instrument/ClassLoading/CachePathManager.php
@@ -108,7 +108,7 @@ class CachePathManager
      *
      * @param string $cacheDir New cache directory
      */
-    public function setCacheDir($cacheDir)
+    public function setCacheDir(string $cacheDir)
     {
         $this->cacheDir = $cacheDir;
     }
@@ -117,7 +117,7 @@ class CachePathManager
      * @param string $resource
      * @return bool|string
      */
-    public function getCachePathForResource($resource)
+    public function getCachePathForResource(string $resource)
     {
         if (!$this->cacheDir) {
             return false;
@@ -133,7 +133,7 @@ class CachePathManager
      *
      * @return array|null Information or null if no record in the cache
      */
-    public function queryCacheState($resource = null)
+    public function queryCacheState(string $resource = null)
     {
         if (!$resource) {
             return $this->cacheState;
@@ -158,7 +158,7 @@ class CachePathManager
      * @param string $resource Name of the file
      * @param array $metadata Miscellaneous information about resource
      */
-    public function setCacheState($resource, array $metadata)
+    public function setCacheState(string $resource, array $metadata)
     {
         $this->newCacheState[$resource] = $metadata;
     }

--- a/src/Instrument/ClassLoading/CacheWarmer.php
+++ b/src/Instrument/ClassLoading/CacheWarmer.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 /*
  * Go! AOP framework
  *

--- a/src/Instrument/ClassLoading/SourceTransformingLoader.php
+++ b/src/Instrument/ClassLoading/SourceTransformingLoader.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 /*
  * Go! AOP framework
  *

--- a/src/Instrument/ClassLoading/SourceTransformingLoader.php
+++ b/src/Instrument/ClassLoading/SourceTransformingLoader.php
@@ -17,6 +17,8 @@ use Go\Instrument\Transformer\SourceTransformer;
 
 /**
  * Php class loader filter for processing php code
+ *
+ * @property resource $stream Stream resource
  */
 class SourceTransformingLoader extends PhpStreamFilter
 {
@@ -57,7 +59,7 @@ class SourceTransformingLoader extends PhpStreamFilter
      * @param string $filterId Identifier for the filter
      * @throws \RuntimeException If registration was failed
      */
-    public static function register($filterId = self::FILTER_IDENTIFIER)
+    public static function register(string $filterId = self::FILTER_IDENTIFIER)
     {
         if (!empty(self::$filterId)) {
             throw new \RuntimeException('Stream filter already registered');
@@ -74,9 +76,8 @@ class SourceTransformingLoader extends PhpStreamFilter
      * Returns the name of registered filter
      *
      * @throws \RuntimeException if filter was not registered
-     * @return string
      */
-    public static function getId()
+    public static function getId() : string
     {
         if (empty(self::$filterId)) {
             throw new \RuntimeException('Stream filter was not registered');
@@ -114,8 +115,6 @@ class SourceTransformingLoader extends PhpStreamFilter
      * Adds a SourceTransformer to be applied by this LoadTimeWeaver.
      *
      * @param $transformer SourceTransformer Transformer for source code
-     *
-     * @return void
      */
     public static function addTransformer(SourceTransformer $transformer)
     {
@@ -126,7 +125,7 @@ class SourceTransformingLoader extends PhpStreamFilter
      * Transforms source code by passing it through all transformers
      *
      * @param StreamMetaData|null $metadata Metadata from stream
-     * @return void|bool Return false if transformation should be stopped
+     * @return bool|null Return false if transformation should be stopped
      */
     public static function transformCode(StreamMetaData $metadata)
     {

--- a/src/Instrument/FileSystem/Enumerator.php
+++ b/src/Instrument/FileSystem/Enumerator.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 /*
  * Go! AOP framework
  *

--- a/src/Instrument/FileSystem/Enumerator.php
+++ b/src/Instrument/FileSystem/Enumerator.php
@@ -11,6 +11,9 @@ declare(strict_types = 1);
 
 namespace Go\Instrument\FileSystem;
 
+use Closure;
+use SplFileInfo;
+
 /**
  * Enumerates files in the concrete directory, applying filtration logic
  */
@@ -45,7 +48,7 @@ class Enumerator
      * @param array  $includePaths  List of additional include paths
      * @param array  $excludePaths  List of additional exclude paths
      */
-    public function __construct($rootDirectory, array $includePaths = [], array $excludePaths = [])
+    public function __construct(string $rootDirectory, array $includePaths = [], array $excludePaths = [])
     {
         $this->rootDirectory = $rootDirectory;
         $this->includePaths = $includePaths;
@@ -55,7 +58,7 @@ class Enumerator
     /**
      * Returns an enumerator for files
      *
-     * @return \CallbackFilterIterator|\RecursiveIteratorIterator|\SplFileInfo[]
+     * @return \CallbackFilterIterator|\RecursiveIteratorIterator|SplFileInfo[]
      */
     public function enumerate()
     {
@@ -74,10 +77,8 @@ class Enumerator
 
     /**
      * Returns a filter callback for enumerating files
-     *
-     * @return \Closure
      */
-    public function getFilter()
+    public function getFilter() : Closure
     {
         $rootDirectory = $this->rootDirectory;
         $includePaths = $this->includePaths;
@@ -125,11 +126,11 @@ class Enumerator
      * In a vfs the 'realPath' methode will always return false.
      * So we have a chance to mock this single function to return different path.
      *
-     * @param \SplFileInfo $file
+     * @param SplFileInfo $file
      *
      * @return string
      */
-    protected function getFileFullPath(\SplFileInfo $file)
+    protected function getFileFullPath(SplFileInfo $file) : string
     {
         return $file->getRealPath();
     }

--- a/src/Instrument/PathResolver.php
+++ b/src/Instrument/PathResolver.php
@@ -36,11 +36,11 @@ class PathResolver
         }
 
         if (is_array($somePath)) {
-            return array_map(array(__CLASS__, __FUNCTION__), $somePath);
+            return array_map([__CLASS__, __FUNCTION__], $somePath);
         }
         // Trick to get scheme name and path in one action. If no scheme, then there will be only one part
         $components = explode('://', $somePath, 2);
-        list ($pathScheme, $path) = isset($components[1]) ? $components : array(null, $components[0]);
+        list ($pathScheme, $path) = isset($components[1]) ? $components : [null, $components[0]];
 
         // Optimization to bypass complex logic for simple paths (eg. not in phar archives)
         if (!$pathScheme && ($fastPath = stream_resolve_include_path($somePath))) {
@@ -53,7 +53,7 @@ class PathResolver
         }
 
         // resolve path parts (single dot, double dot and double delimiters)
-        $path = str_replace(array('/', '\\'), DIRECTORY_SEPARATOR, $path);
+        $path = str_replace(['/', '\\'], DIRECTORY_SEPARATOR, $path);
         if (strpos($path, '.') !== false) {
             $parts     = explode(DIRECTORY_SEPARATOR, $path);
             $absolutes = [];

--- a/src/Instrument/PathResolver.php
+++ b/src/Instrument/PathResolver.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 /*
  * Go! AOP framework
  *

--- a/src/Instrument/Transformer/BaseSourceTransformer.php
+++ b/src/Instrument/Transformer/BaseSourceTransformer.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 /*
  * Go! AOP framework
  *

--- a/src/Instrument/Transformer/CachingTransformer.php
+++ b/src/Instrument/Transformer/CachingTransformer.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 /*
  * Go! AOP framework
  *

--- a/src/Instrument/Transformer/CachingTransformer.php
+++ b/src/Instrument/Transformer/CachingTransformer.php
@@ -91,10 +91,10 @@ class CachingTransformer extends BaseSourceTransformer
                 // For cache files we don't want executable bits by default
                 chmod($cacheUri, $this->cacheFileMode & (~0111));
             }
-            $this->cacheManager->setCacheState($originalUri, array(
+            $this->cacheManager->setCacheState($originalUri, [
                 'filemtime' => isset($_SERVER['REQUEST_TIME']) ? $_SERVER['REQUEST_TIME'] : time(),
                 'cacheUri'  => $wasProcessed ? $cacheUri : null
-            ));
+            ]);
 
             return $wasProcessed;
         }

--- a/src/Instrument/Transformer/ConstructorExecutionTransformer.php
+++ b/src/Instrument/Transformer/ConstructorExecutionTransformer.php
@@ -89,14 +89,14 @@ class ConstructorExecutionTransformer implements SourceTransformer
         $isClassName       = true;
         $classNamePosition = 0;
         foreach ($tokenStream as $index=>$token) {
-            list ($token, $tokenValue) = (array) $token + array(1 => $token);
+            list ($token, $tokenValue) = (array) $token + [1 => $token];
             if ($isWaitingClass && $token !== T_WHITESPACE && $token !== T_COMMENT) {
                 $classNamePosition++;
                 if ($token === T_VARIABLE && $classNamePosition === 1) {
                     $isWaitingEnd   = true;
                     $isWaitingClass = false;
                 }
-                if (in_array($tokenStream[$index + 1], array('(', ';', ')', '.'))) {
+                if (in_array($tokenStream[$index + 1], ['(', ';', ')', '.'])) {
                     $isWaitingEnd   = true;
                     $isWaitingClass = false;
                 }

--- a/src/Instrument/Transformer/ConstructorExecutionTransformer.php
+++ b/src/Instrument/Transformer/ConstructorExecutionTransformer.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 /*
  * Go! AOP framework
  *

--- a/src/Instrument/Transformer/FilterInjectorTransformer.php
+++ b/src/Instrument/Transformer/FilterInjectorTransformer.php
@@ -126,12 +126,12 @@ class FilterInjectorTransformer implements SourceTransformer
         if ((strpos($metadata->source, 'include') === false) && (strpos($metadata->source, 'require') === false)) {
             return;
         }
-        static $lookFor = array(
+        static $lookFor = [
             T_INCLUDE      => true,
             T_INCLUDE_ONCE => true,
             T_REQUIRE      => true,
             T_REQUIRE_ONCE => true
-        );
+        ];
         $tokenStream       = token_get_all($metadata->source);
 
         $transformedSource = '';
@@ -169,7 +169,7 @@ class FilterInjectorTransformer implements SourceTransformer
                 $isWaitingEnd = false;
                 $transformedSource .= ', __DIR__)';
             }
-            list ($token, $value) = (array) $token + array(1 => $token);
+            list ($token, $value) = (array) $token + [1 => $token];
             $transformedSource .= $value;
             if (!$isWaitingEnd && isset($lookFor[$token])) {
                 $isWaitingEnd = true;

--- a/src/Instrument/Transformer/FilterInjectorTransformer.php
+++ b/src/Instrument/Transformer/FilterInjectorTransformer.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 /*
  * Go! AOP framework
  *

--- a/src/Instrument/Transformer/MagicConstantTransformer.php
+++ b/src/Instrument/Transformer/MagicConstantTransformer.php
@@ -93,8 +93,8 @@ class MagicConstantTransformer extends BaseSourceTransformer
     public static function resolveFileName($fileName)
     {
         return str_replace(
-            array(self::$rewriteToPath, DIRECTORY_SEPARATOR . '_proxies'),
-            array(self::$rootPath, ''),
+            [self::$rewriteToPath, DIRECTORY_SEPARATOR . '_proxies'],
+            [self::$rootPath, ''],
             $fileName
         );
     }
@@ -107,15 +107,15 @@ class MagicConstantTransformer extends BaseSourceTransformer
     private function replaceMagicConstants(StreamMetaData $metadata)
     {
         $originalUri = $metadata->uri;
-        $replacement = array(
+        $replacement = [
             T_FILE => $originalUri,
             T_DIR  => dirname($originalUri)
-        );
+        ];
         $tokenStream = token_get_all($metadata->source);
 
         $transformedSource = '';
         foreach ($tokenStream as $token) {
-            list ($token, $value) = (array) $token + array(1 => $token);
+            list ($token, $value) = (array) $token + [1 => $token];
             if (isset($replacement[$token])) {
                 $value = "'" . $replacement[$token] . "'";
             }

--- a/src/Instrument/Transformer/MagicConstantTransformer.php
+++ b/src/Instrument/Transformer/MagicConstantTransformer.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 /*
  * Go! AOP framework
  *

--- a/src/Instrument/Transformer/SourceTransformer.php
+++ b/src/Instrument/Transformer/SourceTransformer.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 /*
  * Go! AOP framework
  *

--- a/src/Instrument/Transformer/StreamMetaData.php
+++ b/src/Instrument/Transformer/StreamMetaData.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 /*
  * Go! AOP framework
  *

--- a/src/Instrument/Transformer/WeavingTransformer.php
+++ b/src/Instrument/Transformer/WeavingTransformer.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 /*
  * Go! AOP framework
  *

--- a/src/Instrument/Transformer/WeavingTransformer.php
+++ b/src/Instrument/Transformer/WeavingTransformer.php
@@ -167,7 +167,7 @@ class WeavingTransformer extends BaseSourceTransformer
         $childClassArray   = explode("\n", $contentToInclude);
         $lineOffset += count($childClassArray) + 2; // returns LoC for child class + 2 blank lines
 
-        $dataArray = array_merge($currentClassArray, array(''), $childClassArray, array(''), $dataArray);
+        $dataArray = array_merge($currentClassArray, [''], $childClassArray, [''], $dataArray);
 
         $metadata->source = implode("\n", $dataArray);
 

--- a/src/Instrument/Transformer/WeavingTransformer.php
+++ b/src/Instrument/Transformer/WeavingTransformer.php
@@ -246,7 +246,7 @@ class WeavingTransformer extends BaseSourceTransformer
      *
      * @return string
      */
-    private function saveProxyToCache($class, $child)
+    private function saveProxyToCache($class, $child) : string
     {
         static $cacheDirSuffix = '/_proxies/';
 
@@ -254,7 +254,7 @@ class WeavingTransformer extends BaseSourceTransformer
 
         // Without cache we should rewrite original file
         if (!$cacheDir) {
-            return $child;
+            return (string) $child;
         }
         $cacheDir = $cacheDir . $cacheDirSuffix;
         $fileName = str_replace($this->options['appDir'] . DIRECTORY_SEPARATOR, '', $class->getFileName());

--- a/src/Lang/Annotation/After.php
+++ b/src/Lang/Annotation/After.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 /*
  * Go! AOP framework
  *

--- a/src/Lang/Annotation/AfterThrowing.php
+++ b/src/Lang/Annotation/AfterThrowing.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 /*
  * Go! AOP framework
  *

--- a/src/Lang/Annotation/Around.php
+++ b/src/Lang/Annotation/Around.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 /*
  * Go! AOP framework
  *

--- a/src/Lang/Annotation/Aspect.php
+++ b/src/Lang/Annotation/Aspect.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 /*
  * Go! AOP framework
  *

--- a/src/Lang/Annotation/BaseAnnotation.php
+++ b/src/Lang/Annotation/BaseAnnotation.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 /*
  * Go! AOP framework
  *

--- a/src/Lang/Annotation/BaseInterceptor.php
+++ b/src/Lang/Annotation/BaseInterceptor.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 /*
  * Go! AOP framework
  *

--- a/src/Lang/Annotation/Before.php
+++ b/src/Lang/Annotation/Before.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 /*
  * Go! AOP framework
  *

--- a/src/Lang/Annotation/DeclareError.php
+++ b/src/Lang/Annotation/DeclareError.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 /*
  * Go! AOP framework
  *

--- a/src/Lang/Annotation/DeclareError.php
+++ b/src/Lang/Annotation/DeclareError.php
@@ -27,7 +27,7 @@ class DeclareError extends BaseAnnotation
     /**
      * Interface name to add
      *
-     * @var string
+     * @var integer
      */
     public $level = E_USER_NOTICE;
 }

--- a/src/Lang/Annotation/DeclareParents.php
+++ b/src/Lang/Annotation/DeclareParents.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 /*
  * Go! AOP framework
  *

--- a/src/Lang/Annotation/Interceptor.php
+++ b/src/Lang/Annotation/Interceptor.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 /*
  * Go! AOP framework
  *

--- a/src/Lang/Annotation/Pointcut.php
+++ b/src/Lang/Annotation/Pointcut.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 /*
  * Go! AOP framework
  *

--- a/src/Proxy/AbstractProxy.php
+++ b/src/Proxy/AbstractProxy.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 /*
  * Go! AOP framework
  *

--- a/src/Proxy/ClassProxy.php
+++ b/src/Proxy/ClassProxy.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 /*
  * Go! AOP framework
  *

--- a/src/Proxy/FunctionProxy.php
+++ b/src/Proxy/FunctionProxy.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 /*
  * Go! AOP framework
  *

--- a/src/Proxy/PropertyInterceptionTrait.php
+++ b/src/Proxy/PropertyInterceptionTrait.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 /*
  * Go! AOP framework
  *

--- a/src/Proxy/TraitProxy.php
+++ b/src/Proxy/TraitProxy.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 /*
  * Go! AOP framework
  *

--- a/src/Proxy/TraitProxy.php
+++ b/src/Proxy/TraitProxy.php
@@ -112,7 +112,7 @@ BODY;
             $this->name . "\n" . // Name of the trait
             "{\n" . // Start of trait body
             $this->indent(
-                'use ' . join(', ', array(-1 => $this->parentClassName) + $this->traits) .
+                'use ' . join(', ', [-1 => $this->parentClassName] + $this->traits) .
                 $this->getMethodAliasesCode()
             ) . "\n" . // Use traits and aliases section
             $this->indent(join("\n", $this->methodsCode)) . "\n" . // Method definitions

--- a/tests/Fixtures/project/bin/console
+++ b/tests/Fixtures/project/bin/console
@@ -1,5 +1,6 @@
 #!/usr/bin/env php
 <?php
+declare(strict_types = 1);
 
 include_once __DIR__ . '/../../../../vendor/autoload.php';
 

--- a/tests/Fixtures/project/src/Annotation/Loggable.php
+++ b/tests/Fixtures/project/src/Annotation/Loggable.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 
 namespace Go\Tests\TestProject\Annotation;
 

--- a/tests/Fixtures/project/src/Application/Main.php
+++ b/tests/Fixtures/project/src/Application/Main.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 
 namespace Go\Tests\TestProject\Application;
 

--- a/tests/Fixtures/project/src/ApplicationAspectKernel.php
+++ b/tests/Fixtures/project/src/ApplicationAspectKernel.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 
 namespace Go\Tests\TestProject;
 

--- a/tests/Fixtures/project/src/Aspect/LoggingAspect.php
+++ b/tests/Fixtures/project/src/Aspect/LoggingAspect.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 
 namespace Go\Tests\TestProject\Aspect;
 

--- a/tests/Fixtures/project/web/index.php
+++ b/tests/Fixtures/project/web/index.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 
 include_once __DIR__ . '/../../../../vendor/autoload.php';
 

--- a/tests/Go/Aop/Bridge/Doctrine/MetadataLoadInterceptorTest.php
+++ b/tests/Go/Aop/Bridge/Doctrine/MetadataLoadInterceptorTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 /*
  * Go! AOP framework
  *

--- a/tests/Go/Aop/Framework/AbstractInterceptorTest.php
+++ b/tests/Go/Aop/Framework/AbstractInterceptorTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 /*
  * Go! AOP framework
  *

--- a/tests/Go/Aop/Framework/AbstractJoinpointTest.php
+++ b/tests/Go/Aop/Framework/AbstractJoinpointTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 
 namespace Go\Aop\Framework;
 

--- a/tests/Go/Aop/Framework/AbstractJoinpointTest.php
+++ b/tests/Go/Aop/Framework/AbstractJoinpointTest.php
@@ -28,100 +28,100 @@ class AbstractJoinpointTest extends \PHPUnit_Framework_TestCase
 
     public function sortingTestSource()
     {
-        return array(
+        return [
             // #0
-            array(
-                array(
+            [
+                [
                     $this->createMock(AdviceAfter::class),
                     $this->createMock(AdviceBefore::class)
-                ),
-                array(
+                ],
+                [
                     AdviceBefore::class,
                     AdviceAfter::class
-                )
-            ),
+                ]
+            ],
             // #1
-            array(
-                array(
+            [
+                [
                     $this->createMock(AdviceAfter::class),
                     $this->createMock(AdviceAround::class)
-                ),
-                array(
+                ],
+                [
                     AdviceAfter::class,
                     AdviceAround::class
-                )
-            ),
+                ]
+            ],
             // #2
-            array(
-                array(
+            [
+                [
                     $this->createMock(AdviceBefore::class),
                     $this->createMock(AdviceAfter::class)
-                ),
-                array(
+                ],
+                [
                     AdviceBefore::class,
                     AdviceAfter::class
-                )
-            ),
+                ]
+            ],
             // #3
-            array(
-                array(
+            [
+                [
                     $this->createMock(AdviceBefore::class),
                     $this->createMock(AdviceAround::class)
-                ),
-                array(
+                ],
+                [
                     AdviceBefore::class,
                     AdviceAround::class
-                )
-            ),
+                ]
+            ],
             // #4
-            array(
-                array(
+            [
+                [
                     $this->createMock(AdviceAround::class),
                     $this->createMock(AdviceAfter::class)
-                ),
-                array(
+                ],
+                [
                     AdviceAfter::class,
                     AdviceAround::class
-                )
-            ),
+                ]
+            ],
             // #5
-            array(
-                array(
+            [
+                [
                     $this->createMock(AdviceAround::class),
                     $this->createMock(AdviceBefore::class)
-                ),
-                array(
+                ],
+                [
                     AdviceBefore::class,
                     AdviceAround::class
-                )
-            ),
+                ]
+            ],
             // #6
-            array(
-                array(
+            [
+                [
                     $this->createMock(AdviceBefore::class),
                     $this->createMock(AdviceAround::class),
                     $this->createMock(AdviceBefore::class),
                     $this->createMock(AdviceAfter::class),
-                ),
-                array(
+                ],
+                [
                     AdviceBefore::class,
                     AdviceBefore::class,
                     AdviceAfter::class,
                     AdviceAround::class,
-                )
-            ),
+                ]
+            ],
             // #7
-            array(
-                array(
+            [
+                [
                     $forth = $this->getOrderedAdvice(4, 'ForthAdvice'),
                     $first = $this->getOrderedAdvice(1, 'FirstAdvice')
-                ),
-                array(
+                ],
+                [
                     get_class($first),
                     get_class($forth),
-                )
-            ),
-        );
+                ]
+            ],
+        ];
     }
 
     /**

--- a/tests/Go/Aop/Framework/AbstractMethodInvocationTest.php
+++ b/tests/Go/Aop/Framework/AbstractMethodInvocationTest.php
@@ -14,7 +14,7 @@ class AbstractMethodInvocationTest extends \PHPUnit_Framework_TestCase
     {
         $this->invocation = $this->getMockForAbstractClass(
             AbstractMethodInvocation::class,
-            array(__CLASS__, __FUNCTION__, [])
+            [__CLASS__, __FUNCTION__, []]
         );
     }
 

--- a/tests/Go/Aop/Framework/AbstractMethodInvocationTest.php
+++ b/tests/Go/Aop/Framework/AbstractMethodInvocationTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 
 namespace Go\Aop\Framework;
 

--- a/tests/Go/Aop/Framework/AfterInterceptorTest.php
+++ b/tests/Go/Aop/Framework/AfterInterceptorTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 /*
  * Go! AOP framework
  *

--- a/tests/Go/Aop/Framework/AfterInterceptorTest.php
+++ b/tests/Go/Aop/Framework/AfterInterceptorTest.php
@@ -24,7 +24,7 @@ class AfterInterceptorTest extends AbstractInterceptorTest
         $result = $interceptor->invoke($invocation);
 
         $this->assertEquals('invocation', $result, "Advice should not affect the return value of invocation");
-        $this->assertEquals(array('invocation', 'advice'), $sequence, "After advice should be invoked after invocation");
+        $this->assertEquals(['invocation', 'advice'], $sequence, "After advice should be invoked after invocation");
     }
 
     public function testAdviceIsCalledAfterExceptionInInvocation()
@@ -38,7 +38,7 @@ class AfterInterceptorTest extends AbstractInterceptorTest
         try {
             $interceptor->invoke($invocation);
         } catch (\Exception $e) {
-            $this->assertEquals(array('invocation', 'advice'), $sequence, "After advice should be invoked after invocation");
+            $this->assertEquals(['invocation', 'advice'], $sequence, "After advice should be invoked after invocation");
             throw $e;
         }
     }

--- a/tests/Go/Aop/Framework/AfterInterceptorTest.php
+++ b/tests/Go/Aop/Framework/AfterInterceptorTest.php
@@ -34,7 +34,7 @@ class AfterInterceptorTest extends AbstractInterceptorTest
         $invocation = $this->getInvocation($sequence, true);
 
         $interceptor = new AfterInterceptor($advice);
-        $this->setExpectedException('RuntimeException');
+        $this->expectException('RuntimeException');
         try {
             $interceptor->invoke($invocation);
         } catch (\Exception $e) {

--- a/tests/Go/Aop/Framework/AfterThrowingInterceptorTest.php
+++ b/tests/Go/Aop/Framework/AfterThrowingInterceptorTest.php
@@ -34,7 +34,7 @@ class AfterThrowingInterceptorTest extends AbstractInterceptorTest
         $invocation = $this->getInvocation($sequence, true);
 
         $interceptor = new AfterThrowingInterceptor($advice);
-        $this->setExpectedException('RuntimeException');
+        $this->expectException('RuntimeException');
         try {
             $interceptor->invoke($invocation);
         } catch (\Exception $e) {

--- a/tests/Go/Aop/Framework/AfterThrowingInterceptorTest.php
+++ b/tests/Go/Aop/Framework/AfterThrowingInterceptorTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 /*
  * Go! AOP framework
  *

--- a/tests/Go/Aop/Framework/AfterThrowingInterceptorTest.php
+++ b/tests/Go/Aop/Framework/AfterThrowingInterceptorTest.php
@@ -24,7 +24,7 @@ class AfterThrowingInterceptorTest extends AbstractInterceptorTest
         $result = $interceptor->invoke($invocation);
 
         $this->assertEquals('invocation', $result, "Advice should not affect the return value of invocation");
-        $this->assertEquals(array('invocation'), $sequence, "Advice should not be invoked");
+        $this->assertEquals(['invocation'], $sequence, "Advice should not be invoked");
     }
 
     public function testAdviceIsCalledAfterExceptionInInvocation()
@@ -38,7 +38,7 @@ class AfterThrowingInterceptorTest extends AbstractInterceptorTest
         try {
             $interceptor->invoke($invocation);
         } catch (\Exception $e) {
-            $this->assertEquals(array('invocation', 'advice'), $sequence, "Advice should be invoked after invocation");
+            $this->assertEquals(['invocation', 'advice'], $sequence, "Advice should be invoked after invocation");
             throw $e;
         }
     }}

--- a/tests/Go/Aop/Framework/AroundInterceptorTest.php
+++ b/tests/Go/Aop/Framework/AroundInterceptorTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 /*
  * Go! AOP framework
  *

--- a/tests/Go/Aop/Framework/AroundInterceptorTest.php
+++ b/tests/Go/Aop/Framework/AroundInterceptorTest.php
@@ -26,7 +26,7 @@ class AroundInterceptorTest extends AbstractInterceptorTest
         $result = $interceptor->invoke($invocation);
 
         $this->assertEquals('advice', $result, "Advice should change the return value of invocation");
-        $this->assertEquals(array('advice'), $sequence, "Only advice should be invoked");
+        $this->assertEquals(['advice'], $sequence, "Only advice should be invoked");
     }
 
     public function testInvocationIsCalledWithinAdvice()
@@ -43,6 +43,6 @@ class AroundInterceptorTest extends AbstractInterceptorTest
         $interceptor = new AroundInterceptor($advice);
         $result = $interceptor->invoke($invocation);
         $this->assertEquals('invocation', $result, "Advice should return an original return value");
-        $this->assertEquals(array('advice', 'invocation', 'advice'), $sequence, "Around logic should work");
+        $this->assertEquals(['advice', 'invocation', 'advice'], $sequence, "Around logic should work");
     }
 }

--- a/tests/Go/Aop/Framework/BaseInterceptorTest.php
+++ b/tests/Go/Aop/Framework/BaseInterceptorTest.php
@@ -28,7 +28,7 @@ class BaseInterceptorTest extends AbstractInterceptorTest
 
         $interceptor = $this->getMockForAbstractClass(
             BaseInterceptor::class,
-            array($advice)
+            [$advice]
         );
         $this->assertEquals($advice, $interceptor->getRawAdvice());
     }

--- a/tests/Go/Aop/Framework/BaseInterceptorTest.php
+++ b/tests/Go/Aop/Framework/BaseInterceptorTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 /*
  * Go! AOP framework
  *

--- a/tests/Go/Aop/Framework/BeforeInterceptorTest.php
+++ b/tests/Go/Aop/Framework/BeforeInterceptorTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 /*
  * Go! AOP framework
  *

--- a/tests/Go/Aop/Framework/BeforeInterceptorTest.php
+++ b/tests/Go/Aop/Framework/BeforeInterceptorTest.php
@@ -23,6 +23,6 @@ class BeforeInterceptorTest extends AbstractInterceptorTest
         $result = $interceptor->invoke($invocation);
 
         $this->assertEquals('invocation', $result, "Advice should not affect the return value of invocation");
-        $this->assertEquals(array('advice', 'invocation'), $sequence, "Before advice should be invoked before invocation");
+        $this->assertEquals(['advice', 'invocation'], $sequence, "Before advice should be invoked before invocation");
     }
 }

--- a/tests/Go/Aop/Framework/DynamicClosureSplatMethodInvocationTest.php
+++ b/tests/Go/Aop/Framework/DynamicClosureSplatMethodInvocationTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 
 namespace Go\Aop\Framework;
 

--- a/tests/Go/Aop/Framework/DynamicClosureSplatMethodInvocationTest.php
+++ b/tests/Go/Aop/Framework/DynamicClosureSplatMethodInvocationTest.php
@@ -13,20 +13,6 @@ use Go\Stubs\First;
 class DynamicClosureSplatMethodInvocationTest extends \PHPUnit_Framework_TestCase
 {
 
-    const FIRST_CLASS_NAME = First::class;
-
-    protected static $invocationClass = DynamicClosureMethodInvocation::class;
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function setUp()
-    {
-        if (PHP_VERSION_ID < 50600) {
-            $this->markTestSkipped("Closure Method Invocation with splat works only on PHP 5.6 and greater");
-        }
-    }
-
     /**
      * Tests dynamic method invocations
      *
@@ -34,8 +20,8 @@ class DynamicClosureSplatMethodInvocationTest extends \PHPUnit_Framework_TestCas
      */
     public function testDynamicMethodInvocation($methodName, $expectedResult)
     {
-        $child      = $this->createMock(self::FIRST_CLASS_NAME);
-        $invocation = new self::$invocationClass(self::FIRST_CLASS_NAME, $methodName, []);
+        $child      = $this->createMock(First::class);
+        $invocation = new DynamicClosureMethodInvocation(First::class, $methodName, []);
 
         $result = $invocation($child);
         $this->assertEquals($expectedResult, $result);
@@ -43,8 +29,8 @@ class DynamicClosureSplatMethodInvocationTest extends \PHPUnit_Framework_TestCas
 
     public function testValueChangedByReference()
     {
-        $child      = $this->createMock(self::FIRST_CLASS_NAME);
-        $invocation = new self::$invocationClass(self::FIRST_CLASS_NAME, 'passByReference', []);
+        $child      = $this->createMock(First::class);
+        $invocation = new DynamicClosureMethodInvocation(First::class, 'passByReference', []);
 
         $value  = 'test';
         $result = $invocation($child, [&$value]);
@@ -54,8 +40,8 @@ class DynamicClosureSplatMethodInvocationTest extends \PHPUnit_Framework_TestCas
 
     public function testInvocationWithDynamicArguments()
     {
-        $child      = $this->createMock(self::FIRST_CLASS_NAME);
-        $invocation = new self::$invocationClass(self::FIRST_CLASS_NAME, 'variableArgsTest', []);
+        $child      = $this->createMock(First::class);
+        $invocation = new DynamicClosureMethodInvocation(First::class, 'variableArgsTest', []);
 
         $args     = [];
         $expected = '';
@@ -69,8 +55,8 @@ class DynamicClosureSplatMethodInvocationTest extends \PHPUnit_Framework_TestCas
 
     public function testInvocationWithVariadicArguments()
     {
-        $child      = $this->createMock(self::FIRST_CLASS_NAME);
-        $invocation = new self::$invocationClass(self::FIRST_CLASS_NAME, 'variadicArgsTest', []);
+        $child      = $this->createMock(First::class);
+        $invocation = new DynamicClosureMethodInvocation(First::class, 'variadicArgsTest', []);
 
         $args     = [];
         $expected = '';
@@ -84,8 +70,8 @@ class DynamicClosureSplatMethodInvocationTest extends \PHPUnit_Framework_TestCas
 
     public function testRecursionWorks()
     {
-        $child      = $this->createMock(self::FIRST_CLASS_NAME);
-        $invocation = new self::$invocationClass(self::FIRST_CLASS_NAME, 'recursion', []);
+        $child      = $this->createMock(First::class);
+        $invocation = new DynamicClosureMethodInvocation(First::class, 'recursion', []);
 
         $child->expects($this->exactly(5))->method('recursion')->will($this->returnCallback(
             function ($value, $level) use ($child, $invocation) {
@@ -99,7 +85,7 @@ class DynamicClosureSplatMethodInvocationTest extends \PHPUnit_Framework_TestCas
 
     public function testInterceptorIsCalledForInvocation()
     {
-        $child  = $this->createMock(self::FIRST_CLASS_NAME);
+        $child  = $this->createMock(First::class);
         $value  = 'test';
         $advice = $this->createMock(Interceptor::class);
         $advice->expects($this->once())
@@ -109,7 +95,7 @@ class DynamicClosureSplatMethodInvocationTest extends \PHPUnit_Framework_TestCas
                 return $object->proceed();
             }));
 
-        $invocation = new self::$invocationClass(self::FIRST_CLASS_NAME, 'publicMethod', [$advice]);
+        $invocation = new DynamicClosureMethodInvocation(First::class, 'publicMethod', [$advice]);
 
         $result = $invocation($child, []);
         $this->assertEquals('ok', $value);

--- a/tests/Go/Aop/Framework/DynamicClosureSplatMethodInvocationTest.php
+++ b/tests/Go/Aop/Framework/DynamicClosureSplatMethodInvocationTest.php
@@ -47,7 +47,7 @@ class DynamicClosureSplatMethodInvocationTest extends \PHPUnit_Framework_TestCas
         $invocation = new self::$invocationClass(self::FIRST_CLASS_NAME, 'passByReference', []);
 
         $value  = 'test';
-        $result = $invocation($child, array(&$value));
+        $result = $invocation($child, [&$value]);
         $this->assertEquals(null, $result);
         $this->assertEquals(null, $value);
     }
@@ -89,7 +89,7 @@ class DynamicClosureSplatMethodInvocationTest extends \PHPUnit_Framework_TestCas
 
         $child->expects($this->exactly(5))->method('recursion')->will($this->returnCallback(
             function ($value, $level) use ($child, $invocation) {
-                return $invocation($child, array($value, $level));
+                return $invocation($child, [$value, $level]);
             }
         ));
 
@@ -109,7 +109,7 @@ class DynamicClosureSplatMethodInvocationTest extends \PHPUnit_Framework_TestCas
                 return $object->proceed();
             }));
 
-        $invocation = new self::$invocationClass(self::FIRST_CLASS_NAME, 'publicMethod', array($advice));
+        $invocation = new self::$invocationClass(self::FIRST_CLASS_NAME, 'publicMethod', [$advice]);
 
         $result = $invocation($child, []);
         $this->assertEquals('ok', $value);
@@ -118,10 +118,10 @@ class DynamicClosureSplatMethodInvocationTest extends \PHPUnit_Framework_TestCas
 
     public function dynamicMethodsBatch()
     {
-        return array(
-            array('publicMethod', T_PUBLIC),
-            array('protectedMethod', T_PROTECTED),
+        return [
+            ['publicMethod', T_PUBLIC],
+            ['protectedMethod', T_PROTECTED],
             // array('privateMethod', T_PRIVATE), This will throw an ReflectionException, need to add use case for that
-        );
+        ];
     }
 }

--- a/tests/Go/Aop/Framework/StaticClosureMethodInvocationTest.php
+++ b/tests/Go/Aop/Framework/StaticClosureMethodInvocationTest.php
@@ -20,7 +20,7 @@ class StaticClosureMethodInvocationTest extends \PHPUnit_Framework_TestCase
     public function testStaticSelfMethodInvocation($methodName, $expectedResult)
     {
         $childClass = $this->createMock(First::class);
-        $invocation = new StaticClosureMethodInvocation($childClass, $methodName, []);
+        $invocation = new StaticClosureMethodInvocation(get_class($childClass), $methodName, []);
 
         $result = $invocation($childClass);
         $this->assertEquals($expectedResult, $result);

--- a/tests/Go/Aop/Framework/StaticClosureMethodInvocationTest.php
+++ b/tests/Go/Aop/Framework/StaticClosureMethodInvocationTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 
 namespace Go\Aop\Framework;
 

--- a/tests/Go/Aop/Framework/StaticClosureMethodInvocationTest.php
+++ b/tests/Go/Aop/Framework/StaticClosureMethodInvocationTest.php
@@ -23,7 +23,7 @@ class StaticClosureMethodInvocationTest extends \PHPUnit_Framework_TestCase
      */
     public function testStaticSelfMethodInvocation($methodName, $expectedResult)
     {
-        $childClass = $this->getMockClass(self::FIRST_CLASS_NAME, array('none'));
+        $childClass = $this->getMockClass(self::FIRST_CLASS_NAME, ['none']);
         $invocation = new self::$invocationClass($childClass, $methodName, []);
 
         $result = $invocation($childClass);
@@ -37,7 +37,7 @@ class StaticClosureMethodInvocationTest extends \PHPUnit_Framework_TestCase
      */
     public function testStaticSelfNotOverridden($methodName, $expectedResult)
     {
-        $childClass = $this->getMockClass(self::FIRST_CLASS_NAME, array($methodName));
+        $childClass = $this->getMockClass(self::FIRST_CLASS_NAME, [$methodName]);
         $invocation = new self::$invocationClass(self::FIRST_CLASS_NAME, $methodName, []);
 
         $result = $invocation($childClass);
@@ -51,7 +51,7 @@ class StaticClosureMethodInvocationTest extends \PHPUnit_Framework_TestCase
      */
     public function testStaticLsbIsWorking($methodName)
     {
-        $childClass = $this->getMockClass(self::FIRST_CLASS_NAME, array($methodName));
+        $childClass = $this->getMockClass(self::FIRST_CLASS_NAME, [$methodName]);
         $invocation = new self::$invocationClass(self::FIRST_CLASS_NAME, $methodName, []);
 
         $result = $invocation($childClass);
@@ -64,7 +64,7 @@ class StaticClosureMethodInvocationTest extends \PHPUnit_Framework_TestCase
         $invocation = new self::$invocationClass(self::FIRST_CLASS_NAME, 'staticPassByReference', []);
 
         $value  = 'test';
-        $result = $invocation($child, array(&$value));
+        $result = $invocation($child, [&$value]);
         $this->assertEquals(null, $result);
         $this->assertEquals(null, $value);
     }
@@ -87,7 +87,7 @@ class StaticClosureMethodInvocationTest extends \PHPUnit_Framework_TestCase
             $value = 'ok';
         });
 
-        $invocation = new self::$invocationClass(self::FIRST_CLASS_NAME, 'staticSelfPublic', array($advice));
+        $invocation = new self::$invocationClass(self::FIRST_CLASS_NAME, 'staticSelfPublic', [$advice]);
 
         $result = $invocation($child, []);
         $this->assertEquals('ok', $value);
@@ -126,19 +126,19 @@ class StaticClosureMethodInvocationTest extends \PHPUnit_Framework_TestCase
 
     public function staticSelfMethodsBatch()
     {
-        return array(
-            array('staticSelfPublic', T_PUBLIC),
-            array('staticSelfProtected', T_PROTECTED),
-            array('staticSelfPublicAccessPrivate', T_PRIVATE),
-        );
+        return [
+            ['staticSelfPublic', T_PUBLIC],
+            ['staticSelfProtected', T_PROTECTED],
+            ['staticSelfPublicAccessPrivate', T_PRIVATE],
+        ];
     }
 
     public function staticLsbMethodsBatch()
     {
-        return array(
-            array('staticLsbPublic'),
-            array('staticLsbProtected'),
-        );
+        return [
+            ['staticLsbPublic'],
+            ['staticLsbProtected'],
+        ];
     }
 
 }

--- a/tests/Go/Aop/Framework/StaticClosureMethodInvocationTest.php
+++ b/tests/Go/Aop/Framework/StaticClosureMethodInvocationTest.php
@@ -12,10 +12,6 @@ use Go\Stubs\FirstStatic;
 class StaticClosureMethodInvocationTest extends \PHPUnit_Framework_TestCase
 {
 
-    const FIRST_CLASS_NAME = First::class;
-
-    protected static $invocationClass = StaticClosureMethodInvocation::class;
-
     /**
      * Tests static method invocations with self
      *
@@ -23,8 +19,8 @@ class StaticClosureMethodInvocationTest extends \PHPUnit_Framework_TestCase
      */
     public function testStaticSelfMethodInvocation($methodName, $expectedResult)
     {
-        $childClass = $this->getMockClass(self::FIRST_CLASS_NAME, ['none']);
-        $invocation = new self::$invocationClass($childClass, $methodName, []);
+        $childClass = $this->createMock(First::class);
+        $invocation = new StaticClosureMethodInvocation($childClass, $methodName, []);
 
         $result = $invocation($childClass);
         $this->assertEquals($expectedResult, $result);
@@ -37,8 +33,8 @@ class StaticClosureMethodInvocationTest extends \PHPUnit_Framework_TestCase
      */
     public function testStaticSelfNotOverridden($methodName, $expectedResult)
     {
-        $childClass = $this->getMockClass(self::FIRST_CLASS_NAME, [$methodName]);
-        $invocation = new self::$invocationClass(self::FIRST_CLASS_NAME, $methodName, []);
+        $childClass = $this->createMock(First::class);
+        $invocation = new StaticClosureMethodInvocation(First::class, $methodName, []);
 
         $result = $invocation($childClass);
         $this->assertEquals($expectedResult, $result);
@@ -51,17 +47,17 @@ class StaticClosureMethodInvocationTest extends \PHPUnit_Framework_TestCase
      */
     public function testStaticLsbIsWorking($methodName)
     {
-        $childClass = $this->getMockClass(self::FIRST_CLASS_NAME, [$methodName]);
-        $invocation = new self::$invocationClass(self::FIRST_CLASS_NAME, $methodName, []);
+        $childClass = $this->createMock(First::class);
+        $invocation = new StaticClosureMethodInvocation(First::class, $methodName, []);
 
-        $result = $invocation($childClass);
-        $this->assertEquals($childClass, $result);
+        $result = $invocation(get_class($childClass));
+        $this->assertEquals(get_class($childClass), $result);
     }
 
     public function testValueChangedByReference()
     {
-        $child      = $this->createMock(self::FIRST_CLASS_NAME);
-        $invocation = new self::$invocationClass(self::FIRST_CLASS_NAME, 'staticPassByReference', []);
+        $child      = $this->createMock(First::class);
+        $invocation = new StaticClosureMethodInvocation(First::class, 'staticPassByReference', []);
 
         $value  = 'test';
         $result = $invocation($child, [&$value]);
@@ -71,7 +67,7 @@ class StaticClosureMethodInvocationTest extends \PHPUnit_Framework_TestCase
 
     public function testRecursionWorks()
     {
-        $invocation = new self::$invocationClass(self::FIRST_CLASS_NAME, 'staticLsbRecursion', []);
+        $invocation = new StaticClosureMethodInvocation(First::class, 'staticLsbRecursion', []);
         $child      = new FirstStatic($invocation);
 
         $childClass = get_class($child);
@@ -81,13 +77,13 @@ class StaticClosureMethodInvocationTest extends \PHPUnit_Framework_TestCase
 
     public function testAdviceIsCalledForInvocation()
     {
-        $child  = $this->createMock(self::FIRST_CLASS_NAME);
+        $child  = $this->createMock(First::class);
         $value  = 'test';
         $advice = new BeforeInterceptor(function () use (&$value) {
             $value = 'ok';
         });
 
-        $invocation = new self::$invocationClass(self::FIRST_CLASS_NAME, 'staticSelfPublic', [$advice]);
+        $invocation = new StaticClosureMethodInvocation(First::class, 'staticSelfPublic', [$advice]);
 
         $result = $invocation($child, []);
         $this->assertEquals('ok', $value);
@@ -96,8 +92,8 @@ class StaticClosureMethodInvocationTest extends \PHPUnit_Framework_TestCase
 
     public function testInvocationWithDynamicArguments()
     {
-        $child      = $this->createMock(self::FIRST_CLASS_NAME);
-        $invocation = new self::$invocationClass(self::FIRST_CLASS_NAME, 'staticVariableArgsTest', []);
+        $child      = $this->createMock(First::class);
+        $invocation = new StaticClosureMethodInvocation(First::class, 'staticVariableArgsTest', []);
 
         $args     = [];
         $expected = '';
@@ -111,8 +107,8 @@ class StaticClosureMethodInvocationTest extends \PHPUnit_Framework_TestCase
 
     public function testInvocationWithVariadicArguments()
     {
-        $child      = $this->createMock(self::FIRST_CLASS_NAME);
-        $invocation = new self::$invocationClass(self::FIRST_CLASS_NAME, 'staticVariadicArgsTest', []);
+        $child      = $this->createMock(First::class);
+        $invocation = new StaticClosureMethodInvocation(First::class, 'staticVariadicArgsTest', []);
 
         $args     = [];
         $expected = '';

--- a/tests/Go/Aop/Pointcut/PointcutParserTest.php
+++ b/tests/Go/Aop/Pointcut/PointcutParserTest.php
@@ -57,63 +57,63 @@ class PointcutParserTest extends \PHPUnit_Framework_TestCase
 
     public function validPointcutDefinitions()
     {
-        return array(
+        return [
             // Execution pointcuts
-            array('execution(public Example->method(*))'),
-            array('execution(public Example->method|method1|method2(*))'),
-            array('execution(final public Example\Aspect\*->method*(*))'),
-            array('execution(protected|public **::*someStatic*Method*(*))'),
+            ['execution(public Example->method(*))'],
+            ['execution(public Example->method|method1|method2(*))'],
+            ['execution(final public Example\Aspect\*->method*(*))'],
+            ['execution(protected|public **::*someStatic*Method*(*))'],
 
             // This will match property that has First\Second\Annotation\Class annotation
-            array('@access(First\Second\Annotation\Class)'),
+            ['@access(First\Second\Annotation\Class)'],
 
             // This will match method execution that has First\Second\Annotation\Class annotation
-            array('@execution(First\Second\Annotation\Class)'),
+            ['@execution(First\Second\Annotation\Class)'],
 
             // This will match all the methods in all classes of Go\Aspects\Blog\Package.
-            array('within(Go\Aspects\Blog\Package\*)'),
+            ['within(Go\Aspects\Blog\Package\*)'],
             // This will match all the methods in all classes of Go\Aspects\Blog\Package and its sub packages.
-            array('within(Go\Aspects\Blog\Package\**)'),
+            ['within(Go\Aspects\Blog\Package\**)'],
             // This will match all the methods in the DemoClass.
-            array('within(Go\Aspects\Blog\Package\DemoClass)'),
+            ['within(Go\Aspects\Blog\Package\DemoClass)'],
             // This will match all the methods which are in classes which implement DemoInterface.
-            array('within(DemoInterface+)'),
+            ['within(DemoInterface+)'],
             // This will match all the methods in the class with specific annotation.
-            array('@within(First\Second\Annotation\Class)'),
+            ['@within(First\Second\Annotation\Class)'],
 
             // Access pointcuts
-            array('access(public|protected Example\Aspect\*->property*)'),
-            array('access(protected Test\Class*->someProtected*Property)'),
+            ['access(public|protected Example\Aspect\*->property*)'],
+            ['access(protected Test\Class*->someProtected*Property)'],
 
             // Logic pointcuts
-            array('!within(DemoInterface\Test+)'),
-            array('within(DemoInterface+) && within(Some\Namespace\**)'),
-            array('within(DemoInterface+) || within(Some\Namespace\**)'),
+            ['!within(DemoInterface\Test+)'],
+            ['within(DemoInterface+) && within(Some\Namespace\**)'],
+            ['within(DemoInterface+) || within(Some\Namespace\**)'],
 
             // Parenthesis
-            array('within(DemoInterface+) && ( within(**) || within(*) )'),
+            ['within(DemoInterface+) && ( within(**) || within(*) )'],
 
             // Control flow execution pointcuts
-            array('cflowbelow(execution(public Example->method(*)))'),
+            ['cflowbelow(execution(public Example->method(*)))'],
 
             // Function pointcut
-            array('execution(Demo\*\Test\**\*(*))'),
-            array('execution(Demo\Namespace\array_*_er(*))'),
-            array('execution(**\*(*))'),
+            ['execution(Demo\*\Test\**\*(*))'],
+            ['execution(Demo\Namespace\array_*_er(*))'],
+            ['execution(**\*(*))'],
 
             // Dynamic pointcut for methods via __callStatic and __call
-            array('dynamic(public Demo\Example\DynamicMethodsDemo::find*(*))'),
-            array('dynamic(public Demo\Example\DynamicMethodsDemo->save*(*))'),
+            ['dynamic(public Demo\Example\DynamicMethodsDemo::find*(*))'],
+            ['dynamic(public Demo\Example\DynamicMethodsDemo->save*(*))'],
 
             // This will match static initialization pointcut
-            array('staticinitialization(Some\Specific\Class\**)'),
+            ['staticinitialization(Some\Specific\Class\**)'],
 
             // This will match all methods, but not inherited
-            array('execution(public **->*(*)) && !matchInherited()'),
+            ['execution(public **->*(*)) && !matchInherited()'],
 
             // This will match dynamic initialization pointcut
-            array('initialization(Some\Specific\Class\**)'),
-        );
+            ['initialization(Some\Specific\Class\**)'],
+        ];
     }
 
 }

--- a/tests/Go/Aop/Pointcut/PointcutParserTest.php
+++ b/tests/Go/Aop/Pointcut/PointcutParserTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 /*
  * Go! AOP framework
  *

--- a/tests/Go/Aop/Pointcut/SignaturePointcutTest.php
+++ b/tests/Go/Aop/Pointcut/SignaturePointcutTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 /*
  * Go! AOP framework
  *

--- a/tests/Go/Aop/Support/AndPointFilterTest.php
+++ b/tests/Go/Aop/Support/AndPointFilterTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 /*
  * Go! AOP framework
  *

--- a/tests/Go/Aop/Support/AndPointFilterTest.php
+++ b/tests/Go/Aop/Support/AndPointFilterTest.php
@@ -51,11 +51,11 @@ class AndPointFilterTest extends \PHPUnit_Framework_TestCase
     {
         $true  = TruePointFilter::getInstance();
         $false = new NotPointFilter($true);
-        return array(
-            array($false, $false, false),
-            array($false, $true, false),
-            array($true, $false, false),
-            array($true, $true, true)
-        );
+        return [
+            [$false, $false, false],
+            [$false, $true, false],
+            [$true, $false, false],
+            [$true, $true, true]
+        ];
     }
 }

--- a/tests/Go/Aop/Support/NotPointFilterTest.php
+++ b/tests/Go/Aop/Support/NotPointFilterTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 /*
  * Go! AOP framework
  *

--- a/tests/Go/Aop/Support/NotPointFilterTest.php
+++ b/tests/Go/Aop/Support/NotPointFilterTest.php
@@ -30,9 +30,9 @@ class NotPointFilterTest extends \PHPUnit_Framework_TestCase
     {
         $true  = TruePointFilter::getInstance();
         $false = new NotPointFilter($true);
-        return array(
-            array($false, true),
-            array($true, false)
-        );
+        return [
+            [$false, true],
+            [$true, false]
+        ];
     }
 }

--- a/tests/Go/Aop/Support/OrPointFilterTest.php
+++ b/tests/Go/Aop/Support/OrPointFilterTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 /*
  * Go! AOP framework
  *

--- a/tests/Go/Aop/Support/OrPointFilterTest.php
+++ b/tests/Go/Aop/Support/OrPointFilterTest.php
@@ -51,11 +51,11 @@ class OrPointFilterTest extends \PHPUnit_Framework_TestCase
     {
         $true  = TruePointFilter::getInstance();
         $false = new NotPointFilter($true);
-        return array(
-            array($false, $false, false),
-            array($false, $true, true),
-            array($true, $false, true),
-            array($true, $true, true)
-        );
+        return [
+            [$false, $false, false],
+            [$false, $true, true],
+            [$true, $false, true],
+            [$true, $true, true]
+        ];
     }
 }

--- a/tests/Go/Aop/Support/TruePointFilterTest.php
+++ b/tests/Go/Aop/Support/TruePointFilterTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 /*
  * Go! AOP framework
  *

--- a/tests/Go/Console/Command/CacheWarmupCommandTest.php
+++ b/tests/Go/Console/Command/CacheWarmupCommandTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 
 namespace Go\Console\Command;
 

--- a/tests/Go/Console/Command/DebugAdvisorCommandTest.php
+++ b/tests/Go/Console/Command/DebugAdvisorCommandTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 
 namespace Go\Console\Command;
 

--- a/tests/Go/Console/Command/DebugAspectCommandTest.php
+++ b/tests/Go/Console/Command/DebugAspectCommandTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 
 namespace Go\Console\Command;
 

--- a/tests/Go/Core/AdviceMatcherTest.php
+++ b/tests/Go/Core/AdviceMatcherTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 
 namespace Go\Core;
 

--- a/tests/Go/Core/AdviceMatcherTest.php
+++ b/tests/Go/Core/AdviceMatcherTest.php
@@ -42,7 +42,7 @@ class AdviceMatcherTest extends TestCase
             ->setConstructorArgs([$container, $reader])
             ->getMock();
 
-        $this->adviceMatcher = new AdviceMatcher($loader, $container);
+        $this->adviceMatcher = new AdviceMatcher($loader);
 
         $reflectionFile        = new ReflectionFile(__FILE__);
         $this->reflectionClass = $reflectionFile->getFileNamespace(__NAMESPACE__)->getClass(__CLASS__);
@@ -84,7 +84,7 @@ class AdviceMatcherTest extends TestCase
         $advice = $this->createMock(Advice::class);
         $advisor = new DefaultPointcutAdvisor($pointcut, $advice);
 
-        $advices = $this->adviceMatcher->getAdvicesForClass($this->reflectionClass, [$advisor]);
+        $advices = $this->adviceMatcher->getAdvicesForClass($this->reflectionClass, ['advisor' => $advisor]);
         $this->assertArrayHasKey(AspectContainer::METHOD_PREFIX, $advices);
         $this->assertArrayHasKey($funcName, $advices[AspectContainer::METHOD_PREFIX]);
         $this->assertCount(1, $advices[AspectContainer::METHOD_PREFIX]);
@@ -116,7 +116,7 @@ class AdviceMatcherTest extends TestCase
         $advice = $this->createMock(Advice::class);
         $advisor = new DefaultPointcutAdvisor($pointcut, $advice);
 
-        $advices = $this->adviceMatcher->getAdvicesForClass($this->reflectionClass, [$advisor]);
+        $advices = $this->adviceMatcher->getAdvicesForClass($this->reflectionClass, ['advisor' => $advisor]);
         $this->assertArrayHasKey(AspectContainer::PROPERTY_PREFIX, $advices);
         $this->assertArrayHasKey($propName, $advices[AspectContainer::PROPERTY_PREFIX]);
         $this->assertCount(1, $advices[AspectContainer::PROPERTY_PREFIX]);

--- a/tests/Go/Core/AdviceMatcherTest.php
+++ b/tests/Go/Core/AdviceMatcherTest.php
@@ -37,7 +37,7 @@ class AdviceMatcherTest extends TestCase
     {
         $container = $this->createMock(AspectContainer::class);
         $reader    = $this->createMock(Reader::class);
-        $loader    = $this->getMockBuilder(AspectLoader::class)->setConstructorArgs(array($container, $reader))->getMock();
+        $loader    = $this->getMockBuilder(AspectLoader::class)->setConstructorArgs([$container, $reader])->getMock();
 
         $this->adviceMatcher = new AdviceMatcher($loader, $container);
 
@@ -81,7 +81,7 @@ class AdviceMatcherTest extends TestCase
         $advice = $this->createMock(Advice::class);
         $advisor = new DefaultPointcutAdvisor($pointcut, $advice);
 
-        $advices = $this->adviceMatcher->getAdvicesForClass($this->reflectionClass, array($advisor));
+        $advices = $this->adviceMatcher->getAdvicesForClass($this->reflectionClass, [$advisor]);
         $this->assertArrayHasKey(AspectContainer::METHOD_PREFIX, $advices);
         $this->assertArrayHasKey($funcName, $advices[AspectContainer::METHOD_PREFIX]);
         $this->assertCount(1, $advices[AspectContainer::METHOD_PREFIX]);
@@ -113,7 +113,7 @@ class AdviceMatcherTest extends TestCase
         $advice = $this->createMock(Advice::class);
         $advisor = new DefaultPointcutAdvisor($pointcut, $advice);
 
-        $advices = $this->adviceMatcher->getAdvicesForClass($this->reflectionClass, array($advisor));
+        $advices = $this->adviceMatcher->getAdvicesForClass($this->reflectionClass, [$advisor]);
         $this->assertArrayHasKey(AspectContainer::PROPERTY_PREFIX, $advices);
         $this->assertArrayHasKey($propName, $advices[AspectContainer::PROPERTY_PREFIX]);
         $this->assertCount(1, $advices[AspectContainer::PROPERTY_PREFIX]);

--- a/tests/Go/Core/AdviceMatcherTest.php
+++ b/tests/Go/Core/AdviceMatcherTest.php
@@ -37,7 +37,10 @@ class AdviceMatcherTest extends TestCase
     {
         $container = $this->createMock(AspectContainer::class);
         $reader    = $this->createMock(Reader::class);
-        $loader    = $this->getMockBuilder(AspectLoader::class)->setConstructorArgs([$container, $reader])->getMock();
+        $loader    = $this
+            ->getMockBuilder(AspectLoader::class)
+            ->setConstructorArgs([$container, $reader])
+            ->getMock();
 
         $this->adviceMatcher = new AdviceMatcher($loader, $container);
 

--- a/tests/Go/Core/GoAspectContainerTest.php
+++ b/tests/Go/Core/GoAspectContainerTest.php
@@ -35,13 +35,13 @@ class GoAspectContainerTest extends TestCase
 
     public function internalServicesList()
     {
-        return array(
-            array('aspect.loader'),
-            array('aspect.advice_matcher'),
-            array('aspect.annotation.reader'),
-            array('aspect.pointcut.lexer'),
-            array('aspect.pointcut.parser'),
-        );
+        return [
+            ['aspect.loader'],
+            ['aspect.advice_matcher'],
+            ['aspect.annotation.reader'],
+            ['aspect.pointcut.lexer'],
+            ['aspect.pointcut.parser'],
+        ];
     }
 
     /**
@@ -55,7 +55,7 @@ class GoAspectContainerTest extends TestCase
         $this->assertSame($pointcut, $this->container->getPointcut('test'));
         // Verify that tag is working
         $pointcuts = $this->container->getByTag('pointcut');
-        $this->assertSame(array('pointcut.test' => $pointcut), $pointcuts);
+        $this->assertSame(['pointcut.test' => $pointcut], $pointcuts);
     }
 
     /**
@@ -68,7 +68,7 @@ class GoAspectContainerTest extends TestCase
 
         // Verify that tag is working
         $advisors = $this->container->getByTag('advisor');
-        $this->assertSame(array('advisor.test' => $advisor), $advisors);
+        $this->assertSame(['advisor.test' => $advisor], $advisors);
     }
 
     /**
@@ -84,7 +84,7 @@ class GoAspectContainerTest extends TestCase
         $this->assertSame($aspect, $this->container->getAspect($aspectClass));
         // Verify that tag is working
         $aspects = $this->container->getByTag('aspect');
-        $this->assertSame(array("aspect.{$aspectClass}" => $aspect), $aspects);
+        $this->assertSame(["aspect.{$aspectClass}" => $aspect], $aspects);
     }
 
     /**

--- a/tests/Go/Core/GoAspectContainerTest.php
+++ b/tests/Go/Core/GoAspectContainerTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 
 namespace Go\Core;
 

--- a/tests/Go/Instrument/FileSystem/EnumeratorTest.php
+++ b/tests/Go/Instrument/FileSystem/EnumeratorTest.php
@@ -1,9 +1,8 @@
 <?php
 declare(strict_types = 1);
 
-namespace Go\Instrument;
+namespace Go\Instrument\FileSystem;
 
-use Go\Instrument\FileSystem\Enumerator;
 use Vfs\FileSystem;
 
 class EnumeratorTest extends \PHPUnit_Framework_TestCase

--- a/tests/Go/Instrument/FileSystem/EnumeratorTest.php
+++ b/tests/Go/Instrument/FileSystem/EnumeratorTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 
 namespace Go\Instrument;
 

--- a/tests/Go/Instrument/PathResolverTest.php
+++ b/tests/Go/Instrument/PathResolverTest.php
@@ -20,7 +20,7 @@ class PathResolverTest extends \PHPUnit_Framework_TestCase
      */
     public function testCanResolveArray()
     {
-        $this->assertEquals(array(__DIR__ , __FILE__), PathResolver::realpath(array(__DIR__ , __FILE__)));
+        $this->assertEquals([__DIR__ , __FILE__], PathResolver::realpath([__DIR__ , __FILE__]));
     }
 
     /**
@@ -35,10 +35,10 @@ class PathResolverTest extends \PHPUnit_Framework_TestCase
     {
         // Trick to get scheme name and path in one action. If no scheme, then there will be only one part
         $components = explode('://', $expected, 2);
-        list ($pathScheme, $localPath) = isset($components[1]) ? $components : array(null, $components[0]);
+        list ($pathScheme, $localPath) = isset($components[1]) ? $components : [null, $components[0]];
 
         // resolve path parts (single dot, double dot and double delimiters)
-        $localPath  = str_replace(array('/', '\\'), DIRECTORY_SEPARATOR, $localPath);
+        $localPath  = str_replace(['/', '\\'], DIRECTORY_SEPARATOR, $localPath);
         if ($pathScheme) {
             $localPath = "$pathScheme://$localPath";
         }
@@ -57,22 +57,22 @@ class PathResolverTest extends \PHPUnit_Framework_TestCase
         $curDir = getcwd();
         $parent = dirname($curDir);
 
-        return array(
-            array('/some/absolute/file' , '/some/absolute/file'),
-            array('/some/absolute/file/../points/' , '/some/absolute/points/'),
-            array('/some/./point.php' , '/some/point.php'),
+        return [
+            ['/some/absolute/file' , '/some/absolute/file'],
+            ['/some/absolute/file/../points/' , '/some/absolute/points/'],
+            ['/some/./point.php' , '/some/point.php'],
 
-            array('relative/to/the/dir' , "$curDir/relative/to/the/dir"),
-            array('../relative/filename' , "$parent/relative/filename"),
-            array('./point/file' , "$curDir/point/file"),
+            ['relative/to/the/dir' , "$curDir/relative/to/the/dir"],
+            ['../relative/filename' , "$parent/relative/filename"],
+            ['./point/file' , "$curDir/point/file"],
 
-            array('C:\\Windows\\..\\filename', 'C:\\filename'),
+            ['C:\\Windows\\..\\filename', 'C:\\filename'],
 
-            array('http://localhost/file.name' , 'http://localhost/file.name'),
-            array('http://localhost/some/../relative.file' , 'http://localhost/relative.file'),
+            ['http://localhost/file.name' , 'http://localhost/file.name'],
+            ['http://localhost/some/../relative.file' , 'http://localhost/relative.file'],
 
-            array('phar://go.phar/some/path' , 'phar://go.phar/some/path'),
-            array('phar://go.phar/some/../relative.file' , 'phar://go.phar/relative.file'),
-        );
+            ['phar://go.phar/some/path' , 'phar://go.phar/some/path'],
+            ['phar://go.phar/some/../relative.file' , 'phar://go.phar/relative.file'],
+        ];
     }
 }

--- a/tests/Go/Instrument/PathResolverTest.php
+++ b/tests/Go/Instrument/PathResolverTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 
 namespace Go\Instrument;
 

--- a/tests/Go/Instrument/Transformer/ConstructorExecutionTransformerTest.php
+++ b/tests/Go/Instrument/Transformer/ConstructorExecutionTransformerTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 
 namespace Go\Instrument\Transformer;
 

--- a/tests/Go/Instrument/Transformer/ConstructorExecutionTransformerTest.php
+++ b/tests/Go/Instrument/Transformer/ConstructorExecutionTransformerTest.php
@@ -41,59 +41,59 @@ class ConstructorExecutionTransformerTest extends \PHPUnit_Framework_TestCase
 
     public function listOfExpressions()
     {
-        return array(
-            array(
+        return [
+            [
                 '$a = new stdClass',
                 '$a = \Go\Instrument\Transformer\ConstructorExecutionTransformer::getInstance()->{ stdClass::class}'
-            ),
-            array(
+            ],
+            [
                 '$b = new stdClass()',
                 '$b = \Go\Instrument\Transformer\ConstructorExecutionTransformer::getInstance()->{ stdClass::class}()'
-            ),
-            array(
+            ],
+            [
                 '$stdClass = "stdClass"; $c = new $stdClass',
                 '$stdClass = "stdClass"; $c = \Go\Instrument\Transformer\ConstructorExecutionTransformer::getInstance()->{ $stdClass}'
-            ),
-            array(
+            ],
+            [
                 '$stdClass = "stdClass"; $d = new $stdClass()',
                 '$stdClass = "stdClass"; $d = \Go\Instrument\Transformer\ConstructorExecutionTransformer::getInstance()->{ $stdClass}()'
-            ),
-            array(
+            ],
+            [
                 '$e = new \Exception',
                 '$e = \Go\Instrument\Transformer\ConstructorExecutionTransformer::getInstance()->{ \Exception::class}'
-            ),
-            array(
+            ],
+            [
                 '$f = new \Exception("Test")',
                 '$f = \Go\Instrument\Transformer\ConstructorExecutionTransformer::getInstance()->{ \Exception::class}("Test")'
-            ),
-            array(
+            ],
+            [
                 '$g = new self',
                 '$g = \Go\Instrument\Transformer\ConstructorExecutionTransformer::getInstance()->{ self::class}',
-            ),
-            array(
+            ],
+            [
                 '$h = new static()',
                 '$h = \Go\Instrument\Transformer\ConstructorExecutionTransformer::getInstance()->{ static::class}()'
-            ),
-            array(
+            ],
+            [
                 '$j = new self::$stdClass()',
                 '$j = \Go\Instrument\Transformer\ConstructorExecutionTransformer::getInstance()->{ self::$stdClass}()'
-            ),
-            array(
+            ],
+            [
                 '$k = new static::$exception["Exception"]("Test")',
                 '$k = \Go\Instrument\Transformer\ConstructorExecutionTransformer::getInstance()->{ static::$exception["Exception"]}("Test")'
-            ),
-            array(
+            ],
+            [
                 '$l = new self::$object[0]->name("Test Message")',
                 '$l = \Go\Instrument\Transformer\ConstructorExecutionTransformer::getInstance()->{ self::$object[0]->name}("Test Message")'
-            ),
-            array(
+            ],
+            [
                 '$m = new static::$object[0]->name',
                 '$m = \Go\Instrument\Transformer\ConstructorExecutionTransformer::getInstance()->{ static::$object[0]->name}'
-            ),
-            array(
+            ],
+            [
                 '$n = new stdClass(new static::$object[0]->name)',
                 '$n = \Go\Instrument\Transformer\ConstructorExecutionTransformer::getInstance()->{ stdClass::class}(\Go\Instrument\Transformer\ConstructorExecutionTransformer::getInstance()->{ static::$object[0]->name})'
-            )
-        );
+            ]
+        ];
     }
 }

--- a/tests/Go/Instrument/Transformer/FilterInjectorTransformerTest.php
+++ b/tests/Go/Instrument/Transformer/FilterInjectorTransformerTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 
 namespace Go\Instrument\Transformer;
 

--- a/tests/Go/Instrument/Transformer/FilterInjectorTransformerTest.php
+++ b/tests/Go/Instrument/Transformer/FilterInjectorTransformerTest.php
@@ -37,11 +37,6 @@ class FilterInjectorTransformerTest extends \PHPUnit_Framework_TestCase
                 ],
                 $this->createMock(GoAspectContainer::class)
             );
-            self::$transformer = new FilterInjectorTransformer(
-                $kernelMock,
-                'unit.test',
-                $this->getMockBuilder(CachePathManager::class)->setConstructorArgs([$kernelMock])->getMock()
-            );
             $cachePathManager = $this
                 ->getMockBuilder(CachePathManager::class)
                 ->setConstructorArgs([$kernelMock])

--- a/tests/Go/Instrument/Transformer/FilterInjectorTransformerTest.php
+++ b/tests/Go/Instrument/Transformer/FilterInjectorTransformerTest.php
@@ -42,6 +42,11 @@ class FilterInjectorTransformerTest extends \PHPUnit_Framework_TestCase
                 'unit.test',
                 $this->getMockBuilder(CachePathManager::class)->setConstructorArgs([$kernelMock])->getMock()
             );
+            $cachePathManager = $this
+                ->getMockBuilder(CachePathManager::class)
+                ->setConstructorArgs([$kernelMock])
+                ->getMock();
+            self::$transformer = new FilterInjectorTransformer($kernelMock, 'unit.test', $cachePathManager);
         }
         $stream = fopen('php://input', 'r');
         $this->metadata = new StreamMetaData($stream);

--- a/tests/Go/Instrument/Transformer/FilterInjectorTransformerTest.php
+++ b/tests/Go/Instrument/Transformer/FilterInjectorTransformerTest.php
@@ -28,19 +28,19 @@ class FilterInjectorTransformerTest extends \PHPUnit_Framework_TestCase
     {
         if (!self::$transformer) {
             $kernelMock = $this->getKernelMock(
-                array(
+                [
                     'cacheDir'      => null,
                     'cacheFileMode' => 0770,
                     'appDir'        => '',
                     'debug'         => false,
                     'features'      => 0
-                ),
+                ],
                 $this->createMock(GoAspectContainer::class)
             );
             self::$transformer = new FilterInjectorTransformer(
                 $kernelMock,
                 'unit.test',
-                $this->getMockBuilder(CachePathManager::class)->setConstructorArgs(array($kernelMock))->getMock()
+                $this->getMockBuilder(CachePathManager::class)->setConstructorArgs([$kernelMock])->getMock()
             );
         }
         $stream = fopen('php://input', 'r');
@@ -62,7 +62,7 @@ class FilterInjectorTransformerTest extends \PHPUnit_Framework_TestCase
             false,
             true,
             true,
-            array('getOptions', 'getContainer')
+            ['getOptions', 'getContainer']
         );
         $mock->expects($this->any())
             ->method('getOptions')

--- a/tests/Go/Instrument/Transformer/MagicConstantTransformerTest.php
+++ b/tests/Go/Instrument/Transformer/MagicConstantTransformerTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 
 namespace Go\Instrument\Transformer;
 

--- a/tests/Go/Instrument/Transformer/MagicConstantTransformerTest.php
+++ b/tests/Go/Instrument/Transformer/MagicConstantTransformerTest.php
@@ -25,10 +25,10 @@ class MagicConstantTransformerTest extends \PHPUnit_Framework_TestCase
     public function setUp()
     {
         $this->transformer = new MagicConstantTransformer(
-            $this->getKernelMock(array(
+            $this->getKernelMock([
                 'cacheDir' => __DIR__,
                 'appDir'   => dirname(__DIR__),
-            ))
+            ])
         );
 
         if (defined("HHVM_VERSION")) {
@@ -56,7 +56,7 @@ class MagicConstantTransformerTest extends \PHPUnit_Framework_TestCase
             false,
             true,
             true,
-            array('getOptions')
+            ['getOptions']
         );
         $mock->expects($this->any())
             ->method('getOptions')

--- a/tests/Go/Instrument/Transformer/MagicConstantTransformerTest.php
+++ b/tests/Go/Instrument/Transformer/MagicConstantTransformerTest.php
@@ -3,6 +3,7 @@ declare(strict_types = 1);
 
 namespace Go\Instrument\Transformer;
 
+use Go\Core\AspectContainer;
 use Go\Core\AspectKernel;
 use Go\Instrument\Transformer\MagicConstantTransformer;
 use Go\Instrument\Transformer\StreamMetaData;
@@ -56,13 +57,19 @@ class MagicConstantTransformerTest extends \PHPUnit_Framework_TestCase
             false,
             true,
             true,
-            ['getOptions']
+            ['getOptions', 'getContainer']
         );
         $mock->expects($this->any())
             ->method('getOptions')
             ->will(
                 $this->returnValue($options)
             );
+        $mock->expects($this->any())
+            ->method('getContainer')
+            ->will(
+                $this->returnValue($this->createMock(AspectContainer::class))
+            );
+
         return $mock;
     }
 

--- a/tests/Go/Instrument/Transformer/WeavingTransformerTest.php
+++ b/tests/Go/Instrument/Transformer/WeavingTransformerTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 
 namespace Go\Instrument\Transformer;
 

--- a/tests/Go/Instrument/Transformer/WeavingTransformerTest.php
+++ b/tests/Go/Instrument/Transformer/WeavingTransformerTest.php
@@ -28,13 +28,21 @@ class WeavingTransformerTest extends \PHPUnit_Framework_TestCase
     protected $adviceMatcher = null;
 
     /**
+     * @var null|CachePathManager|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $cachePathManager = null;
+
+    /**
      * {@inheritDoc}
      */
     public function setUp()
     {
         $container = $this->getContainerMock();
         $reader    = $this->createMock(Reader::class);
-        $loader    = $this->getMockBuilder(AspectLoader::class)->setConstructorArgs([$container, $reader])->getMock();
+        $loader    = $this
+            ->getMockBuilder(AspectLoader::class)
+            ->setConstructorArgs([$container, $reader])
+            ->getMock();
 
         $this->adviceMatcher = $this->getAdviceMatcherMock();
         $this->kernel        = $this->getKernelMock(
@@ -47,11 +55,15 @@ class WeavingTransformerTest extends \PHPUnit_Framework_TestCase
             ],
             $container
         );
+        $this->cachePathManager = $this
+            ->getMockBuilder(CachePathManager::class)
+            ->setConstructorArgs([$this->kernel])
+            ->getMock();
 
         $this->transformer = new WeavingTransformer(
             $this->kernel,
             $this->adviceMatcher,
-            $this->getMockBuilder(CachePathManager::class)->setConstructorArgs([$this->kernel])->getMock(),
+            $this->cachePathManager,
             $loader
         );
     }
@@ -157,7 +169,10 @@ class WeavingTransformerTest extends \PHPUnit_Framework_TestCase
     {
         $container = $this->getContainerMock();
         $reader    = $this->createMock(Reader::class);
-        $loader    = $this->getMockBuilder(AspectLoader::class)->setConstructorArgs([$container, $reader])->getMock();
+        $loader    = $this
+            ->getMockBuilder(AspectLoader::class)
+            ->setConstructorArgs([$container, $reader])
+            ->getMock();
 
         $this->transformer = new WeavingTransformer(
             $this->getKernelMock(
@@ -169,7 +184,7 @@ class WeavingTransformerTest extends \PHPUnit_Framework_TestCase
                 $container
             ),
             $this->adviceMatcher,
-            $this->getMockBuilder(CachePathManager::class)->setConstructorArgs([$this->kernel])->getMock(),
+            $this->cachePathManager,
             $loader
         );
         $metadata = $this->loadTest('class');
@@ -249,7 +264,7 @@ class WeavingTransformerTest extends \PHPUnit_Framework_TestCase
      */
     protected function getAdviceMatcherMock()
     {
-        $mock = $this->createMock(AdviceMatcher::class);
+        $mock = $this->createPartialMock(AdviceMatcher::class, ['getAdvicesForClass']);
         $mock->expects($this->any())
             ->method('getAdvicesForClass')
             ->will(
@@ -293,7 +308,7 @@ class WeavingTransformerTest extends \PHPUnit_Framework_TestCase
     /**
      * Returns a mock for the container
      *
-     * @return AspectContainer
+     * @return AspectContainer|\PHPUnit_Framework_MockObject_MockObject
      */
     private function getContainerMock()
     {

--- a/tests/Go/Instrument/Transformer/WeavingTransformerTest.php
+++ b/tests/Go/Instrument/Transformer/WeavingTransformerTest.php
@@ -34,24 +34,24 @@ class WeavingTransformerTest extends \PHPUnit_Framework_TestCase
     {
         $container = $this->getContainerMock();
         $reader    = $this->createMock(Reader::class);
-        $loader    = $this->getMockBuilder(AspectLoader::class)->setConstructorArgs(array($container, $reader))->getMock();
+        $loader    = $this->getMockBuilder(AspectLoader::class)->setConstructorArgs([$container, $reader])->getMock();
 
         $this->adviceMatcher = $this->getAdviceMatcherMock();
         $this->kernel        = $this->getKernelMock(
-            array(
+            [
                 'appDir'        => dirname(__DIR__),
                 'cacheDir'      => null,
                 'cacheFileMode' => 0770,
                 'includePaths'  => [],
                 'excludePaths'  => []
-            ),
+            ],
             $container
         );
 
         $this->transformer = new WeavingTransformer(
             $this->kernel,
             $this->adviceMatcher,
-            $this->getMockBuilder(CachePathManager::class)->setConstructorArgs(array($this->kernel))->getMock(),
+            $this->getMockBuilder(CachePathManager::class)->setConstructorArgs([$this->kernel])->getMock(),
             $loader
         );
     }
@@ -157,19 +157,19 @@ class WeavingTransformerTest extends \PHPUnit_Framework_TestCase
     {
         $container = $this->getContainerMock();
         $reader    = $this->createMock(Reader::class);
-        $loader    = $this->getMockBuilder(AspectLoader::class)->setConstructorArgs(array($container, $reader))->getMock();
+        $loader    = $this->getMockBuilder(AspectLoader::class)->setConstructorArgs([$container, $reader])->getMock();
 
         $this->transformer = new WeavingTransformer(
             $this->getKernelMock(
-                array(
+                [
                     'appDir'       => dirname(__DIR__),
-                    'includePaths' => array(__DIR__),
+                    'includePaths' => [__DIR__],
                     'excludePaths' => []
-                ),
+                ],
                 $container
             ),
             $this->adviceMatcher,
-            $this->getMockBuilder(CachePathManager::class)->setConstructorArgs(array($this->kernel))->getMock(),
+            $this->getMockBuilder(CachePathManager::class)->setConstructorArgs([$this->kernel])->getMock(),
             $loader
         );
         $metadata = $this->loadTest('class');
@@ -203,10 +203,10 @@ class WeavingTransformerTest extends \PHPUnit_Framework_TestCase
     {
         return strtr(
             preg_replace('/\s+$/m', '', $value),
-            array(
+            [
                 "\r\n" => PHP_EOL,
                 "\n"   => PHP_EOL,
-            )
+            ]
         );
     }
 
@@ -226,7 +226,7 @@ class WeavingTransformerTest extends \PHPUnit_Framework_TestCase
             false,
             true,
             true,
-            array('getOptions', 'getContainer', 'hasFeature')
+            ['getOptions', 'getContainer', 'hasFeature']
         );
         $mock->expects($this->any())
             ->method('getOptions')
@@ -254,7 +254,7 @@ class WeavingTransformerTest extends \PHPUnit_Framework_TestCase
             ->method('getAdvicesForClass')
             ->will(
                 $this->returnCallback(function (\ReflectionClass $refClass) {
-                    $advices  = array();
+                    $advices  = [];
                     foreach ($refClass->getMethods() as $method) {
                         $advisorId = "advisor.{$refClass->name}->{$method->name}";
                         $advices[AspectContainer::METHOD_PREFIX][$method->name][$advisorId] = true;
@@ -302,9 +302,9 @@ class WeavingTransformerTest extends \PHPUnit_Framework_TestCase
         $container
             ->expects($this->any())
             ->method('getByTag')
-            ->will($this->returnValueMap(array(
-                array('advisor', [])
-            )));
+            ->will($this->returnValueMap([
+                ['advisor', []]
+            ]));
 
         return $container;
     }

--- a/tests/Go/Instrument/Transformer/_files/aspect.php
+++ b/tests/Go/Instrument/Transformer/_files/aspect.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 namespace Test\ns1 {
     use Go\Aop\Aspect;
 

--- a/tests/Go/Instrument/Transformer/_files/class-woven.php
+++ b/tests/Go/Instrument/Transformer/_files/class-woven.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 namespace Test\ns1;
 
 class TestClass__AopProxied {

--- a/tests/Go/Instrument/Transformer/_files/class.php
+++ b/tests/Go/Instrument/Transformer/_files/class.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 namespace Test\ns1;
 
 class TestClass {

--- a/tests/Go/Instrument/Transformer/_files/empty-classes.php
+++ b/tests/Go/Instrument/Transformer/_files/empty-classes.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 // Just some global code
 if (true) {
     function emptyNsFunction()

--- a/tests/Go/Instrument/Transformer/_files/final-class-woven.php
+++ b/tests/Go/Instrument/Transformer/_files/final-class-woven.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 namespace Test\ns1;
 
 class TestFinalClass__AopProxied {

--- a/tests/Go/Instrument/Transformer/_files/final-class.php
+++ b/tests/Go/Instrument/Transformer/_files/final-class.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 namespace Test\ns1;
 
 final class TestFinalClass {

--- a/tests/Go/Instrument/Transformer/_files/interface.php
+++ b/tests/Go/Instrument/Transformer/_files/interface.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 namespace Test\ns1 {
 
     interface TestInterface {}

--- a/tests/Go/Instrument/Transformer/_files/multiple-classes-woven.php
+++ b/tests/Go/Instrument/Transformer/_files/multiple-classes-woven.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 
 namespace Test\ns3;
 

--- a/tests/Go/Instrument/Transformer/_files/multiple-classes.php
+++ b/tests/Go/Instrument/Transformer/_files/multiple-classes.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 
 namespace Test\ns3;
 

--- a/tests/Go/Instrument/Transformer/_files/multiple-ns-woven.php
+++ b/tests/Go/Instrument/Transformer/_files/multiple-ns-woven.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 namespace Test\ns1 {
     class TestClass1__AopProxied {
         public static function test() {}

--- a/tests/Go/Instrument/Transformer/_files/multiple-ns.php
+++ b/tests/Go/Instrument/Transformer/_files/multiple-ns.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 namespace Test\ns1 {
     class TestClass1 {
         public static function test() {}

--- a/tests/Go/Instrument/Transformer/_files/php7-class-woven.php
+++ b/tests/Go/Instrument/Transformer/_files/php7-class-woven.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 namespace Test\ns1;
 class TestPhp7Class__AopProxied
 {

--- a/tests/Go/Instrument/Transformer/_files/php7-class.php
+++ b/tests/Go/Instrument/Transformer/_files/php7-class.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 namespace Test\ns1;
 
 class TestPhp7Class

--- a/tests/Go/Instrument/Transformer/_files/yii_style.php
+++ b/tests/Go/Instrument/Transformer/_files/yii_style.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 
 include($class->method('filename'));
 include_once($class->method('filename'));

--- a/tests/Go/Instrument/Transformer/_files/yii_style_output.php
+++ b/tests/Go/Instrument/Transformer/_files/yii_style_output.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 
 include \Go\Instrument\Transformer\FilterInjectorTransformer::rewrite(($class->method('filename')), __DIR__);
 include_once \Go\Instrument\Transformer\FilterInjectorTransformer::rewrite(($class->method('filename')), __DIR__);

--- a/tests/Go/Stubs/BaseInterceptorMock.php
+++ b/tests/Go/Stubs/BaseInterceptorMock.php
@@ -25,11 +25,11 @@ class BaseInterceptorMock extends BaseInterceptor
      */
     public static function serializeAdvice(\Closure $adviceMethod)
     {
-        return array(
+        return [
             'scope'  => 'aspect',
             'method' => 'Go\Aop\Framework\{closure}',
             'aspect' => 'Go\Aop\Framework\BaseInterceptorTest'
-        );
+        ];
     }
 
     /**

--- a/tests/Go/Stubs/BaseInterceptorMock.php
+++ b/tests/Go/Stubs/BaseInterceptorMock.php
@@ -3,9 +3,9 @@ declare(strict_types = 1);
 
 namespace Go\Stubs;
 
+use Closure;
 use Go\Aop\Framework\BaseInterceptor;
 use Go\Aop\Intercept\Joinpoint;
-use Go\Aop\Pointcut;
 
 class BaseInterceptorMock extends BaseInterceptor
 {
@@ -23,7 +23,7 @@ class BaseInterceptorMock extends BaseInterceptor
     /**
      * {@inheritdoc}
      */
-    public static function serializeAdvice(\Closure $adviceMethod)
+    public static function serializeAdvice(Closure $adviceMethod) : array
     {
         return [
             'scope'  => 'aspect',
@@ -35,7 +35,7 @@ class BaseInterceptorMock extends BaseInterceptor
     /**
      * {@inheritdoc}
      */
-    public static function unserializeAdvice(array $adviceData)
+    public static function unserializeAdvice(array $adviceData) : Closure
     {
         return self::$advice;
     }

--- a/tests/Go/Stubs/BaseInterceptorMock.php
+++ b/tests/Go/Stubs/BaseInterceptorMock.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 
 namespace Go\Stubs;
 

--- a/tests/Go/Stubs/First.php
+++ b/tests/Go/Stubs/First.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 
 namespace Go\Stubs;
 

--- a/tests/Go/Stubs/FirstStatic.php
+++ b/tests/Go/Stubs/FirstStatic.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 
 namespace Go\Stubs;
 

--- a/tests/Go/Stubs/FirstStatic.php
+++ b/tests/Go/Stubs/FirstStatic.php
@@ -20,6 +20,6 @@ class FirstStatic extends First
     // Recursion test
     public static function staticLsbRecursion($value, $level = 0)
     {
-        return static::$invocation->__invoke(__CLASS__, array($value, $level));
+        return static::$invocation->__invoke(__CLASS__, [$value, $level]);
     }
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -8,6 +8,6 @@ declare(strict_types = 1);
  * This source file is subject to the license that is bundled
  * with this source code in the file LICENSE.
  */
-ini_set('display_errors', 1);
+ini_set('display_errors', 'on');
 
 include __DIR__ . '/../vendor/autoload.php';

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 /*
  * Go! AOP framework
  *


### PR DESCRIPTION
Time to move to the new codebase and prepare for 3.0 which will require PHP>=7.0 to run. This includes strict typing in the engine, scalar and return typehints and more cleaner code.