### PR TITLE
Fixed #330 - commands are modified, they can be owerwritten now

### DIFF
--- a/src/Console/Command/BaseAspectCommand.php
+++ b/src/Console/Command/BaseAspectCommand.php
@@ -37,16 +37,26 @@ class BaseAspectCommand extends Command
     }
 
     /**
-     * {@inheritDoc}
+     * Loads aspect kernel.
+     *
+     * Aspect kernel is loaded by executing loader and fetching singleton instance.
+     * If your application environment initializes aspect kernel differently, you may
+     * modify this metod to get aspect kernel suitable to your needs.
+     *
+     * @param InputInterface $input
+     * @param OutputInterface $output
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function loadAspectKernel(InputInterface $input, OutputInterface $output)
     {
         $loader = $input->getArgument('loader');
         $path   = stream_resolve_include_path($loader);
         if (!is_readable($path)) {
             throw new \InvalidArgumentException("Invalid loader path: {$loader}");
         }
+
+        ob_start();
         include_once $path;
+        ob_clean();
 
         if (!class_exists(AspectKernel::class, false)) {
             $message = "Kernel was not initialized yet, please configure it in the {$path}";

--- a/src/Console/Command/CacheWarmupCommand.php
+++ b/src/Console/Command/CacheWarmupCommand.php
@@ -45,7 +45,8 @@ EOT
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        parent::execute($input, $output);
+        $this->loadAspectKernel($input, $output);
+
         $options = $this->aspectKernel->getOptions();
 
         if (empty($options['cacheDir'])) {

--- a/src/Console/Command/DebugAdvisorCommand.php
+++ b/src/Console/Command/DebugAdvisorCommand.php
@@ -49,7 +49,8 @@ EOT
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        parent::execute($input, $output);
+        $this->loadAspectKernel($input, $output);
+
         $io = new SymfonyStyle($input, $output);
         $io->title('Advisor debug information');
 

--- a/src/Console/Command/DebugAspectCommand.php
+++ b/src/Console/Command/DebugAspectCommand.php
@@ -46,7 +46,8 @@ EOT
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        parent::execute($input, $output);
+        $this->loadAspectKernel($input, $output);
+
         $io = new SymfonyStyle($input, $output);
 
         $container = $this->aspectKernel->getContainer();


### PR DESCRIPTION
This PR will enable us to expose commands for other frameworks (especially in Symfony).

These commands are very useful and should be available to all bridges/adapters out-of-the-box.

TODO:
    - Expose commands in Symfony AOP bundle (I can do that)
    - Expose commands in other FWs 
