### PR TITLE
[Improvement] Inline definition of advices into classes and beautify formatting

### DIFF
--- a/tests/Go/Instrument/Transformer/_files/class-woven.php
+++ b/tests/Go/Instrument/Transformer/_files/class-woven.php
@@ -27,7 +27,28 @@ class TestClass extends TestClass__AopProxied implements \Go\Aop\Proxy
     /**
      * Property was created automatically, do not change it manually
      */
-    private static $__joinPoints = [];
+    private static $__joinPoints = [
+        'method' => [
+            'publicMethod' => [
+                'advisor.Test\\ns1\\TestClass->publicMethod'
+            ],
+            'protectedMethod' => [
+                'advisor.Test\\ns1\\TestClass->protectedMethod'
+            ],
+            'publicStaticMethod' => [
+                'advisor.Test\\ns1\\TestClass->publicStaticMethod'
+            ],
+            'protectedStaticMethod' => [
+                'advisor.Test\\ns1\\TestClass->protectedStaticMethod'
+            ],
+            'publicMethodDynamicArguments' => [
+                'advisor.Test\\ns1\\TestClass->publicMethodDynamicArguments'
+            ],
+            'publicMethodFixedArguments' => [
+                'advisor.Test\\ns1\\TestClass->publicMethodFixedArguments'
+            ]
+        ]
+    ];
 
     public function publicMethod()
     {
@@ -60,32 +81,4 @@ class TestClass extends TestClass__AopProxied implements \Go\Aop\Proxy
     }
 
 }
-\Go\Proxy\ClassProxy::injectJoinPoints('Test\ns1\TestClass',array (
-  'method' =>
-  array (
-    'publicMethod' =>
-    array (
-      0 => 'advisor.Test\\ns1\\TestClass->publicMethod',
-    ),
-    'protectedMethod' =>
-    array (
-      0 => 'advisor.Test\\ns1\\TestClass->protectedMethod',
-    ),
-    'publicStaticMethod' =>
-    array (
-      0 => 'advisor.Test\\ns1\\TestClass->publicStaticMethod',
-    ),
-    'protectedStaticMethod' =>
-    array (
-      0 => 'advisor.Test\\ns1\\TestClass->protectedStaticMethod',
-    ),
-    'publicMethodDynamicArguments' =>
-    array (
-      0 => 'advisor.Test\\ns1\\TestClass->publicMethodDynamicArguments',
-    ),
-    'publicMethodFixedArguments' =>
-    array (
-      0 => 'advisor.Test\\ns1\\TestClass->publicMethodFixedArguments',
-    ),
-  ),
-));
+\Go\Proxy\ClassProxy::injectJoinPoints(TestClass::class);

--- a/tests/Go/Instrument/Transformer/_files/final-class-woven.php
+++ b/tests/Go/Instrument/Transformer/_files/final-class-woven.php
@@ -18,7 +18,22 @@ final class TestFinalClass extends TestFinalClass__AopProxied implements \Go\Aop
     /**
      * Property was created automatically, do not change it manually
      */
-    private static $__joinPoints = [];
+    private static $__joinPoints = [
+        'method' => [
+            'publicMethod' => [
+                'advisor.Test\\ns1\\TestFinalClass->publicMethod'
+            ],
+            'protectedMethod' => [
+                'advisor.Test\\ns1\\TestFinalClass->protectedMethod'
+            ],
+            'publicStaticMethod' => [
+                'advisor.Test\\ns1\\TestFinalClass->publicStaticMethod'
+            ],
+            'protectedStaticMethod' => [
+                'advisor.Test\\ns1\\TestFinalClass->protectedStaticMethod'
+            ]
+        ]
+    ];
 
     public function publicMethod()
     {
@@ -40,24 +55,4 @@ final class TestFinalClass extends TestFinalClass__AopProxied implements \Go\Aop
         return self::$__joinPoints['static:protectedStaticMethod']->__invoke(static::class);
     }
 }
