### PR TITLE
Feature/detecting inconsistent weaving

### DIFF
--- a/src/Console/Command/DebugWeavingCommand.php
+++ b/src/Console/Command/DebugWeavingCommand.php
@@ -9,6 +9,7 @@
  */
 
 namespace Go\Console\Command;
+
 use Go\Instrument\ClassLoading\CachePathManager;
 use Go\Instrument\ClassLoading\CacheWarmer;
 use Symfony\Component\Console\Input\InputInterface;
@@ -62,7 +63,6 @@ EOT
         $errors = 0;
 
         foreach ($this->getProxies($cachePathManager) as $path => $content) {
-
             if (!isset($proxies[$path])) {
                 $io->writeln(sprintf('<fg=white;bg=red;options=bold>[ERR]</>: Proxy on path "%s" is generated on second "warmup" pass.', $path));
                 $errors++;
@@ -89,14 +89,13 @@ EOT
     private function getProxies(CachePathManager $cachePathManager)
     {
         $path = $cachePathManager->getCacheDir() . '/_proxies';
-        $iterator = new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($path, \FilesystemIterator::SKIP_DOTS | \FilesystemIterator::UNIX_PATHS),\RecursiveIteratorIterator::CHILD_FIRST);
+        $iterator = new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($path, \FilesystemIterator::SKIP_DOTS | \FilesystemIterator::UNIX_PATHS), \RecursiveIteratorIterator::CHILD_FIRST);
         $proxies = [];
 
         /**
          * @var \SplFileInfo $value
          */
-        foreach($iterator as $value) {
-
+        foreach ($iterator as $value) {
             if ($value->isFile()) {
                 $proxies[$value->getPathname()] = file_get_contents($value->getPathname());
             }

--- a/src/Console/Command/DebugWeavingCommand.php
+++ b/src/Console/Command/DebugWeavingCommand.php
@@ -80,7 +80,7 @@ EOT
 
         if ($errors > 0) {
             $io->error(sprintf('Weaving is unstable, there are %s reported error(s).', $errors));
-            return 1;
+            return $errors;
         }
 
         $io->success('Weaving is stable, there are no errors reported.');

--- a/src/Console/Command/DebugWeavingCommand.php
+++ b/src/Console/Command/DebugWeavingCommand.php
@@ -1,0 +1,107 @@
+<?php
+/*
+ * Go! AOP framework
+ *
+ * @copyright Copyright 2015, Lisachenko Alexander <lisachenko.it@gmail.com>
+ *
+ * This source file is subject to the license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Go\Console\Command;
+use Go\Instrument\ClassLoading\CachePathManager;
+use Go\Instrument\ClassLoading\CacheWarmer;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\NullOutput;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+/**
+ * Console command for querying an information about aspects
+ *
+ * @codeCoverageIgnore
+ */
+class DebugWeavingCommand extends BaseAspectCommand
+{
+    /**
+     * {@inheritDoc}
+     */
+    protected function configure()
+    {
+        parent::configure();
+        $this
+            ->setName('debug:weaving')
+            ->setDescription('Checks consistency in weaving process')
+            ->setHelp(<<<EOT
+Allows to check consistency of weaving process, detects circular references and mutual dependencies between
+subjects of weaving and aspects.
+EOT
+            );
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $this->loadAspectKernel($input, $output);
+
+        $io = new SymfonyStyle($input, $output);
+
+        $io->title('Weaving debug information');
+
+        $cachePathManager = $this->aspectKernel->getContainer()->get('aspect.cache.path.manager');
+        $warmer = new CacheWarmer($this->aspectKernel, new NullOutput());
+        $warmer->warmUp();
+
+        $proxies = $this->getProxies($cachePathManager);
+
+        $cachePathManager->clearCacheState();
+        $warmer->warmUp();
+
+        $errors = 0;
+
+        foreach ($this->getProxies($cachePathManager) as $path => $content) {
+
+            if (!isset($proxies[$path])) {
+                $io->writeln(sprintf('<fg=white;bg=red;options=bold>[ERR]</>: Proxy on path "%s" is generated on second "warmup" pass.', $path));
+                $errors++;
+                continue;
+            }
+
+            if (isset($proxies[$path]) && $proxies[$path] !== $content) {
+                $io->writeln(sprintf('<fg=white;bg=red;options=bold>[ERR]</>: Proxy on path "%s" is weaved differnlty on second "warmup" pass.', $path));
+                $errors++;
+                continue;
+            }
+
+            $io->writeln(sprintf('<fg=green;options=bold>[OK]</>: <comment>Proxy  on path "%s" is consistently weaved.</comment>', $path));
+        }
+
+        if ($errors > 0) {
+            $io->error(sprintf('Weaving is unstable, there are %s reported error(s).', $errors));
+            return -1;
+        }
+
+        $io->success('Weaving is stabile, there are no errors reported.');
+    }
+
+    private function getProxies(CachePathManager $cachePathManager)
+    {
+        $path = $cachePathManager->getCacheDir() . '/_proxies';
+        $iterator = new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($path, \FilesystemIterator::SKIP_DOTS | \FilesystemIterator::UNIX_PATHS),\RecursiveIteratorIterator::CHILD_FIRST);
+        $proxies = [];
+
+        /**
+         * @var \SplFileInfo $value
+         */
+        foreach($iterator as $value) {
+
+            if ($value->isFile()) {
+                $proxies[$value->getPathname()] = file_get_contents($value->getPathname());
+            }
+        }
+
+        return $proxies;
+    }
+}

--- a/src/Instrument/ClassLoading/CachePathManager.php
+++ b/src/Instrument/ClassLoading/CachePathManager.php
@@ -174,10 +174,12 @@ class CachePathManager
 
     /**
      * Flushes the cache state into the file
+     *
+     * @var bool $force Should be flushed regardless of its state.
      */
-    public function flushCacheState()
+    public function flushCacheState($force = false)
     {
-        if (!empty($this->newCacheState) && is_writable($this->cacheDir)) {
+        if ((!empty($this->newCacheState) && is_writable($this->cacheDir)) || $force) {
             $fullCacheMap = $this->newCacheState + $this->cacheState;
             $cachePath    = substr(var_export($this->cacheDir, true), 1, -1);
             $rootPath     = substr(var_export($this->appDir, true), 1, -1);
@@ -197,5 +199,16 @@ class CachePathManager
             $this->cacheState    = $this->newCacheState + $this->cacheState;
             $this->newCacheState = [];
         }
+    }
+
+    /**
+     * Clear the cache state.
+     */
+    public function clearCacheState()
+    {
+        $this->cacheState       = [];
+        $this->newCacheState    = [];
+
+        $this->flushCacheState(true);
     }
 }

--- a/tests/Fixtures/project/bin/console
+++ b/tests/Fixtures/project/bin/console
@@ -7,6 +7,7 @@ use Symfony\Component\Console\Application;
 use Go\Console\Command\CacheWarmupCommand;
 use Go\Console\Command\DebugAdvisorCommand;
 use Go\Console\Command\DebugAspectCommand;
+use Go\Console\Command\DebugWeavingCommand;
 
 $application = new Application();
 
@@ -14,6 +15,7 @@ $application->addCommands([
     new CacheWarmupCommand(),
     new DebugAdvisorCommand(),
     new DebugAspectCommand(),
+    new DebugWeavingCommand(),
 ]);
 
 $application->run();

--- a/tests/Fixtures/project/src/Application/InconsistentlyWeavedClass.php
+++ b/tests/Fixtures/project/src/Application/InconsistentlyWeavedClass.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Go\Tests\TestProject\Application;
+
+class InconsistentlyWeavedClass
+{
+    public function badlyWeaved()
+    {
+        echo 'I get weaved differently every time.';
+    }
+}

--- a/tests/Fixtures/project/src/Aspect/InconsistentlyWeavingAspect.php
+++ b/tests/Fixtures/project/src/Aspect/InconsistentlyWeavingAspect.php
@@ -25,5 +25,3 @@ class InconsistentlyWeavingAspect implements Aspect
         echo 'I weave badly.';
     }
 }
