### PR TITLE
Apply PHP7 type hinting to the Proxy generator classes

### DIFF
--- a/src/Proxy/AbstractProxy.php
+++ b/src/Proxy/AbstractProxy.php
@@ -67,7 +67,7 @@ abstract class AbstractProxy
      *
      * @return string Indented text
      */
-    protected function indent($text)
+    protected function indent(string $text): string
     {
         $pad   = str_pad('', $this->indent, ' ');
         $lines = array_map(function($line) use ($pad) {
@@ -82,9 +82,9 @@ abstract class AbstractProxy
      *
      * @param array|ReflectionParameter[] $parameters List of parameters
      *
-     * @return array
+     * @return array|string[]
      */
-    protected function getParameters(array $parameters)
+    protected function getParameters(array $parameters): array
     {
         $parameterDefinitions = [];
         foreach ($parameters as $parameter) {
@@ -101,24 +101,14 @@ abstract class AbstractProxy
      *
      * @return string
      */
-    protected function getParameterCode(ReflectionParameter $parameter)
+    protected function getParameterCode(ReflectionParameter $parameter): string
     {
         $type = '';
-        if (PHP_VERSION_ID >= 70000) {
-            $reflectionType = $parameter->getType();
-            if ($reflectionType) {
-                $nullablePrefix = (PHP_VERSION_ID >= 70100 && $reflectionType->allowsNull()) ? '?' : '';
-                $nsPrefix       = $reflectionType->isBuiltin() ? '' : '\\';
-                $type           = $nullablePrefix . $nsPrefix . (string) $reflectionType;
-            }
-        } else {
-            if ($parameter->isArray()) {
-                $type = 'array';
-            } elseif ($parameter->isCallable()) {
-                $type = 'callable';
-            } elseif ($parameter->getClass()) {
-                $type = '\\' . $parameter->getClass()->name;
-            }
+        $reflectionType = $parameter->getType();
+        if ($reflectionType) {
+            $nullablePrefix = (PHP_VERSION_ID >= 70100 && $reflectionType->allowsNull()) ? '?' : '';
+            $nsPrefix       = $reflectionType->isBuiltin() ? '' : '\\';
+            $type           = $nullablePrefix . $nsPrefix . (string) $reflectionType;
         }
         $defaultValue = null;
         $isDefaultValueAvailable = $parameter->isDefaultValueAvailable();
@@ -142,11 +132,11 @@ abstract class AbstractProxy
     /**
      * Replace concrete advices with list of ids
      *
-     * @param $advices
+     * @param array $advices List of advices
      *
      * @return array flatten list of advices
      */
-    private function flattenAdvices($advices)
+    private function flattenAdvices(array $advices): array
     {
         $flattenAdvices = [];
         foreach ($advices as $type => $typedAdvices) {
@@ -167,7 +157,7 @@ abstract class AbstractProxy
      *
      * @return string
      */
-    protected function prepareArgsLine(ReflectionFunctionAbstract $functionLike)
+    protected function prepareArgsLine(ReflectionFunctionAbstract $functionLike): string
     {
         $argumentsPart = [];
         $arguments     = [];
@@ -204,9 +194,9 @@ abstract class AbstractProxy
      *
      * @return string
      */
-    protected function getOverriddenFunction(ReflectionFunctionAbstract $functionLike, $body)
+    protected function getOverriddenFunction(ReflectionFunctionAbstract $functionLike, string $body): string
     {
-        $reflectionReturnType = PHP_VERSION_ID >= 70000 ? $functionLike->getReturnType() : '';
+        $reflectionReturnType = $functionLike->getReturnType();
         $modifiersLine        = '';
         if ($reflectionReturnType) {
             $nullablePrefix = $reflectionReturnType->allowsNull() ? '?' : '';

--- a/src/Proxy/FunctionProxy.php
+++ b/src/Proxy/FunctionProxy.php
@@ -78,7 +78,7 @@ class FunctionProxy extends AbstractProxy
      *
      * @return FunctionInvocation
      */
-    public static function getJoinPoint($joinPointName, $namespace)
+    public static function getJoinPoint(string $joinPointName, string $namespace): FunctionInvocation
     {
         /** @var LazyAdvisorAccessor $accessor */
         static $accessor = null;
@@ -104,10 +104,8 @@ class FunctionProxy extends AbstractProxy
      *
      * @param string $namespace Aop child proxy class
      * @param array|Advice[] $advices List of advices to inject into class
-     *
-     * @return void
      */
-    public static function injectJoinPoints($namespace, array $advices = [])
+    public static function injectJoinPoints(string $namespace, array $advices = [])
     {
         self::$functionAdvices[$namespace] = $advices;
     }
@@ -117,14 +115,10 @@ class FunctionProxy extends AbstractProxy
      *
      * @param ReflectionFunction $function Function reflection
      * @param string $body New body for function
-     *
-     * @return $this
      */
-    public function override(ReflectionFunction $function, $body)
+    public function override(ReflectionFunction $function, string $body)
     {
         $this->functionsCode[$function->name] = $this->getOverriddenFunction($function, $body);
-
-        return $this;
     }
 
     /**
@@ -156,7 +150,7 @@ class FunctionProxy extends AbstractProxy
      *
      * @return string new method body
      */
-    protected function getJoinpointInvocationBody(ReflectionFunction $function)
+    protected function getJoinpointInvocationBody(ReflectionFunction $function): string
     {
         $class = '\\' . __CLASS__;
 


### PR DESCRIPTION
Improve code quality by applying type hints to Proxy classes in the source code, also clean some PHP<7.0.0 source code.