-\Go\Proxy\ClassProxy::injectJoinPoints('Test\ns1\TestFinalClass',array (
-  'method' =>
-  array (
-    'publicMethod' =>
-    array (
-      0 => 'advisor.Test\\ns1\\TestFinalClass->publicMethod',
-    ),
-    'protectedMethod' =>
-    array (
-      0 => 'advisor.Test\\ns1\\TestFinalClass->protectedMethod',
-    ),
-    'publicStaticMethod' =>
-    array (
-      0 => 'advisor.Test\\ns1\\TestFinalClass->publicStaticMethod',
-    ),
-    'protectedStaticMethod' =>
-    array (
-      0 => 'advisor.Test\\ns1\\TestFinalClass->protectedStaticMethod',
-    ),
-  ),
-));
+\Go\Proxy\ClassProxy::injectJoinPoints(TestFinalClass::class);

--- a/tests/Go/Instrument/Transformer/_files/multiple-classes-woven.php
+++ b/tests/Go/Instrument/Transformer/_files/multiple-classes-woven.php
@@ -12,7 +12,13 @@ class TestClass1 extends TestClass1__AopProxied implements \Go\Aop\Proxy
     /**
      * Property was created automatically, do not change it manually
      */
-    private static $__joinPoints = [];
+    private static $__joinPoints = [
+        'method' => [
+            'test' => [
+                'advisor.Test\\ns3\\TestClass1->test'
+            ]
+        ]
+    ];
 
     public static function test()
     {
@@ -20,15 +26,7 @@ class TestClass1 extends TestClass1__AopProxied implements \Go\Aop\Proxy
     }
 
 }
-\Go\Proxy\ClassProxy::injectJoinPoints('Test\ns3\TestClass1',array (
-  'method' =>
-  array (
-    'test' =>
-    array (
-      0 => 'advisor.Test\\ns3\\TestClass1->test',
-    ),
-  ),
-));
+\Go\Proxy\ClassProxy::injectJoinPoints(TestClass1::class);
 
 TestClass1::test();
 
@@ -42,7 +40,13 @@ class TestClass11 extends TestClass11__AopProxied implements \Go\Aop\Proxy
     /**
      * Property was created automatically, do not change it manually
      */
-    private static $__joinPoints = [];
+    private static $__joinPoints = [
+        'method' => [
+            'test' => [
+                'advisor.Test\\ns3\\TestClass11->test'
+            ]
+        ]
+    ];
 
     public static function test()
     {
@@ -50,15 +54,7 @@ class TestClass11 extends TestClass11__AopProxied implements \Go\Aop\Proxy
     }
 
 }
-\Go\Proxy\ClassProxy::injectJoinPoints('Test\ns3\TestClass11',array (
-  'method' =>
-  array (
-    'test' =>
-    array (
-      0 => 'advisor.Test\\ns3\\TestClass11->test',
-    ),
-  ),
-));
+\Go\Proxy\ClassProxy::injectJoinPoints(TestClass11::class);
 
 TestClass11::test();
 
@@ -72,7 +68,13 @@ class TestClass2 extends TestClass2__AopProxied implements \Go\Aop\Proxy
     /**
      * Property was created automatically, do not change it manually
      */
-    private static $__joinPoints = [];
+    private static $__joinPoints = [
+        'method' => [
+            'test' => [
+                'advisor.Test\\ns3\\TestClass2->test'
+            ]
+        ]
+    ];
 
     public static function test()
     {
@@ -80,14 +82,6 @@ class TestClass2 extends TestClass2__AopProxied implements \Go\Aop\Proxy
     }
 
 }
-\Go\Proxy\ClassProxy::injectJoinPoints('Test\ns3\TestClass2',array (
-  'method' =>
-  array (
-    'test' =>
-    array (
-      0 => 'advisor.Test\\ns3\\TestClass2->test',
-    ),
-  ),
-));
+\Go\Proxy\ClassProxy::injectJoinPoints(TestClass2::class);
 
 TestClass2::test();

