### PR TITLE
[BC BREAK] Simplify interface of IntroductionAdvisor

### DIFF
--- a/src/Aop/Framework/TraitIntroductionInfo.php
+++ b/src/Aop/Framework/TraitIntroductionInfo.php
@@ -19,48 +19,48 @@ class TraitIntroductionInfo implements IntroductionInfo
 {
 
     /**
-     * List of interfaces to introduce
+     * Introduced interface
      *
-     * @var array
+     * @var string
      */
-    private $introducedInterfaces;
+    private $introducedInterface = '';
 
     /**
-     * List of traits to include
+     * Trait to use
      *
-     * @var array
+     * @var string
      */
-    private $introducedTraits;
+    private $introducedTrait = '';
 
     /**
      * Create a DefaultIntroductionAdvisor for the given advice.
      *
-     * @param string|string[] $introducedInterfaces List of introduced interfaces
-     * @param string|string[] $introducedTraits List of introduced traits
+     * @param string $introducedTrait Introduced trait
+     * @param string $introducedInterface Introduced interface
      */
-    public function __construct($introducedInterfaces, $introducedTraits)
+    public function __construct($introducedTrait, $introducedInterface)
     {
-        $this->introducedInterfaces = (array) $introducedInterfaces;
-        $this->introducedTraits     = (array) $introducedTraits;
+        $this->introducedTrait     = $introducedTrait;
+        $this->introducedInterface = $introducedInterface;
     }
 
     /**
-     * Return the additional interfaces introduced by this Advisor or Advice.
+     * Return the additional interface introduced by this Advisor or Advice.
      *
-     * @return array|string[] introduced interfaces
+     * @return string The introduced interface or empty
      */
-    public function getInterfaces()
+    public function getInterface()
     {
-        return $this->introducedInterfaces;
+        return $this->introducedInterface;
     }
 
     /**
-     * Return the list of traits with realization of introduced interfaces
+     * Return the additional trait with realization of introduced interface
      *
-     * @return array|string[] trait implementations
+     * @return string The trait name to use or empty
      */
-    public function getTraits()
+    public function getTrait()
     {
-        return $this->introducedTraits;
+        return $this->introducedTrait;
     }
 }

--- a/src/Aop/IntroductionAdvisor.php
+++ b/src/Aop/IntroductionAdvisor.php
@@ -29,14 +29,4 @@ interface IntroductionAdvisor extends Advisor
      * @return PointFilter The class filter
      */
     public function getClassFilter();
-
-    /**
-     * Can the advised interfaces be implemented by the introduction advice?
-     *
-     * Invoked before adding an IntroductionAdvisor.
-     *
-     * @return void
-     * @throws \InvalidArgumentException if the advised interfaces can't be implemented by the introduction advice
-     */
-    public function validateInterfaces();
 }

--- a/src/Aop/IntroductionInfo.php
+++ b/src/Aop/IntroductionInfo.php
@@ -21,16 +21,16 @@ interface IntroductionInfo extends Advice
 {
 
     /**
-     * Return the additional interfaces introduced by this Advisor or Advice.
+     * Return the additional interface introduced by this Advisor or Advice.
      *
-     * @return array|string[] the introduced interfaces
+     * @return string The introduced interface or empty
      */
-    public function getInterfaces();
+    public function getInterface();
 
     /**
-     * Return the list of traits with realization of introduced interfaces
+     * Return the additional trait with realization of introduced interface
      *
-     * @return array|string[] the implementations
+     * @return string The trait name to use or empty
      */
-    public function getTraits();
+    public function getTrait();
 }

--- a/src/Aop/Support/DeclareParentsAdvisor.php
+++ b/src/Aop/Support/DeclareParentsAdvisor.php
@@ -10,12 +10,9 @@
 
 namespace Go\Aop\Support;
 
-use InvalidArgumentException;
-use ReflectionClass;
-use Go\Aop\Advice;
-use Go\Aop\PointFilter;
-use Go\Aop\IntroductionInfo;
 use Go\Aop\IntroductionAdvisor;
+use Go\Aop\IntroductionInfo;
+use Go\Aop\PointFilter;
 
 /**
  * Introduction advisor delegating to the given object.
@@ -24,7 +21,9 @@ class DeclareParentsAdvisor implements IntroductionAdvisor
 {
 
     /**
-     * @var null|IntroductionInfo
+     * Information about introduced interface/trait
+     *
+     * @var IntroductionInfo
      */
     private $advice;
 
