### PR TITLE
[Feature] Implement parameter widening feature for generated code (#380)

### DIFF
--- a/src/Aop/Features.php
+++ b/src/Aop/Features.php
@@ -40,4 +40,11 @@ interface Features
      * This flag is usable for read-only file systems (GAE, phar, etc)
      */
     const PREBUILT_CACHE = 64;
+
+    /**
+     * Enables usage of parameter widening for PHP>=7.2.0
+     *
+     * @see https://wiki.php.net/rfc/parameter-no-type-variance
+     */
+    const PARAMETER_WIDENING = 128;
 }

--- a/src/Proxy/AbstractProxy.php
+++ b/src/Proxy/AbstractProxy.php
@@ -44,13 +44,24 @@ abstract class AbstractProxy
     protected static $staticLsbExpression = 'static::class';
 
     /**
+     * Whether or not proxy should use parameter widening
+     *
+     * @see https://wiki.php.net/rfc/parameter-no-type-variance
+     *
+     * @var bool
+     */
+    private $useParameterWidening;
+
+    /**
      * Constructs an abstract proxy class
      *
      * @param array $advices List of advices
+     * @param bool $useParameterWidening Should proxy use parameter widening feature
      */
-    public function __construct(array $advices = [])
+    public function __construct(array $advices = [], bool $useParameterWidening = false)
     {
-        $this->advices = $this->flattenAdvices($advices);
+        $this->advices              = $this->flattenAdvices($advices);
+        $this->useParameterWidening = $useParameterWidening;
     }
 
     /**
@@ -105,7 +116,7 @@ abstract class AbstractProxy
     {
         $type = '';
         $reflectionType = $parameter->getType();
-        if ($reflectionType) {
+        if ($reflectionType !== null && $this->useParameterWidening === false) {
             $nullablePrefix = (PHP_VERSION_ID >= 70100 && $reflectionType->allowsNull()) ? '?' : '';
             $nsPrefix       = $reflectionType->isBuiltin() ? '' : '\\';
             $type           = $nullablePrefix . $nsPrefix . ltrim((string) $reflectionType, '\\');

--- a/src/Proxy/ClassProxy.php
+++ b/src/Proxy/ClassProxy.php
@@ -114,12 +114,13 @@ class ClassProxy extends AbstractProxy
      *
      * @param ReflectionClass $parent Parent class reflection
      * @param array|Advice[][] $classAdvices List of advices for class
+     * @param bool $useParameterWidening Enables usage of parameter widening feature
      *
      * @throws \InvalidArgumentException if there are unknown type of advices
      */
-    public function __construct(ReflectionClass $parent, array $classAdvices)
+    public function __construct(ReflectionClass $parent, array $classAdvices, bool $useParameterWidening)
     {
-        parent::__construct($classAdvices);
+        parent::__construct($classAdvices, $useParameterWidening);
 
         $this->class           = $parent;
         $this->name            = $parent->getShortName();


### PR DESCRIPTION
This PR introduces logic of skipping parameter types for children classes, according to the implemented in 7.2 [parameter widening](https://wiki.php.net/rfc/parameter-no-type-variance).

So, you can apply this feature to control manually parameter binding or conversion. This can be `ParamConvertors`, parameter injectors, etc..

To enable this feature, add into kernel initialization:
```php
// Initialize demo aspect container
AspectKernel::getInstance()->init([
    // ... other config options
    'features' =>Features::PARAMETER_WIDENING,
]);
```

Please, remember, that this feature is available only for PHP>=7.2.0