### PR TITLE
Clean default null values for properties

### DIFF
--- a/demos/Demo/Aspect/IntroductionAspect.php
+++ b/demos/Demo/Aspect/IntroductionAspect.php
@@ -32,5 +32,5 @@ class IntroductionAspect implements Aspect
      *
      * @var null
      */
-    protected $introduction = null;
+    protected $introduction;
 }

--- a/src/Aop/Framework/ClassFieldAccess.php
+++ b/src/Aop/Framework/ClassFieldAccess.php
@@ -26,7 +26,7 @@ class ClassFieldAccess extends AbstractJoinpoint implements FieldAccess
      *
      * @var object
      */
-    protected $instance = null;
+    protected $instance;
 
     /**
      * Instance of reflection property
@@ -40,7 +40,7 @@ class ClassFieldAccess extends AbstractJoinpoint implements FieldAccess
      *
      * @var mixed
      */
-    protected $newValue = null;
+    protected $newValue;
 
     /**
      * Access type for field access
@@ -54,7 +54,7 @@ class ClassFieldAccess extends AbstractJoinpoint implements FieldAccess
      *
      * @var mixed
      */
-    private $value = null;
+    private $value;
 
     /**
      * Constructor for field access

--- a/src/Aop/Framework/DynamicClosureMethodInvocation.php
+++ b/src/Aop/Framework/DynamicClosureMethodInvocation.php
@@ -20,14 +20,14 @@ final class DynamicClosureMethodInvocation extends AbstractMethodInvocation
      *
      * @var \Closure
      */
-    protected $closureToCall = null;
+    protected $closureToCall;
 
     /**
      * Previous instance of invocation
      *
      * @var null|object|string
      */
-    protected $previousInstance = null;
+    protected $previousInstance;
 
     /**
      * Invokes original method and return result from it

--- a/src/Aop/Framework/ReflectionConstructorInvocation.php
+++ b/src/Aop/Framework/ReflectionConstructorInvocation.php
@@ -25,21 +25,21 @@ class ReflectionConstructorInvocation extends AbstractInvocation implements Cons
      *
      * @var ReflectionClass
      */
-    protected $class = null;
+    protected $class;
 
     /**
      * Instance of created class, can be used for Around or After types of advices
      *
      * @var object|null
      */
-    protected $instance = null;
+    protected $instance;
 
     /**
      * Instance of reflection constructor for class
      *
      * @var null|ReflectionMethod
      */
-    private $constructor = null;
+    private $constructor;
 
     /**
      * Number of constructor arguments

--- a/src/Aop/Framework/ReflectionFunctionInvocation.php
+++ b/src/Aop/Framework/ReflectionFunctionInvocation.php
@@ -25,7 +25,7 @@ class ReflectionFunctionInvocation extends AbstractInvocation implements Functio
      *
      * @var null|ReflectionFunction
      */
-    protected $reflectionFunction = null;
+    protected $reflectionFunction;
 
     /**
      * Constructor for function invocation

--- a/src/Aop/Framework/StaticClosureMethodInvocation.php
+++ b/src/Aop/Framework/StaticClosureMethodInvocation.php
@@ -20,14 +20,14 @@ final class StaticClosureMethodInvocation extends AbstractMethodInvocation
      *
      * @var \Closure
      */
-    protected $closureToCall = null;
+    protected $closureToCall;
 
     /**
      * Previous scope of invocation
      *
      * @var null|object|string
      */
-    protected $previousScope = null;
+    protected $previousScope;
 
     /**
      * Invokes original method and return result from it

--- a/src/Aop/Pointcut/AnnotationPointcut.php
+++ b/src/Aop/Pointcut/AnnotationPointcut.php
@@ -34,7 +34,7 @@ class AnnotationPointcut implements Pointcut
      *
      * @var null|Reader
      */
-    protected $annotationReader = null;
+    protected $annotationReader;
 
     /**
      * Kind of current filter, can be KIND_CLASS, KIND_METHOD, KIND_PROPERTY, KIND_TRAIT

--- a/src/Aop/Pointcut/CFlowBelowMethodPointcut.php
+++ b/src/Aop/Pointcut/CFlowBelowMethodPointcut.php
@@ -27,7 +27,7 @@ class CFlowBelowMethodPointcut implements PointFilter, Pointcut
      *
      * @var null|PointFilter
      */