-
-

--- a/tests/Fixtures/project/src/Aspect/InconsistentlyWeavingAspect.php
+++ b/tests/Fixtures/project/src/Aspect/InconsistentlyWeavingAspect.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Go\Tests\TestProject\Aspect;
+
+use Go\Aop\Aspect;
+use Go\Aop\Intercept\MethodInvocation;
+use Go\Tests\TestProject\Application\InconsistentlyWeavedClass;
+use Go\Lang\Annotation as Pointcut;
+
+class InconsistentlyWeavingAspect implements Aspect
+{
+    public function __construct(InconsistentlyWeavedClass $problematicClass)
+    {
+    }
+
+    /**
+     * Intercepts badlyWeaved()
+     *
+     * @param MethodInvocation $invocation
+     *
+     * @Pointcut\After("execution(public Go\Tests\TestProject\Application\InconsistentlyWeavedClass->badlyWeaved(*))")
+     */
+    public function weaveBadly()
+    {
+        echo 'I weave badly.';
+    }
+}
+
+

--- a/tests/Fixtures/project/src/Aspect/InconsistentlyWeavingAspect.php
+++ b/tests/Fixtures/project/src/Aspect/InconsistentlyWeavingAspect.php
@@ -7,16 +7,23 @@ use Go\Aop\Intercept\MethodInvocation;
 use Go\Tests\TestProject\Application\InconsistentlyWeavedClass;
 use Go\Lang\Annotation as Pointcut;
 
