### PR TITLE
[WIP][Incomplete] Detection of circular reference, part of #340

### DIFF
--- a/src/Exception/CircularWeavingException.php
+++ b/src/Exception/CircularWeavingException.php
@@ -1,0 +1,16 @@
+<?php
+/*
+ * Go! AOP framework
+ *
+ * @copyright Copyright 2014, Lisachenko Alexander <lisachenko.it@gmail.com>
+ *
+ * This source file is subject to the license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Go\Exception;
+
+class CircularWeavingException extends \RuntimeException implements ExceptionInterface
+{
+
+}

--- a/src/Exception/ExceptionInterface.php
+++ b/src/Exception/ExceptionInterface.php
@@ -1,0 +1,16 @@
+<?php
+/*
+ * Go! AOP framework
+ *
+ * @copyright Copyright 2014, Lisachenko Alexander <lisachenko.it@gmail.com>
+ *
+ * This source file is subject to the license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Go\Exception;
+
+interface ExceptionInterface
+{
+
+}

--- a/src/Instrument/ClassLoading/CacheWarmer.php
+++ b/src/Instrument/ClassLoading/CacheWarmer.php
@@ -11,6 +11,7 @@
 namespace Go\Instrument\ClassLoading;
 
 use Go\Core\AspectKernel;
+use Go\Exception\CircularWeavingException;
 use Go\Instrument\FileSystem\Enumerator;
 use Go\Instrument\Transformer\FilterInjectorTransformer;
 use Symfony\Component\Console\Output\NullOutput;
@@ -83,6 +84,9 @@ class CacheWarmer
                 );
 
                 $this->output->writeln(sprintf('<fg=green;options=bold>[OK]</>: <comment>%s</comment>', $path));
+            } catch (CircularWeavingException $e) {
+                $this->output->writeln(sprintf('<fg=white;bg=red;options=bold>[ERR]</>: File "%s" is not processed correctly due to detected circular weaving.', $path));
+                throw $e;
             } catch (\Throwable $e) {
                 $displayException($e, $path);
             } catch (\Exception $e) {

--- a/tests/Fixtures/project/src/Application/CircularyWeaved.php
+++ b/tests/Fixtures/project/src/Application/CircularyWeaved.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Go\Tests\TestProject\Application;
+
+use Go\Tests\TestProject\Annotation as Aop;
+
+class CircularyWeaved
+{
+    /**
+     * @Aop\Loggable()
+     */
+    public function youCanNotWeaveMe()
+    {
+
+    }
+}

--- a/tests/Fixtures/project/src/Aspect/CircularWeavingAspect.php
+++ b/tests/Fixtures/project/src/Aspect/CircularWeavingAspect.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Go\Tests\TestProject\Aspect;
+
+use Go\Aop\Aspect;
+use Go\Aop\Intercept\MethodInvocation;
+use Go\Tests\TestProject\Application\CircularyWeaved;
+use Go\Lang\Annotation as Pointcut;
+
+class CircularWeavingAspect implements Aspect
+{
+    private $circularyWeaved;
+
+    public function __construct(CircularyWeaved $circularyWeaved)
+    {
+        $this->circularyWeaved = $circularyWeaved;
+    }
+
+    /**
+     * Intercepts doSomething()
+     *
+     * @param MethodInvocation $invocation
+     *
+     * @Pointcut\After("execution(public Go\Tests\TestProject\Application\CircularyWeaved->youCanNotWeaveMe(*))")
+     */
+    public function failToIntercept(MethodInvocation $invocation)
+    {
+        $this->circularyWeaved->youCanNotWeaveMe();
+    }
+}

--- a/tests/Fixtures/project/src/Kernel/CircularWeavingAspectKernel.php
+++ b/tests/Fixtures/project/src/Kernel/CircularWeavingAspectKernel.php
@@ -4,12 +4,12 @@ namespace Go\Tests\TestProject\Kernel;
 
 use Go\Core\AspectContainer;
 use Go\Core\AspectKernel;
-use Go\Tests\TestProject\Aspect\DoSomethingAspect;
-use Go\Tests\TestProject\Aspect\Issue293Aspect;
+use Go\Tests\TestProject\Application\CircularyWeaved;
+use Go\Tests\TestProject\Aspect\CircularWeavingAspect;
 use Go\Tests\TestProject\Aspect\LoggingAspect;
 use Psr\Log\NullLogger;
 
