### PR TITLE
fnmatch bugfix when used on Windows

### DIFF
--- a/src/Instrument/FileSystem/Enumerator.php
+++ b/src/Instrument/FileSystem/Enumerator.php
@@ -97,7 +97,7 @@ class Enumerator
             if (!empty($includePaths)) {
                 $found = false;
                 foreach ($includePaths as $includePattern) {
-                    if (fnmatch("{$includePattern}*", $fullPath)) {
+                    if (fnmatch("{$includePattern}*", $fullPath, FNM_NOESCAPE)) {
                         $found = true;
                         break;
                     }
@@ -108,7 +108,7 @@ class Enumerator
             }
 
             foreach ($excludePaths as $excludePattern) {
-                if (fnmatch("{$excludePattern}*", $fullPath)) {
+                if (fnmatch("{$excludePattern}*", $fullPath, FNM_NOESCAPE)) {
                     return false;
                 }
             }


### PR DESCRIPTION
@lisachenko 
Windows has pathes like c:\projects\....
If a path contains backslashes fnmatch will fail.