--- a/tests/Go/Instrument/Transformer/_files/multiple-ns-woven.php
+++ b/tests/Go/Instrument/Transformer/_files/multiple-ns-woven.php
@@ -11,7 +11,13 @@ class TestClass1 extends TestClass1__AopProxied implements \Go\Aop\Proxy
     /**
      * Property was created automatically, do not change it manually
      */
-    private static $__joinPoints = [];
+    private static $__joinPoints = [
+        'method' => [
+            'test' => [
+                'advisor.Test\\ns1\\TestClass1->test'
+            ]
+        ]
+    ];
 
     public static function test()
     {
@@ -19,15 +25,7 @@ class TestClass1 extends TestClass1__AopProxied implements \Go\Aop\Proxy
     }
 
 }
-\Go\Proxy\ClassProxy::injectJoinPoints('Test\ns1\TestClass1',array (
-  'method' =>
-  array (
-    'test' =>
-    array (
-      0 => 'advisor.Test\\ns1\\TestClass1->test',
-    ),
-  ),
-));
+\Go\Proxy\ClassProxy::injectJoinPoints(TestClass1::class);
 
 }
 
@@ -43,7 +41,13 @@ class TestClass2 extends TestClass2__AopProxied implements \Go\Aop\Proxy
     /**
      * Property was created automatically, do not change it manually
      */
-    private static $__joinPoints = [];
+    private static $__joinPoints = [
+        'method' => [
+            'test' => [
+                'advisor.Test\\ns2\\TestClass2->test'
+            ]
+        ]
+    ];
 
     public static function test()
     {
@@ -51,14 +55,6 @@ class TestClass2 extends TestClass2__AopProxied implements \Go\Aop\Proxy
     }
 
 }
-\Go\Proxy\ClassProxy::injectJoinPoints('Test\ns2\TestClass2',array (
-  'method' =>
-  array (
-    'test' =>
-    array (
-      0 => 'advisor.Test\\ns2\\TestClass2->test',
-    ),
-  ),
-));
+\Go\Proxy\ClassProxy::injectJoinPoints(TestClass2::class);
 
 }

--- a/tests/Go/Instrument/Transformer/_files/php7-class-woven.php
+++ b/tests/Go/Instrument/Transformer/_files/php7-class-woven.php
@@ -24,7 +24,58 @@ class TestPhp7Class extends TestPhp7Class__AopProxied implements \Go\Aop\Proxy
     /**
      * Property was created automatically, do not change it manually
      */
-    private static $__joinPoints = [];
+    private static $__joinPoints = [
+        'method' => [
+            'stringSth' => [
+                'advisor.Test\\ns1\\TestPhp7Class->stringSth'
+            ],
+            'floatSth' => [
+                'advisor.Test\\ns1\\TestPhp7Class->floatSth'
+            ],
+            'boolSth' => [
+                'advisor.Test\\ns1\\TestPhp7Class->boolSth'
+            ],
+            'intSth' => [
+                'advisor.Test\\ns1\\TestPhp7Class->intSth'
+            ],
+            'callableSth' => [
+                'advisor.Test\\ns1\\TestPhp7Class->callableSth'
+            ],
+            'arraySth' => [
+                'advisor.Test\\ns1\\TestPhp7Class->arraySth'
+            ],
+            'variadicStringSthByRef' => [
+                'advisor.Test\\ns1\\TestPhp7Class->variadicStringSthByRef'
+            ],
+            'exceptionArg' => [
+                'advisor.Test\\ns1\\TestPhp7Class->exceptionArg'
+            ],
+            'stringRth' => [
+                'advisor.Test\\ns1\\TestPhp7Class->stringRth'
+            ],
+            'floatRth' => [
+                'advisor.Test\\ns1\\TestPhp7Class->floatRth'
+            ],
+            'boolRth' => [
+                'advisor.Test\\ns1\\TestPhp7Class->boolRth'
+            ],
+            'intRth' => [
+                'advisor.Test\\ns1\\TestPhp7Class->intRth'
+            ],
+            'callableRth' => [
+                'advisor.Test\\ns1\\TestPhp7Class->callableRth'
+            ],
+            'arrayRth' => [
+                'advisor.Test\\ns1\\TestPhp7Class->arrayRth'
+            ],
+            'exceptionRth' => [
+                'advisor.Test\\ns1\\TestPhp7Class->exceptionRth'
+            ],
+            'noRth' => [
+                'advisor.Test\\ns1\\TestPhp7Class->noRth'
+            ]
+        ]
+    ];
     public function stringSth(string $arg)
     {
         return self::$__joinPoints['method:stringSth']->__invoke($this, [$arg]);
@@ -90,72 +141,4 @@ class TestPhp7Class extends TestPhp7Class__AopProxied implements \Go\Aop\Proxy
         return self::$__joinPoints['method:noRth']->__invoke($this, [$exception]);
     }
 }