-class DefaultAspectKernel extends AspectKernel
+class CircularWeavingAspectKernel extends AspectKernel
 {
     /**
      * {@inheritdoc}
@@ -17,7 +17,6 @@ class DefaultAspectKernel extends AspectKernel
     protected function configureAop(AspectContainer $container)
     {
         $container->registerAspect(new LoggingAspect(new NullLogger()));
-        $container->registerAspect(new DoSomethingAspect());
-        $container->registerAspect(new Issue293Aspect());
+        $container->registerAspect(new CircularWeavingAspect(new CircularyWeaved()));
     }
 }

--- a/tests/Fixtures/project/src/Kernel/DefaultAspectKernel.php
+++ b/tests/Fixtures/project/src/Kernel/DefaultAspectKernel.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Go\Tests\TestProject;
+namespace Go\Tests\TestProject\Kernel;
 
 use Go\Core\AspectContainer;
 use Go\Core\AspectKernel;
@@ -9,7 +9,7 @@ use Go\Tests\TestProject\Aspect\Issue293Aspect;
 use Go\Tests\TestProject\Aspect\LoggingAspect;
 use Psr\Log\NullLogger;
 
-class ApplicationAspectKernel extends AspectKernel
+class DefaultAspectKernel extends AspectKernel
 {
     /**
      * Configure an AspectContainer with advisors, aspects and pointcuts

--- a/tests/Fixtures/project/web/configuration.php
+++ b/tests/Fixtures/project/web/configuration.php
@@ -11,4 +11,13 @@ return array(
             __DIR__ . '/../src/'
         )
     ),
+    'circular_weaving' => array(
+        'kernel' => \Go\Tests\TestProject\Kernel\CircularWeavingAspectKernel::class,
+        'appDir' => __DIR__ . '/../',
+        'debug' => true,
+        'cacheDir'  => __DIR__ . '/../var/cache/aspect',
+        'includePaths' => array(
+            __DIR__ . '/../src/'
+        )
+    ),
 );

--- a/tests/Fixtures/project/web/configuration.php
+++ b/tests/Fixtures/project/web/configuration.php
@@ -1,0 +1,14 @@
+<?php
+
+return array(
+
+    'default' => array(
+        'kernel' => \Go\Tests\TestProject\Kernel\DefaultAspectKernel::class,
+        'appDir' => __DIR__ . '/../',
+        'debug' => true,
+        'cacheDir'  => __DIR__ . '/../var/cache/aspect',
+        'includePaths' => array(
+            __DIR__ . '/../src/'
+        )
+    ),
+);

--- a/tests/Fixtures/project/web/index.php
+++ b/tests/Fixtures/project/web/index.php
@@ -2,14 +2,8 @@
 
 include_once __DIR__ . '/../../../../vendor/autoload.php';
 
-use Go\Tests\TestProject\ApplicationAspectKernel;
+$configuration = ($env = getenv('GO_AOP_CONFIGURATION')) ? $env : 'default' ;
+$settings = require __DIR__.'/configuration.php';
 
-$applicationAspectKernel = ApplicationAspectKernel::getInstance();
-$applicationAspectKernel->init(array(
-    'appDir' => __DIR__ . '/../',
-    'debug' => true,
-    'cacheDir'  => __DIR__ . '/../var/cache/aspect',
-    'includePaths' => array(
-        __DIR__ . '/../src/'
-    )
-));
+$applicationAspectKernel = $settings[$configuration]['kernel']::getInstance();
+$applicationAspectKernel->init($settings[$configuration]);

--- a/tests/Go/Console/Command/DebugAdvisorCommandTest.php
+++ b/tests/Go/Console/Command/DebugAdvisorCommandTest.php
@@ -9,6 +9,7 @@ class DebugAdvisorCommandTest extends BaseFunctionalTest
 {
     public function setUp()
     {
+        self::clearCache();
         self::warmUp();
     }
 

--- a/tests/Go/Console/Command/DebugAspectCommandTest.php
+++ b/tests/Go/Console/Command/DebugAspectCommandTest.php
@@ -16,7 +16,7 @@ class DebugAspectCommandTest extends BaseFunctionalTest
         $output = self::exec('debug:aspect');
 
         $expected = [
-            'Go\Tests\TestProject\ApplicationAspectKernel has following enabled aspects',
+            'Go\Tests\TestProject\Kernel\DefaultAspectKernel has following enabled aspects',
             'Go\Tests\TestProject\Aspect\LoggingAspect',
             'Go\Tests\TestProject\Aspect\LoggingAspect->beforeMethod'
         ];

--- a/tests/Go/Console/Command/DebugAspectCommandTest.php
+++ b/tests/Go/Console/Command/DebugAspectCommandTest.php
@@ -8,6 +8,7 @@ class DebugAspectCommandTest extends BaseFunctionalTest
 {
     public function setUp()
     {
+        self::clearCache();
         self::warmUp();
     }
 

--- a/tests/Go/Functional/BaseFunctionalTest.php
+++ b/tests/Go/Functional/BaseFunctionalTest.php
@@ -22,14 +22,17 @@ abstract class BaseFunctionalTest extends TestCase
         }
     }
 
-    protected static function warmUp()
+    protected static function warmUp($configuration = null)
     {
-        return self::exec('cache:warmup:aop');
+        return self::exec('cache:warmup:aop', '', $configuration);
     }
 
-    protected static function exec($command, $args = '')
+    protected static function exec($command, $args = '', $configuration = null)
     {
-        $commandStatement = sprintf('php %s %s %s %s',
+        $configuration = ($configuration) ? sprintf('GO_AOP_CONFIGURATION=%s ', $configuration) : '';
+
+        $commandStatement = sprintf('%sphp %s %s %s %s',
+            $configuration,
             self::$consolePath,
             $command,
             self::$frontControllerPath,
@@ -40,7 +43,7 @@ abstract class BaseFunctionalTest extends TestCase
 
         $process->run();
 
-        self::assertTrue($process->isSuccessful(), sprintf('Unable to execute "%s" command.', $command));
+        self::assertTrue($process->isSuccessful(), sprintf('Unable to execute "%s" command, got output: "%s".', $command, $process->getOutput()));
 
         return $process->getOutput();
     }

--- a/tests/Go/Functional/BaseFunctionalTest.php
+++ b/tests/Go/Functional/BaseFunctionalTest.php
@@ -27,7 +27,7 @@ abstract class BaseFunctionalTest extends TestCase
         return self::exec('cache:warmup:aop', '', $configuration);
     }
 
-    protected static function exec($command, $args = '', $configuration = null)
+    protected static function exec($command, $args = '', $configuration = null, $success = true)
     {
         $configuration = ($configuration) ? sprintf('GO_AOP_CONFIGURATION=%s ', $configuration) : '';
 
@@ -43,7 +43,9 @@ abstract class BaseFunctionalTest extends TestCase
 
         $process->run();
 
-        self::assertTrue($process->isSuccessful(), sprintf('Unable to execute "%s" command, got output: "%s".', $command, $process->getOutput()));
+        $assert = ($success) ? 'assertTrue' : 'assertFalse';
+
+        self::{$assert}($process->isSuccessful(), sprintf('Unable to execute "%s" command, got output: "%s".', $command, $process->getOutput()));
 
         return $process->getOutput();
     }

--- a/tests/Go/Functional/CircularWeavingTest.php
+++ b/tests/Go/Functional/CircularWeavingTest.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Go\Functional;
+
+class CircularWeavingTest extends BaseFunctionalTest
+{
+    public function testCircularWeaving()
+    {
+        self::clearCache();
+        $output = self::exec('cache:warmup:aop', '', 'circular_weaving', false);
+        $this->assertContains('is not processed correctly due to detected circular weaving.', $output);
+    }
+}

--- a/tests/Go/Functional/Issue293Test.php
+++ b/tests/Go/Functional/Issue293Test.php
@@ -6,6 +6,7 @@ class Issue293Test extends BaseFunctionalTest
 {
     public function setUp()
     {
+        self::clearCache();
         self::warmUp();
     }
 

--- a/tests/Go/Functional/MethodWeavingTest.php
+++ b/tests/Go/Functional/MethodWeavingTest.php
@@ -6,6 +6,7 @@ class MethodWeavingTest extends BaseFunctionalTest
 {
     public function setUp()
     {
+        self::clearCache();
         self::warmUp();
     }
 


### PR DESCRIPTION
Ok, this is just a proposal of implementing 1. and 2. of issue https://github.com/goaop/framework/issues/340.

Idea is to have a configuration file where you can setup which Kernel implementations should be used and which configuration values should be used.

After that, when you invoke "exec" you can define which configuration should be used. If omitted, `default` will be used.

Configuration key is temporarily set via environment variable in console (GO_AOP_CONFIGURATION) which is read by index.php. When console command is executed, variable is deleted by system, so it is transient. 

@lisachenko What do you think? It is not most elegant solution, but it gives us possibility to choose Kernel (different aspects) and to choose configuration params - so it will be possible to write functional tests where command should fail, or succeed, but with exotic config values. 