-    protected $internalClassFilter = null;
+    protected $internalClassFilter;
 
     /**
      * Filter for the points

--- a/src/Aop/Pointcut/PointcutClassFilterTrait.php
+++ b/src/Aop/Pointcut/PointcutClassFilterTrait.php
@@ -26,7 +26,7 @@ trait PointcutClassFilterTrait
      *
      * @var null|PointFilter
      */
-    protected $classFilter = null;
+    protected $classFilter;
 
     /**
      * Set the ClassFilter to use for this pointcut.

--- a/src/Aop/Pointcut/PointcutReference.php
+++ b/src/Aop/Pointcut/PointcutReference.php
@@ -23,7 +23,7 @@ class PointcutReference implements Pointcut
     /**
      * @var Pointcut
      */
-    protected $pointcut = null;
+    protected $pointcut;
 
     /**
      * Name of the pointcut to fetch from the container

--- a/src/Aop/Support/AndPointFilter.php
+++ b/src/Aop/Support/AndPointFilter.php
@@ -30,14 +30,14 @@ class AndPointFilter implements PointFilter
      *
      * @var PointFilter|null
      */
-    private $first = null;
+    private $first;
 
     /**
      * Second part of filter
      *
      * @var PointFilter|null
      */
-    private $second = null;
+    private $second;
 
     /**
      * And constructor

--- a/src/Aop/Support/AnnotatedReflectionMethod.php
+++ b/src/Aop/Support/AnnotatedReflectionMethod.php
@@ -24,7 +24,7 @@ class AnnotatedReflectionMethod extends ReflectionMethod
      *
      * @var Reader
      */
-    private static $annotationReader = null;
+    private static $annotationReader;
 
     /**
      * Gets a method annotation.

--- a/src/Aop/Support/DeclareParentsAdvisor.php
+++ b/src/Aop/Support/DeclareParentsAdvisor.php
@@ -26,7 +26,7 @@ class DeclareParentsAdvisor implements IntroductionAdvisor
     /**
      * @var null|IntroductionInfo
      */
-    private $advice = null;
+    private $advice;
 
     /**
      * Type pattern the introduction is restricted to

--- a/src/Aop/Support/NotPointFilter.php
+++ b/src/Aop/Support/NotPointFilter.php
@@ -29,7 +29,7 @@ class NotPointFilter implements PointFilter
      *
      * @var PointFilter|null
      */
-    private $first = null;
+    private $first;
 
     /**
      * Not constructor

--- a/src/Aop/Support/OrPointFilter.php
+++ b/src/Aop/Support/OrPointFilter.php
@@ -30,14 +30,14 @@ class OrPointFilter implements PointFilter
      *
      * @var PointFilter|null
      */
-    private $first = null;
+    private $first;
 
     /**
      * Second part of filter
      *
      * @var PointFilter|null
      */