@@ -45,35 +44,9 @@ class DeclareParentsAdvisor implements IntroductionAdvisor
     }
 
     /**
-     * Can the advised interfaces be implemented by the introduction advice?
-     *
-     * Invoked before adding an IntroductionAdvisor.
-     *
-     * @return void
-     * @throws \InvalidArgumentException if the advised interfaces can't be implemented by the introduction advice
-     */
-    public function validateInterfaces()
-    {
-        $refInterface      = new ReflectionClass(reset($this->advice->getInterfaces()));
-        $refImplementation = new ReflectionClass(reset($this->advice->getTraits()));
-        if (!$refInterface->isInterface()) {
-            throw new \InvalidArgumentException("Only interface can be introduced");
-        }
-        if (!$refImplementation->isTrait()) {
-            throw new \InvalidArgumentException("Only trait can be used as implementation");
-        }
-
-        foreach ($refInterface->getMethods() as $interfaceMethod) {
-            if (!$refImplementation->hasMethod($interfaceMethod->name)) {
-                throw new \DomainException("Implementation requires method {$interfaceMethod->name}");
-            }
-        }
-    }
-
-    /**
      * Returns an advice to apply
      *
-     * @return Advice|IntroductionInfo|null
+     * @return IntroductionInfo
      */
     public function getAdvice()
     {
@@ -90,28 +63,5 @@ class DeclareParentsAdvisor implements IntroductionAdvisor
     public function getClassFilter()
     {
         return $this->classFilter;
-    }
-
-    /**
-     * Set the class filter for advisor
-     *
-     * @param PointFilter $classFilter Filter for classes
-     */
-    public function setClassFilter(PointFilter $classFilter)
-    {
-        $this->classFilter = $classFilter;
-    }
-
-    /**
-     * Return string representation of object
-     *
-     * @return string
-     */
-    public function __toString()
-    {
-        $adviceClass      = get_class($this->advice);
-        $interfaceClasses = implode(',', $this->advice->getInterfaces());
-
-        return get_called_class() . ": advice [{$adviceClass}]; interfaces [{$interfaceClasses}] ";
     }
 }

--- a/src/Core/IntroductionAspectExtension.php
+++ b/src/Core/IntroductionAspectExtension.php
@@ -80,9 +80,9 @@ class IntroductionAspectExtension extends AbstractAspectLoaderExtension
 
         switch (true) {
             case ($metaInformation instanceof Annotation\DeclareParents):
-                $interface = $metaInformation->interface;
                 $implement = $metaInformation->defaultImpl;
-                $advice    = new Framework\TraitIntroductionInfo($interface, $implement);
+                $interface = $metaInformation->interface;
+                $advice    = new Framework\TraitIntroductionInfo($implement, $interface);
                 $advisor   = new Support\DeclareParentsAdvisor($pointcut->getClassFilter(), $advice);
                 $loadedItems[$propertyId] = $advisor;
                 break;

--- a/src/Lang/Annotation/DeclareParents.php
+++ b/src/Lang/Annotation/DeclareParents.php
@@ -18,8 +18,8 @@ namespace Go\Lang\Annotation;
  *
  * @Attributes({
  *   @Attribute("value", type = "string", required=true),
- *   @Attribute("interface", type = "array"),
- *   @Attribute("defaultImpl", type = "array")
+ *   @Attribute("interface", type = "string"),
+ *   @Attribute("defaultImpl", type = "string")
  * })
  */
 class DeclareParents extends BaseAnnotation

--- a/src/Proxy/ClassProxy.php
+++ b/src/Proxy/ClassProxy.php
@@ -147,11 +147,13 @@ class ClassProxy extends AbstractProxy
                 case AspectContainer::INTRODUCTION_TRAIT_PREFIX:
                     foreach ($typedAdvices as $advice) {
                         /** @var $advice IntroductionInfo */
-                        foreach ($advice->getInterfaces() as $interface) {
-                            $this->addInterface($interface);
+                        $introducedTrait = $advice->getTrait();
+                        if (!empty($introducedTrait)) {
+                            $this->addTrait($introducedTrait);
                         }
-                        foreach ($advice->getTraits() as $trait) {
-                            $this->addTrait($trait);
+                        $introducedInterface = $advice->getInterface();
+                        if (!empty($introducedInterface)) {
+                            $this->addInterface($introducedInterface);
                         }
                     }
                     break;


### PR DESCRIPTION
This PR introduces small BC break, but no-one should notice that, because it's only implementation detail and not marked with "@api" tag. However code become cleaner and straightforward.

What changed: 
 - Introduction could contain now only one interface/trait per introduction.
 - Method `validateInterfaces()` was removed, because it was unused. This check isn't required at weaving time, we can rely on PHP to check if we implement all methods or should declare class an abstract.
 - Removed `__toString()` from advisor class implementation. Why this method was here?