### PR TITLE
Fix incorrect optimization logic for transformers, resolves #355

### DIFF
--- a/src/Core/AspectKernel.php
+++ b/src/Core/AspectKernel.php
@@ -235,7 +235,13 @@ abstract class AspectKernel
         $aspectKernel     = $this;
 
         $sourceTransformers = function () use ($filterInjector, $magicTransformer, $aspectKernel, $cacheManager) {
-            $transformers    = [];
+            $transformers = [];
+            if ($aspectKernel->hasFeature(Features::INTERCEPT_INITIALIZATIONS)) {
+                $transformers[] = new ConstructorExecutionTransformer();
+            }
+            if ($aspectKernel->hasFeature(Features::INTERCEPT_INCLUDES)) {
+                $transformers[] = $filterInjector;
+            }
             $aspectContainer = $aspectKernel->getContainer();
             $transformers[]  = new WeavingTransformer(
                 $aspectKernel,
@@ -243,14 +249,7 @@ abstract class AspectKernel
                 $cacheManager,
                 $aspectContainer->get('aspect.cached.loader')
             );
-            if ($aspectKernel->hasFeature(Features::INTERCEPT_INCLUDES)) {
-                $transformers[] = $filterInjector;
-            }
             $transformers[] = $magicTransformer;
-
-            if ($aspectKernel->hasFeature(Features::INTERCEPT_INITIALIZATIONS)) {
-                $transformers[] = new ConstructorExecutionTransformer();
-            }
 
             return $transformers;
         };

--- a/src/Instrument/ClassLoading/SourceTransformingLoader.php
+++ b/src/Instrument/ClassLoading/SourceTransformingLoader.php
@@ -125,18 +125,16 @@ class SourceTransformingLoader extends PhpStreamFilter
      * Transforms source code by passing it through all transformers
      *
      * @param StreamMetaData|null $metadata Metadata from stream
-     * @return void|bool Return false if transformation should be stopped
+     *
+     * @return void
      */
     public static function transformCode(StreamMetaData $metadata)
     {
-        $result = null;
         foreach (self::$transformers as $transformer) {
             $result = $transformer->transform($metadata);
-            if ($result === false) {
+            if ($result === SourceTransformer::RESULT_ABORTED) {
                 break;
             }
         }
-
-        return $result;
     }
 }

--- a/src/Instrument/Transformer/FilterInjectorTransformer.php
+++ b/src/Instrument/Transformer/FilterInjectorTransformer.php
@@ -118,12 +118,12 @@ class FilterInjectorTransformer implements SourceTransformer
      * Wrap all includes into rewrite filter
      *
      * @param StreamMetaData $metadata Metadata for source
-     * @return void|bool Return false if transformation should be stopped
+     * @return int See RESULT_XXX constants in the interface
      */
     public function transform(StreamMetaData $metadata)
     {
         if ((strpos($metadata->source, 'include') === false) && (strpos($metadata->source, 'require') === false)) {
-            return;
+            return self::RESULT_ABSTAIN;
         }
         static $lookFor = array(
             T_INCLUDE      => true,
@@ -131,7 +131,7 @@ class FilterInjectorTransformer implements SourceTransformer
             T_REQUIRE      => true,
             T_REQUIRE_ONCE => true
         );
-        $tokenStream       = token_get_all($metadata->source);
+        $tokenStream = token_get_all($metadata->source);
 
         $transformedSource = '';
         $isWaitingEnd      = false;
@@ -176,6 +176,12 @@ class FilterInjectorTransformer implements SourceTransformer
                 $transformedSource .= ' \\' . __CLASS__ . '::rewrite(';
             }
         }
+        $transformationResult = ($metadata->source !== $transformedSource)
+            ? self::RESULT_TRANSFORMED
+            : self::RESULT_ABSTAIN;
+
         $metadata->source = $transformedSource;
+
+        return $transformationResult;
     }
 }

--- a/src/Instrument/Transformer/MagicConstantTransformer.php
+++ b/src/Instrument/Transformer/MagicConstantTransformer.php
@@ -50,13 +50,13 @@ class MagicConstantTransformer extends BaseSourceTransformer
      * This method may transform the supplied source and return a new replacement for it
      *
      * @param StreamMetaData $metadata Metadata for source
-     * @return void|bool Return false if transformation should be stopped
+     * @return int See RESULT_XXX constants in the interface
      */
     public function transform(StreamMetaData $metadata)
     {
         // Make the job only when we use cache directory
         if (!self::$rewriteToPath) {
-            return;
+            return self::RESULT_ABSTAIN;
         }
 
         $hasReflectionFilename = strpos($metadata->source, 'getFileName') !== false;
@@ -64,7 +64,7 @@ class MagicConstantTransformer extends BaseSourceTransformer
             (strpos($metadata->source, '__FILE__') !== false);
 
         if (!$hasMagicConstants && !$hasReflectionFilename) {
-            return;
+            return self::RESULT_ABSTAIN;
         }
 
         // Resolve magic constants
@@ -80,6 +80,8 @@ class MagicConstantTransformer extends BaseSourceTransformer
                 $metadata->source
             );
         }
+
+        return self::RESULT_TRANSFORMED;
     }
 
     /**

--- a/src/Instrument/Transformer/SourceTransformer.php
+++ b/src/Instrument/Transformer/SourceTransformer.php
@@ -15,12 +15,26 @@ namespace Go\Instrument\Transformer;
  */
 interface SourceTransformer
 {
+    /**
+     * Transformer decided to stop whole transformation process, all changes should be reverted
+     */
+    const RESULT_ABORTED = 'aborted';
+
+    /**
+     * Transformer voted to abstain transformation, need to process following transformers to get result
+     */
+    const RESULT_ABSTAIN = 'abstain';
+
+    /**
+     * Source code was transformed, can process next transformers if needed
+     */
+    const RESULT_TRANSFORMED = 'transformed';
 
     /**
      * This method may transform the supplied source and return a new replacement for it
      *
      * @param StreamMetaData $metadata Metadata for source
-     * @return void|bool Return false if transformation should be stopped
+     * @return int See RESULT_XXX constants in the interface
      */
     public function transform(StreamMetaData $metadata);
 }

--- a/src/Instrument/Transformer/WeavingTransformer.php
+++ b/src/Instrument/Transformer/WeavingTransformer.php
@@ -74,7 +74,7 @@ class WeavingTransformer extends BaseSourceTransformer
      * This method may transform the supplied source and return a new replacement for it
      *
      * @param StreamMetaData $metadata Metadata for source
-     * @return boolean Return false if transformation should be stopped
+     * @return int See RESULT_XXX constants in the interface
      */
     public function transform(StreamMetaData $metadata)
     {
@@ -111,8 +111,9 @@ class WeavingTransformer extends BaseSourceTransformer
             $totalTransformations += (integer) $wasFunctionsProcessed;
         }
 
-        // If we return false this will indicate no more transformation for following transformers
-        return $totalTransformations > 0;
+        $result = ($totalTransformations > 0) ? self::RESULT_TRANSFORMED : self::RESULT_ABSTAIN;
+
+        return $result;
     }
 
     /**


### PR DESCRIPTION
Initially all transformers were included during transformation phase, then I decided to optimize this behaviour for code that should not be woven.

At some point, initialization joinpoint weren't applied to each class even with enabled feature, because `WeavingTransformer` could decide to break transformation if no matching joinpoints are present in the class.

This PR should fix this, but initialization interception still requires transformation of almost every class that uses `new` in the source code.