-    private $second = null;
+    private $second;
 
     /**
      * Or constructor

--- a/src/Aop/Support/TruePointFilter.php
+++ b/src/Aop/Support/TruePointFilter.php
@@ -32,7 +32,7 @@ class TruePointFilter implements PointFilter
      */
     public static function getInstance()
     {
-        static $instance = null;
+        static $instance;
         if (!$instance) {
             $instance = new self();
         }

--- a/src/Console/Command/BaseAspectCommand.php
+++ b/src/Console/Command/BaseAspectCommand.php
@@ -28,7 +28,7 @@ class BaseAspectCommand extends Command
      *
      * @var null|AspectKernel
      */
-    protected $aspectKernel = null;
+    protected $aspectKernel;
 
     /**
      * {@inheritDoc}

--- a/src/Core/AbstractAspectLoaderExtension.php
+++ b/src/Core/AbstractAspectLoaderExtension.php
@@ -33,14 +33,14 @@ abstract class AbstractAspectLoaderExtension implements AspectLoaderExtension
      *
      * @var null|Lexer
      */
-    protected $pointcutLexer = null;
+    protected $pointcutLexer;
 
     /**
      * Instance of pointcut parser
      *
      * @var null|Parser
      */
-    protected $pointcutParser = null;
+    protected $pointcutParser;
 
     /**
      * Default initialization of dependencies

--- a/src/Core/AspectKernel.php
+++ b/src/Core/AspectKernel.php
@@ -46,7 +46,7 @@ abstract class AspectKernel
      *
      * @var null|static
      */
-    protected static $instance = null;
+    protected static $instance;
 
     /**
      * Default class name for container, can be redefined in children
@@ -67,7 +67,7 @@ abstract class AspectKernel
      *
      * @var null|AspectContainer
      */
-    protected $container = null;
+    protected $container;
 
     /**
      * Protected constructor is used to prevent direct creation, but allows customization if needed

--- a/src/Core/AspectLoader.php
+++ b/src/Core/AspectLoader.php
@@ -27,7 +27,7 @@ class AspectLoader
      *
      * @var null|AspectContainer
      */
-    protected $container = null;
+    protected $container;
 
     /**
      * List of aspect loaders
@@ -41,7 +41,7 @@ class AspectLoader
      *
      * @var Reader|null
      */
-    protected $annotationReader = null;
+    protected $annotationReader;
 
     /**
      * List of aspects that was loaded

--- a/src/Instrument/ClassLoading/AopComposerLoader.php
+++ b/src/Instrument/ClassLoading/AopComposerLoader.php
@@ -28,7 +28,7 @@ class AopComposerLoader
      *
      * @var ClassLoader
      */
-    protected $original = null;
+    protected $original;
 
     /**
      * AOP kernel options

--- a/src/Instrument/Transformer/BaseSourceTransformer.php
+++ b/src/Instrument/Transformer/BaseSourceTransformer.php
@@ -29,12 +29,12 @@ abstract class BaseSourceTransformer implements SourceTransformer
     /**
      * @var AspectKernel|null
      */
-    protected $kernel = null;
+    protected $kernel;
 
     /**
      * @var AspectContainer|null
      */
-    protected $container = null;
+    protected $container;
 
     /**
      * Default constructor for transformer

--- a/src/Instrument/Transformer/ConstructorExecutionTransformer.php
+++ b/src/Instrument/Transformer/ConstructorExecutionTransformer.php
@@ -60,7 +60,7 @@ class ConstructorExecutionTransformer implements SourceTransformer
      */
     public static function getInstance()
     {
-        static $instance = null;
+        static $instance;
         if (!$instance) {
             $instance = new static;
         }

--- a/src/Lang/Annotation/DeclareParents.php
+++ b/src/Lang/Annotation/DeclareParents.php
@@ -29,12 +29,12 @@ class DeclareParents extends BaseAnnotation
      *
      * @var string
      */
-    public $defaultImpl = null;
+    public $defaultImpl;
 
     /**
      * Interface name to add
      *
      * @var string
      */
-    public $interface = null;
+    public $interface;
 }

--- a/src/Proxy/ClassProxy.php
+++ b/src/Proxy/ClassProxy.php
@@ -36,14 +36,14 @@ class ClassProxy extends AbstractProxy
      *
      * @var null|ReflectionClass
      */
-    protected $class = null;
+    protected $class;
 
     /**
      * Parent class name, can be changed manually
      *
      * @var string
      */
-    protected $parentClassName = null;
+    protected $parentClassName;
 
     /**
      * Source code for methods
@@ -266,7 +266,7 @@ class ClassProxy extends AbstractProxy
     protected static function wrapWithJoinPoints($classAdvices, $className)
     {
         /** @var LazyAdvisorAccessor $accessor */
-        static $accessor = null;
+        static $accessor;
 
         if (!isset($accessor)) {
             $aspectKernel = AspectKernel::getInstance();

--- a/src/Proxy/FunctionProxy.php
+++ b/src/Proxy/FunctionProxy.php
@@ -80,7 +80,7 @@ class FunctionProxy extends AbstractProxy
     public static function getJoinPoint($joinPointName, $namespace)
     {
         /** @var LazyAdvisorAccessor $accessor */
-        static $accessor = null;
+        static $accessor;
 
         if (!$accessor) {
             $accessor = AspectKernel::getInstance()->getContainer()->get('aspect.advisor.accessor');
@@ -171,7 +171,7 @@ class FunctionProxy extends AbstractProxy
         }
 
         return <<<BODY
-static \$__joinPoint = null;
+static \$__joinPoint;
 if (!\$__joinPoint) {
     \$__joinPoint = {$class}::getJoinPoint('{$function->name}', __NAMESPACE__);
 }

--- a/src/Proxy/TraitProxy.php
+++ b/src/Proxy/TraitProxy.php
@@ -46,7 +46,7 @@ class TraitProxy extends ClassProxy
     public static function getJoinPoint($traitName, $className, $joinPointType, $pointName)
     {
         /** @var LazyAdvisorAccessor $accessor */
-        static $accessor = null;
+        static $accessor;
 
         if (!isset($accessor)) {
             $aspectKernel = AspectKernel::getInstance();
@@ -92,7 +92,7 @@ class TraitProxy extends ClassProxy
         }
 
         return <<<BODY
-static \$__joinPoint = null;
+static \$__joinPoint;
 if (!\$__joinPoint) {
     \$__joinPoint = {$class}::getJoinPoint(__TRAIT__, __CLASS__, '{$prefix}', '{$method->name}');
 }

--- a/tests/Go/Aop/Pointcut/PointcutParserTest.php
+++ b/tests/Go/Aop/Pointcut/PointcutParserTest.php
@@ -23,12 +23,12 @@ class PointcutParserTest extends \PHPUnit_Framework_TestCase
     /**
      * @var null|Lexer
      */
-    protected $lexer = null;
+    protected $lexer;
 
     /**
      * @var null|PointcutParser
      */
-    protected $parser = null;
+    protected $parser;
 
     /**
      * {@inheritdoc}

--- a/tests/Go/Core/AdviceMatcherTest.php
+++ b/tests/Go/Core/AdviceMatcherTest.php
@@ -18,9 +18,9 @@ class AdviceMatcherTest extends TestCase
     /**
      * @var null|AdviceMatcher
      */
-    protected $adviceMatcher = null;
+    protected $adviceMatcher;
 
-    protected $reflectionClass = null;
+    protected $reflectionClass;
 
     /**
      * This method is called before the first test of this test class is run.

--- a/tests/Go/Core/GoAspectContainerTest.php
+++ b/tests/Go/Core/GoAspectContainerTest.php
@@ -12,7 +12,7 @@ class GoAspectContainerTest extends TestCase
     /**
      * @var null|GoAspectContainer
      */
-    protected $container = null;
+    protected $container;
 
     protected function setUp()
     {

--- a/tests/Go/Instrument/Transformer/ConstructorExecutionTransformerTest.php
+++ b/tests/Go/Instrument/Transformer/ConstructorExecutionTransformerTest.php
@@ -12,7 +12,7 @@ class ConstructorExecutionTransformerTest extends \PHPUnit_Framework_TestCase
     /**
      * @var StreamMetaData|null
      */
-    protected $metadata = null;
+    protected $metadata;
 
     /**
      * {@inheritDoc}

--- a/tests/Go/Instrument/Transformer/FilterInjectorTransformerTest.php
+++ b/tests/Go/Instrument/Transformer/FilterInjectorTransformerTest.php
@@ -18,7 +18,7 @@ class FilterInjectorTransformerTest extends \PHPUnit_Framework_TestCase
     /**
      * @var StreamMetaData|null
      */
-    protected $metadata = null;
+    protected $metadata;
 
     /**
      * {@inheritDoc}

--- a/tests/Go/Instrument/Transformer/MagicConstantTransformerTest.php
+++ b/tests/Go/Instrument/Transformer/MagicConstantTransformerTest.php
@@ -16,7 +16,7 @@ class MagicConstantTransformerTest extends \PHPUnit_Framework_TestCase
     /**
      * @var StreamMetaData|null
      */
-    protected $metadata = null;
+    protected $metadata;
 
      /**
      * {@inheritDoc}

--- a/tests/Go/Instrument/Transformer/WeavingTransformerTest.php
+++ b/tests/Go/Instrument/Transformer/WeavingTransformerTest.php
@@ -19,12 +19,12 @@ class WeavingTransformerTest extends \PHPUnit_Framework_TestCase
     /**
      * @var null|AspectKernel|\PHPUnit_Framework_MockObject_MockObject
      */
-    protected $kernel = null;
+    protected $kernel;
 
     /**
      * @var null|AdviceMatcher
      */
-    protected $adviceMatcher = null;
+    protected $adviceMatcher;
 
     /**
      * {@inheritDoc}

--- a/tests/Go/Stubs/BaseInterceptorMock.php
+++ b/tests/Go/Stubs/BaseInterceptorMock.php
@@ -8,7 +8,7 @@ use Go\Aop\Pointcut;
 
 class BaseInterceptorMock extends BaseInterceptor
 {
-    private static $advice = null;
+    private static $advice;
 
     /**
      * {@inheritdoc}

--- a/tests/Go/Stubs/FirstStatic.php
+++ b/tests/Go/Stubs/FirstStatic.php
@@ -9,7 +9,7 @@ class FirstStatic extends First
     /**
      * @var Invocation|null
      */
-    protected static $invocation = null;
+    protected static $invocation;
 
     public function __construct(Invocation $invocation)
     {


### PR DESCRIPTION
By default all values have `null` value, so there is no need to declare this explicitly. All `null` values could be cleaned from the codebase.