+/**
+ * Apspect can not depend on class that is subject of its weaving
+ * if that class is being weaved after aspect is registered.
+ *
+ * @see https://github.com/goaop/framework/issues/338
+ * @see https://github.com/goaop/goaop-symfony-bundle/issues/15
+ */
 class InconsistentlyWeavingAspect implements Aspect
 {
     public function __construct(InconsistentlyWeavedClass $problematicClass)
     {
+        /* noop */
     }
 
     /**
-     * Intercepts badlyWeaved()
-     *
-     * @param MethodInvocation $invocation
+     * Intercepts \Go\Tests\TestProject\Application\InconsistentlyWeavedClass\badlyWeaved() on which
+     * this aspects depends in constructor, therefor, it is already loaded and can not be weaved.
      *
      * @Pointcut\After("execution(public Go\Tests\TestProject\Application\InconsistentlyWeavedClass->badlyWeaved(*))")
      */

--- a/tests/Fixtures/project/src/Kernel/DefaultAspectKernel.php
+++ b/tests/Fixtures/project/src/Kernel/DefaultAspectKernel.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Go\Tests\TestProject;
+namespace Go\Tests\TestProject\Kernel;
 
 use Go\Core\AspectContainer;
 use Go\Core\AspectKernel;
@@ -9,7 +9,7 @@ use Go\Tests\TestProject\Aspect\Issue293Aspect;
 use Go\Tests\TestProject\Aspect\LoggingAspect;
 use Psr\Log\NullLogger;
 
-class ApplicationAspectKernel extends AspectKernel
+class DefaultAspectKernel extends AspectKernel
 {
     /**
      * Configure an AspectContainer with advisors, aspects and pointcuts

--- a/tests/Fixtures/project/src/Kernel/InconsistentlyWeavingAspectKernel.php
+++ b/tests/Fixtures/project/src/Kernel/InconsistentlyWeavingAspectKernel.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Go\Tests\TestProject\Kernel;
+
+use Go\Core\AspectContainer;
+use Go\Core\AspectKernel;
+use Go\Tests\TestProject\Application\InconsistentlyWeavedClass;
+use Go\Tests\TestProject\Aspect\InconsistentlyWeavingAspect;
+use Go\Tests\TestProject\Aspect\LoggingAspect;
+use Psr\Log\NullLogger;
+
+class InconsistentlyWeavingAspectKernel extends AspectKernel
+{
+    /**
+     * Configure an AspectContainer with advisors, aspects and pointcuts
+     *
+     * @param AspectContainer $container
+     *
+     * @return void
+     */
+    protected function configureAop(AspectContainer $container)
+    {
+        $container->registerAspect(new LoggingAspect(new NullLogger()));
+        $container->registerAspect(new InconsistentlyWeavingAspect(new InconsistentlyWeavedClass()));
+    }
+}

--- a/tests/Fixtures/project/web/configuration.php
+++ b/tests/Fixtures/project/web/configuration.php
@@ -4,6 +4,8 @@ return array(
 
     'default' => array(
         'kernel' => \Go\Tests\TestProject\Kernel\DefaultAspectKernel::class,
+        'console' => __DIR__ . '/../bin/console',
+        'frontController' => __DIR__ . '/../web/index.php',
         'appDir' => __DIR__ . '/../',
         'debug' => true,
         'cacheDir'  => __DIR__ . '/../var/cache/aspect',
@@ -14,6 +16,8 @@ return array(
 
     'inconsistent_weaving' => array(
         'kernel' => \Go\Tests\TestProject\Kernel\InconsistentlyWeavingAspectKernel::class,
+        'console' => __DIR__ . '/../bin/console',
+        'frontController' => __DIR__ . '/../web/index.php',
         'appDir' => __DIR__ . '/../',
         'debug' => true,
         'cacheDir'  => __DIR__ . '/../var/cache/aspect',

--- a/tests/Fixtures/project/web/configuration.php
+++ b/tests/Fixtures/project/web/configuration.php
@@ -9,6 +9,16 @@ return array(
         'cacheDir'  => __DIR__ . '/../var/cache/aspect',
         'includePaths' => array(
             __DIR__ . '/../src/'
-        )
+        ),
+    ),
+
+    'inconsistent_weaving' => array(
+        'kernel' => \Go\Tests\TestProject\Kernel\InconsistentlyWeavingAspectKernel::class,
+        'appDir' => __DIR__ . '/../',
+        'debug' => true,
+        'cacheDir'  => __DIR__ . '/../var/cache/aspect',
+        'includePaths' => array(
+            __DIR__ . '/../src/'
+        ),
     ),
 );

--- a/tests/Fixtures/project/web/configuration.php
+++ b/tests/Fixtures/project/web/configuration.php
@@ -1,0 +1,14 @@
+<?php
+
+return array(
+
+    'default' => array(
+        'kernel' => \Go\Tests\TestProject\Kernel\DefaultAspectKernel::class,
+        'appDir' => __DIR__ . '/../',
+        'debug' => true,
+        'cacheDir'  => __DIR__ . '/../var/cache/aspect',
+        'includePaths' => array(
+            __DIR__ . '/../src/'
+        )
+    ),
+);

--- a/tests/Fixtures/project/web/index.php
+++ b/tests/Fixtures/project/web/index.php
@@ -2,14 +2,8 @@
 
 include_once __DIR__ . '/../../../../vendor/autoload.php';
 
-use Go\Tests\TestProject\ApplicationAspectKernel;
+$configuration = ($env = getenv('GO_AOP_CONFIGURATION')) ? $env : 'default' ;
+$settings = require __DIR__.'/configuration.php';
 
-$applicationAspectKernel = ApplicationAspectKernel::getInstance();
-$applicationAspectKernel->init(array(
-    'appDir' => __DIR__ . '/../',
-    'debug' => true,
-    'cacheDir'  => __DIR__ . '/../var/cache/aspect',
-    'includePaths' => array(
-        __DIR__ . '/../src/'
-    )
-));
+$applicationAspectKernel = $settings[$configuration]['kernel']::getInstance();
+$applicationAspectKernel->init($settings[$configuration]);

--- a/tests/Go/Console/Command/CacheWarmupCommandTest.php
+++ b/tests/Go/Console/Command/CacheWarmupCommandTest.php
@@ -19,6 +19,6 @@ class CacheWarmupCommandTest extends BaseFunctionalTest
 
         $this->warmUp();
 
-        $this->assertClassIsWeaved(Main::class);
+        $this->assertClassIsWoven(Main::class);
     }
 }

--- a/tests/Go/Console/Command/CacheWarmupCommandTest.php
+++ b/tests/Go/Console/Command/CacheWarmupCommandTest.php
@@ -3,21 +3,22 @@
 namespace Go\Console\Command;
 
 use Go\Functional\BaseFunctionalTest;
+use Go\Tests\TestProject\Application\Main;
 
 class CacheWarmupCommandTest extends BaseFunctionalTest
 {
     public function setUp()
     {
-        self::clearCache();
+        $this->loadConfiguration();
+        $this->clearCache();
     }
 
     public function testItWarmsUpCache()
     {
-        $this->assertFalse(file_exists(self::$aspectCacheDir));
+        $this->assertFalse(file_exists($this->configuration['cacheDir']));
 
-        self::warmUp();
+        $this->warmUp();
 
-        $this->assertTrue(file_exists(self::$aspectCacheDir.'/_proxies/src/Application/Main.php'));
-        $this->assertTrue(file_exists(self::$aspectCacheDir.'/src/Application/Main.php'));
+        $this->assertClassIsWeaved(Main::class);
     }
 }

--- a/tests/Go/Console/Command/DebugAdvisorCommandTest.php
+++ b/tests/Go/Console/Command/DebugAdvisorCommandTest.php
@@ -9,6 +9,7 @@ class DebugAdvisorCommandTest extends BaseFunctionalTest
 {
     public function setUp()
     {
+        self::clearCache();
         self::warmUp();
     }
 

--- a/tests/Go/Console/Command/DebugAdvisorCommandTest.php
+++ b/tests/Go/Console/Command/DebugAdvisorCommandTest.php
@@ -7,15 +7,9 @@ use Go\Instrument\FileSystem\Enumerator;
 
 class DebugAdvisorCommandTest extends BaseFunctionalTest
 {
-    public function setUp()
-    {
-        self::clearCache();
-        self::warmUp();
-    }
-
     public function testItDisplaysAdvisorsDebugInfo()
     {
-        $output = self::exec('debug:advisor');
+        $output = $this->execute('debug:advisor');
 
         $expected = [
             'List of registered advisors in the container',
@@ -30,9 +24,9 @@ class DebugAdvisorCommandTest extends BaseFunctionalTest
 
     public function testItDisplaysStatedAdvisorDebugInfo()
     {
-        $output = self::exec('debug:advisor', '--advisor="Go\Tests\TestProject\Aspect\LoggingAspect->beforeMethod"');
+        $output = self::execute('debug:advisor', '--advisor="Go\Tests\TestProject\Aspect\LoggingAspect->beforeMethod"');
 
-        $enumerator = new Enumerator(realpath(self::$projectDir.'/src'));
+        $enumerator = new Enumerator(realpath($this->configuration['appDir'].'/src'));
         $srcFilesCount = iterator_count($enumerator->enumerate());
 
         $expected = [

--- a/tests/Go/Console/Command/DebugAspectCommandTest.php
+++ b/tests/Go/Console/Command/DebugAspectCommandTest.php
@@ -6,15 +6,9 @@ use Go\Functional\BaseFunctionalTest;
 
 class DebugAspectCommandTest extends BaseFunctionalTest
 {
-    public function setUp()
-    {
-        self::clearCache();
-        self::warmUp();
-    }
-
     public function testItDisplaysAspectsDebugInfo()
     {
-        $output = self::exec('debug:aspect');
+        $output = $this->execute('debug:aspect');
 
         $expected = [
             'Go\Tests\TestProject\Kernel\DefaultAspectKernel has following enabled aspects',

--- a/tests/Go/Console/Command/DebugAspectCommandTest.php
+++ b/tests/Go/Console/Command/DebugAspectCommandTest.php
@@ -16,7 +16,7 @@ class DebugAspectCommandTest extends BaseFunctionalTest
         $output = self::exec('debug:aspect');
 
         $expected = [
-            'Go\Tests\TestProject\ApplicationAspectKernel has following enabled aspects',
+            'Go\Tests\TestProject\Kernel\DefaultAspectKernel has following enabled aspects',
             'Go\Tests\TestProject\Aspect\LoggingAspect',
             'Go\Tests\TestProject\Aspect\LoggingAspect->beforeMethod'
         ];

--- a/tests/Go/Console/Command/DebugAspectCommandTest.php
+++ b/tests/Go/Console/Command/DebugAspectCommandTest.php
@@ -8,6 +8,7 @@ class DebugAspectCommandTest extends BaseFunctionalTest
 {
     public function setUp()
     {
+        self::clearCache();
         self::warmUp();
     }
 

--- a/tests/Go/Console/Command/DebugWeavingCommandTest.php
+++ b/tests/Go/Console/Command/DebugWeavingCommandTest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Go\Console\Command;
+
+use Go\Functional\BaseFunctionalTest;
+
+class DebugWeavingCommandTest extends BaseFunctionalTest
+{
+    public function setUp()
+    {
+        self::clearCache();
+    }
+
+    public function testReportInconsistentWeaving()
+    {
+        $output = self::exec('debug:weaving', '', 'inconsistent_weaving', false);
+
+        $this->assertContains('aspect/_proxies/src/Application/InconsistentlyWeavedClass.php" is generated on second "warmup" pass.', $output);
+        $this->assertContains('aspect/_proxies/src/Application/Main.php" is consistently weaved.', $output);
+        $this->assertContains('[ERROR] Weaving is unstable, there are 1 reported error(s).', $output);
+    }
+}

--- a/tests/Go/Console/Command/DebugWeavingCommandTest.php
+++ b/tests/Go/Console/Command/DebugWeavingCommandTest.php
@@ -10,8 +10,8 @@ class DebugWeavingCommandTest extends BaseFunctionalTest
     {
         $output = str_replace("\n", ' ', $this->execute('debug:weaving', null, false));
 
-        $this->assertRegexp('/.+aspect\/_proxies\/src\/Application\/InconsistentlyWeavedClass.php.+generated on second "warmup" pass.+/', $output);
-        $this->assertRegexp('/.+aspect\/_proxies\/src\/Application\/Main.php".+is consistently weaved.+/', $output);
+        $this->assertRegexp('/.+InconsistentlyWeavedClass.php.+generated.+on.+second.+"warmup".+pass.+/', $output);
+        $this->assertRegexp('/.+Main.php".+is.+consistently.+weaved.+/', $output);
         $this->assertContains('[ERROR] Weaving is unstable, there are 1 reported error(s).', $output);
     }
 

--- a/tests/Go/Console/Command/DebugWeavingCommandTest.php
+++ b/tests/Go/Console/Command/DebugWeavingCommandTest.php
@@ -6,17 +6,17 @@ use Go\Functional\BaseFunctionalTest;
 
 class DebugWeavingCommandTest extends BaseFunctionalTest
 {
-    public function setUp()
-    {
-        self::clearCache();
-    }
-
     public function testReportInconsistentWeaving()
     {
-        $output = self::exec('debug:weaving', '', 'inconsistent_weaving', false);
+        $output = str_replace("\n", ' ', $this->execute('debug:weaving', null, false));
 
-        $this->assertContains('aspect/_proxies/src/Application/InconsistentlyWeavedClass.php" is generated on second "warmup" pass.', $output);
-        $this->assertContains('aspect/_proxies/src/Application/Main.php" is consistently weaved.', $output);
+        $this->assertRegexp('/.+aspect\/_proxies\/src\/Application\/InconsistentlyWeavedClass.php.+generated on second "warmup" pass.+/', $output);
+        $this->assertRegexp('/.+aspect\/_proxies\/src\/Application\/Main.php".+is consistently weaved.+/', $output);
         $this->assertContains('[ERROR] Weaving is unstable, there are 1 reported error(s).', $output);
+    }
+
+    protected function getConfigurationName()
+    {
+        return 'inconsistent_weaving';
     }
 }

--- a/tests/Go/Console/Command/DebugWeavingCommandTest.php
+++ b/tests/Go/Console/Command/DebugWeavingCommandTest.php
@@ -8,7 +8,7 @@ class DebugWeavingCommandTest extends BaseFunctionalTest
 {
     public function testReportInconsistentWeaving()
     {
-        $output = str_replace("\n", ' ', $this->execute('debug:weaving', null, false));
+        $output = str_replace("\n", ' ', $this->execute('debug:weaving', null, false, 1));
 
         $this->assertRegexp('/.+InconsistentlyWeavedClass.php.+generated.+on.+second.+"warmup".+pass.+/', $output);
         $this->assertRegexp('/.+Main.php".+is.+consistently.+weaved.+/', $output);

--- a/tests/Go/Functional/BaseFunctionalTest.php
+++ b/tests/Go/Functional/BaseFunctionalTest.php
@@ -1,51 +1,162 @@
 <?php
+/*
+ * Go! AOP framework
+ *
+ * @copyright Copyright 2011, Lisachenko Alexander <lisachenko.it@gmail.com>
+ *
+ * This source file is subject to the license that is bundled
+ * with this source code in the file LICENSE.
+ */
 
 namespace Go\Functional;
 
+use Go\Instrument\PathResolver;
+use Go\ParserReflection\ReflectionClass;
 use PHPUnit_Framework_TestCase as TestCase;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Process\Process;
 
+/**
+ * Base class for functional tests.
+ */
 abstract class BaseFunctionalTest extends TestCase
 {
-    protected static $projectDir            = __DIR__ . '/../../Fixtures/project';
-    protected static $aspectCacheDir        = __DIR__ . '/../../Fixtures/project/var/cache/aspect';
-    protected static $consolePath           = __DIR__ . '/../../Fixtures/project/bin/console';
-    protected static $frontControllerPath   = __DIR__ . '/../../Fixtures/project/web/index.php';
+    /**
+     * Configuration which ought to be used in this test suite.
+     *
+     * @var array
+     */
+    protected $configuration;
 
-    protected static function clearCache()
+    /**
+     * {@inheritdoc}
+     */
+    public function setUp()
+    {
+        $this->loadConfiguration();
+        $this->clearCache();
+        $this->warmUp();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function tearDown()
+    {
+        $this->clearCache();
+    }
+
+    /**
+     * Clear Go! AOP cache.
+     */
+    protected function clearCache()
     {
         $filesystem = new Filesystem();
 
-        if ($filesystem->exists(self::$aspectCacheDir)) {
-            $filesystem->remove(self::$aspectCacheDir);
+        if ($filesystem->exists($this->configuration['cacheDir'])) {
+            $filesystem->remove($this->configuration['cacheDir']);
         }
     }
 
-    protected static function warmUp($configuration = null)
+    /**
+     * Warms up Go! AOP cache.
+     *
+     * @return string Command output.
+     */
+    protected function warmUp()
     {
-        return self::exec('cache:warmup:aop', '', $configuration);
+        return $this->execute('cache:warmup:aop');
     }
 
-    protected static function exec($command, $args = '', $configuration = null, $expectSuccess = true)
+    /**
+     * Get configuration name.
+     *
+     * Get configuration name from available configurations settings defined in
+     * /tests/Fixtures/project/web/configuration.php used for executing this
+     * functional test suite.
+     *
+     * Override this method to use desired configuration settings.
+     *
+     * @return string
+     */
+    protected function getConfigurationName()
     {
-        $configuration = ($configuration) ? sprintf('GO_AOP_CONFIGURATION=%s ', $configuration) : '';
+        return 'default';
+    }
 
-        $commandStatement = sprintf('%sphp %s %s %s %s',
-            $configuration,
-            self::$consolePath,
+    /**
+     * Load configuration settings.
+     *
+     * Load configuration settings which ought to be used in this test suite,
+     * defined in /tests/Fixtures/project/web/configuration.php.
+     */
+    protected function loadConfiguration()
+    {
+        if (!$this->configuration) {
+            $configurations = require __DIR__.'/../../Fixtures/project/web/configuration.php';
+            $this->configuration = $configurations[$this->getConfigurationName()];
+        }
+    }
+
+    /**
+     * Execute console command.
+     *
+     * @param string $command Command to execute.
+     * @param string|null $args Command arguments to append, if any.
+     * @param bool $expectSuccess Should command be executed successfully
+     *
+     * @return string Console output.
+     */
+    protected function execute($command, $args = null, $expectSuccess = true)
+    {
+        $commandStatement = sprintf('GO_AOP_CONFIGURATION=%s php %s %s %s %s',
+            $this->getConfigurationName(),
+            $this->configuration['console'],
             $command,
-            self::$frontControllerPath,
-            $args
+            $this->configuration['frontController'],
+            (null !== $args) ? $args : ''
         );
 
         $process = new Process($commandStatement);
 
         $process->run();
 
-        $assert = ($expectSuccess) ? 'assertTrue' : 'assertFalse';
-        self::{$assert}($process->isSuccessful(), sprintf('Unable to execute "%s" command, got output: "%s".', $command, $process->getOutput()));
+        if ($expectSuccess) {
+            $this->assertTrue($process->isSuccessful(), sprintf('Unable to execute "%s" command, got output: "%s".', $command, $process->getOutput()));
+        } else {
+            $this->assertFalse($process->isSuccessful(), sprintf('Command "%s" excuted successfully, even if it is expected to fail, got output: "%s".', $command, $process->getOutput()));
+        }
 
         return $process->getOutput();
+    }
+
+    /**
+     * Assert that class is weaved.
+     *
+     * @param string $class Full qualified class name which is subject of weaving.
+     * @param string $message Assertion info message.
+     */
+    protected function assertClassIsWeaved($class, $message = '')
+    {
+        $filename = (new ReflectionClass($class))->getFileName();
+        $suffix = substr($filename, strlen(PathResolver::realpath($this->configuration['appDir'])));
+
+        $this->assertFileExists($this->configuration['cacheDir'].$suffix, $message);
+        $this->assertFileExists($this->configuration['cacheDir'].'/_proxies'.$suffix, $message);
+    }
+
+    /**
+     * Assert that class is not weaved.
+     *
+     * @param string $class Full qualified class name which is not subject of weaving.
+     * @param string $message Assertion info message.
+     */
+    protected function assertClassIsNotWeaved($class, $message = '')
+    {
+        $filename = (new ReflectionClass($class))->getFileName();
+        $suffix = substr($filename, strlen(PathResolver::realpath($this->configuration['appDir'])));
+
+        $this->assertFileNotExists($this->configuration['cacheDir'].$suffix, $message);
+        $this->assertFileNotExists($this->configuration['cacheDir'].'/_proxies'.$suffix, $message);
     }
 }

--- a/tests/Go/Functional/BaseFunctionalTest.php
+++ b/tests/Go/Functional/BaseFunctionalTest.php
@@ -22,14 +22,17 @@ abstract class BaseFunctionalTest extends TestCase
         }
     }
 
-    protected static function warmUp()
+    protected static function warmUp($configuration = null)
     {
-        return self::exec('cache:warmup:aop');
+        return self::exec('cache:warmup:aop', '', $configuration);
     }
 
-    protected static function exec($command, $args = '')
+    protected static function exec($command, $args = '', $configuration = null)
     {
-        $commandStatement = sprintf('php %s %s %s %s',
+        $configuration = ($configuration) ? sprintf('GO_AOP_CONFIGURATION=%s ', $configuration) : '';
+
+        $commandStatement = sprintf('%sphp %s %s %s %s',
+            $configuration,
             self::$consolePath,
             $command,
             self::$frontControllerPath,
@@ -40,7 +43,7 @@ abstract class BaseFunctionalTest extends TestCase
 
         $process->run();
 
-        self::assertTrue($process->isSuccessful(), sprintf('Unable to execute "%s" command.', $command));
+        self::assertTrue($process->isSuccessful(), sprintf('Unable to execute "%s" command, got output: "%s".', $command, $process->getOutput()));
 
         return $process->getOutput();
     }

--- a/tests/Go/Functional/BaseFunctionalTest.php
+++ b/tests/Go/Functional/BaseFunctionalTest.php
@@ -136,12 +136,12 @@ abstract class BaseFunctionalTest extends TestCase
     }
 
     /**
-     * Assert that class is weaved.
+     * Assert that class is woven.
      *
      * @param string $class Full qualified class name which is subject of weaving.
      * @param string $message Assertion info message.
      */
-    protected function assertClassIsWeaved($class, $message = '')
+    protected function assertClassIsWoven($class, $message = '')
     {
         $filename = (new ReflectionClass($class))->getFileName();
         $suffix = substr($filename, strlen(PathResolver::realpath($this->configuration['appDir'])));
@@ -151,12 +151,12 @@ abstract class BaseFunctionalTest extends TestCase
     }
 
     /**
-     * Assert that class is not weaved.
+     * Assert that class is not woven.
      *
      * @param string $class Full qualified class name which is not subject of weaving.
      * @param string $message Assertion info message.
      */
-    protected function assertClassIsNotWeaved($class, $message = '')
+    protected function assertClassIsNotWoven($class, $message = '')
     {
         $filename = (new ReflectionClass($class))->getFileName();
         $suffix = substr($filename, strlen(PathResolver::realpath($this->configuration['appDir'])));

--- a/tests/Go/Functional/BaseFunctionalTest.php
+++ b/tests/Go/Functional/BaseFunctionalTest.php
@@ -104,10 +104,11 @@ abstract class BaseFunctionalTest extends TestCase
      * @param string $command Command to execute.
      * @param string|null $args Command arguments to append, if any.
      * @param bool $expectSuccess Should command be executed successfully
+     * @param null|int $expectedExitCode If provided, exit code will be asserted.
      *
      * @return string Console output.
      */
-    protected function execute($command, $args = null, $expectSuccess = true)
+    protected function execute($command, $args = null, $expectSuccess = true, $expectedExitCode = null)
     {
         $commandStatement = sprintf('GO_AOP_CONFIGURATION=%s php %s %s %s %s',
             $this->getConfigurationName(),
@@ -125,6 +126,10 @@ abstract class BaseFunctionalTest extends TestCase
             $this->assertTrue($process->isSuccessful(), sprintf('Unable to execute "%s" command, got output: "%s".', $command, $process->getOutput()));
         } else {
             $this->assertFalse($process->isSuccessful(), sprintf('Command "%s" excuted successfully, even if it is expected to fail, got output: "%s".', $command, $process->getOutput()));
+        }
+
+        if (null !== $expectedExitCode) {
+            $this->assertEquals($expectedExitCode, $process->getExitCode(), 'Assert that exit code is matched.');
         }
 
         return $process->getOutput();

--- a/tests/Go/Functional/BaseFunctionalTest.php
+++ b/tests/Go/Functional/BaseFunctionalTest.php
@@ -27,7 +27,7 @@ abstract class BaseFunctionalTest extends TestCase
         return self::exec('cache:warmup:aop', '', $configuration);
     }
 
-    protected static function exec($command, $args = '', $configuration = null)
+    protected static function exec($command, $args = '', $configuration = null, $expectSuccess = true)
     {
         $configuration = ($configuration) ? sprintf('GO_AOP_CONFIGURATION=%s ', $configuration) : '';
 
@@ -43,7 +43,8 @@ abstract class BaseFunctionalTest extends TestCase
 
         $process->run();
 
-        self::assertTrue($process->isSuccessful(), sprintf('Unable to execute "%s" command, got output: "%s".', $command, $process->getOutput()));
+        $assert = ($expectSuccess) ? 'assertTrue' : 'assertFalse';
+        self::{$assert}($process->isSuccessful(), sprintf('Unable to execute "%s" command, got output: "%s".', $command, $process->getOutput()));
 
         return $process->getOutput();
     }

--- a/tests/Go/Functional/Issue293Test.php
+++ b/tests/Go/Functional/Issue293Test.php
@@ -6,6 +6,7 @@ class Issue293Test extends BaseFunctionalTest
 {
     public function setUp()
     {
+        self::clearCache();
         self::warmUp();
     }
 

--- a/tests/Go/Functional/Issue293Test.php
+++ b/tests/Go/Functional/Issue293Test.php
@@ -2,25 +2,19 @@
 
 namespace Go\Functional;
 
+use Go\Tests\TestProject\Application\Issue293DynamicMembers;
+use Go\Tests\TestProject\Application\Issue293StaticMembers;
+
 class Issue293Test extends BaseFunctionalTest
 {
-    public function setUp()
-    {
-        self::clearCache();
-        self::warmUp();
-    }
-
     /**
      * test for https://github.com/goaop/framework/issues/293
      */
     public function testItDoesNotWeaveDynamicMethodsForComplexStaticPointcut()
     {
-        // it weaves Issue293StaticMembers class
-        $this->assertTrue(file_exists(self::$aspectCacheDir.'/_proxies/src/Application/Issue293StaticMembers.php'));
-        $this->assertTrue(file_exists(self::$aspectCacheDir.'/src/Application/Issue293StaticMembers.php'));
+        $this->assertClassIsWeaved(Issue293StaticMembers::class);
 
         // it does not weaves Issue293DynamicMembers class
-        $this->assertFalse(file_exists(self::$aspectCacheDir.'/_proxies/src/Application/Issue293DynamicMembers.php'));
-        $this->assertFalse(file_exists(self::$aspectCacheDir.'/src/Application/Issue293DynamicMembers.php'));
+        $this->assertClassIsNotWeaved(Issue293DynamicMembers::class);
     }
 }

--- a/tests/Go/Functional/Issue293Test.php
+++ b/tests/Go/Functional/Issue293Test.php
@@ -12,9 +12,9 @@ class Issue293Test extends BaseFunctionalTest
      */
     public function testItDoesNotWeaveDynamicMethodsForComplexStaticPointcut()
     {
-        $this->assertClassIsWeaved(Issue293StaticMembers::class);
+        $this->assertClassIsWoven(Issue293StaticMembers::class);
 
         // it does not weaves Issue293DynamicMembers class
-        $this->assertClassIsNotWeaved(Issue293DynamicMembers::class);
+        $this->assertClassIsNotWoven(Issue293DynamicMembers::class);
     }
 }

--- a/tests/Go/Functional/MethodWeavingTest.php
+++ b/tests/Go/Functional/MethodWeavingTest.php
@@ -2,24 +2,20 @@
 
 namespace Go\Functional;
 
+use Go\Tests\TestProject\Application\AbstractBar;
+use Go\Tests\TestProject\Application\Main;
+
 class MethodWeavingTest extends BaseFunctionalTest
 {
-    public function setUp()
-    {
-        self::warmUp();
-    }
-
     /**
      * test for https://github.com/goaop/framework/issues/335
      */
     public function testItDoesNotWeaveAbstractMethods()
     {
         // it weaves Main class
-        $this->assertTrue(file_exists(self::$aspectCacheDir.'/_proxies/src/Application/Main.php'));
-        $this->assertTrue(file_exists(self::$aspectCacheDir.'/src/Application/Main.php'));
+        $this->assertClassIsWeaved(Main::class);
 
         // it does not weaves AbstractBar class
-        $this->assertFalse(file_exists(self::$aspectCacheDir.'/_proxies/src/Application/AbstractBar.php'));
-        $this->assertFalse(file_exists(self::$aspectCacheDir.'/src/Application/AbstractBar.php'));
+        $this->assertClassIsNotWeaved(AbstractBar::class);
     }
 }

--- a/tests/Go/Functional/MethodWeavingTest.php
+++ b/tests/Go/Functional/MethodWeavingTest.php
@@ -13,9 +13,9 @@ class MethodWeavingTest extends BaseFunctionalTest
     public function testItDoesNotWeaveAbstractMethods()
     {
         // it weaves Main class
-        $this->assertClassIsWeaved(Main::class);
+        $this->assertClassIsWoven(Main::class);
 
         // it does not weaves AbstractBar class
-        $this->assertClassIsNotWeaved(AbstractBar::class);
+        $this->assertClassIsNotWoven(AbstractBar::class);
     }
 }


### PR DESCRIPTION
@lisachenko Bad weaving is not possible to detect in runtime.

But it is possible to detect it via command. If there is a "bad" weaving (circular references and what now) -> generated proxies will vary. 

So -> at least, we can provide a command utility that can help in debugging.

Need to do some code cleanup - but I would like you to checkout idea and see if we are on same page.