-\Go\Proxy\ClassProxy::injectJoinPoints('Test\ns1\TestPhp7Class',array (
-  'method' =>
-  array (
-    'stringSth' =>
-    array (
-      0 => 'advisor.Test\\ns1\\TestPhp7Class->stringSth',
-    ),
-    'floatSth' =>
-    array (
-      0 => 'advisor.Test\\ns1\\TestPhp7Class->floatSth',
-    ),
-    'boolSth' =>
-    array (
-      0 => 'advisor.Test\\ns1\\TestPhp7Class->boolSth',
-    ),
-    'intSth' =>
-    array (
-      0 => 'advisor.Test\\ns1\\TestPhp7Class->intSth',
-    ),
-    'callableSth' =>
-    array (
-      0 => 'advisor.Test\\ns1\\TestPhp7Class->callableSth',
-    ),
-    'arraySth' =>
-    array (
-      0 => 'advisor.Test\\ns1\\TestPhp7Class->arraySth',
-    ),
-    'variadicStringSthByRef' =>
-    array (
-      0 => 'advisor.Test\\ns1\\TestPhp7Class->variadicStringSthByRef',
-    ),
-    'exceptionArg' =>
-    array (
-      0 => 'advisor.Test\\ns1\\TestPhp7Class->exceptionArg',
-    ),
-    'stringRth' =>
-    array (
-      0 => 'advisor.Test\\ns1\\TestPhp7Class->stringRth',
-    ),
-    'floatRth' =>
-    array (
-      0 => 'advisor.Test\\ns1\\TestPhp7Class->floatRth',
-    ),
-    'boolRth' =>
-    array (
-      0 => 'advisor.Test\\ns1\\TestPhp7Class->boolRth',
-    ),
-    'intRth' =>
-    array (
-      0 => 'advisor.Test\\ns1\\TestPhp7Class->intRth',
-    ),
-    'callableRth' =>
-    array (
-      0 => 'advisor.Test\\ns1\\TestPhp7Class->callableRth',
-    ),
-    'arrayRth' =>
-    array (
-      0 => 'advisor.Test\\ns1\\TestPhp7Class->arrayRth',
-    ),
-    'exceptionRth' =>
-    array (
-      0 => 'advisor.Test\\ns1\\TestPhp7Class->exceptionRth',
-    ),
-    'noRth' =>
-    array (
-      0 => 'advisor.Test\\ns1\\TestPhp7Class->noRth',
-    ),
-  ),
-));
+\Go\Proxy\ClassProxy::injectJoinPoints(TestPhp7Class::class);


### PR DESCRIPTION
This PR changes the way of storing advices in proxies, as of now, all advices are stored in the property by default. This should enable opcache optimization for storing this array (it won't be parsed and will be stored in shared memory for classes).

Also, PR beautifies formatting of array and make it clever in proxies, no more ugly `var_export`. 