### PR TITLE
[Feature] Implementation of annotation getters for the ClassField joinpoint (#387)

### DIFF
--- a/src/Aop/Framework/ClassFieldAccess.php
+++ b/src/Aop/Framework/ClassFieldAccess.php
@@ -13,6 +13,7 @@ namespace Go\Aop\Framework;
 
 use Go\Aop\AspectException;
 use Go\Aop\Intercept\FieldAccess;
+use Go\Aop\Support\AnnotatedReflectionProperty;
 use ReflectionProperty;
 
 /**
@@ -67,7 +68,7 @@ class ClassFieldAccess extends AbstractJoinpoint implements FieldAccess
     {
         parent::__construct($advices);
 
-        $this->reflectionProperty = $reflectionProperty = new ReflectionProperty($className, $fieldName);
+        $this->reflectionProperty = $reflectionProperty = new AnnotatedReflectionProperty($className, $fieldName);
         // Give an access to protected field
         if ($reflectionProperty->isProtected()) {
             $reflectionProperty->setAccessible(true);
@@ -84,6 +85,8 @@ class ClassFieldAccess extends AbstractJoinpoint implements FieldAccess
 
     /**
      * Gets the field being accessed.
+     *
+     * @return ReflectionProperty|AnnotatedReflectionProperty the property which is being accessed.
      */
     public function getField(): ReflectionProperty
     {

--- a/src/Aop/Support/AnnotatedReflectionMethod.php
+++ b/src/Aop/Support/AnnotatedReflectionMethod.php
@@ -18,7 +18,7 @@ use ReflectionMethod;
 /**
  * Extended version of ReflectionMethod with annotation support
  */
-class AnnotatedReflectionMethod extends ReflectionMethod
+class AnnotatedReflectionMethod extends ReflectionMethod implements AnnotationAccess
 {
     /**
      * Annotation reader

--- a/src/Aop/Support/AnnotatedReflectionMethod.php
+++ b/src/Aop/Support/AnnotatedReflectionMethod.php
@@ -28,7 +28,7 @@ class AnnotatedReflectionMethod extends ReflectionMethod implements AnnotationAc
     private static $annotationReader;
 
     /**
-     * Gets a method annotation.
+     * Gets method annotation.
      *
      * @param string $annotationName The name of the annotation.
      * @return mixed The Annotation or NULL, if the requested annotation does not exist.

--- a/src/Aop/Support/AnnotatedReflectionProperty.php
+++ b/src/Aop/Support/AnnotatedReflectionProperty.php
@@ -1,0 +1,60 @@
+<?php
+declare(strict_types = 1);
+/*
+ * Go! AOP framework
+ *
+ * @copyright Copyright 2014, Lisachenko Alexander <lisachenko.it@gmail.com>
+ *
+ * This source file is subject to the license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Go\Aop\Support;
+
+use Doctrine\Common\Annotations\Reader;
+use Go\Core\AspectKernel;
+use ReflectionProperty;
+
+/**
+ * Extended version of ReflectionProperty with annotation support
+ */
+class AnnotatedReflectionProperty extends ReflectionProperty
+{
+    /**
+     * Annotation reader
+     *
+     * @var Reader
+     */
+    private static $annotationReader;
+
+    /**
+     * Gets a property annotation.
+     *
+     * @param string $annotationName The name of the annotation.
+     * @return mixed The Annotation or NULL, if the requested annotation does not exist.
+     */
+    public function getAnnotation(string $annotationName)
+    {
+        return self::getReader()->getPropertyAnnotation($this, $annotationName);
+    }
+
+    /**
+     * Gets the annotations applied to a property.
+     */
+    public function getAnnotations(): array
+    {
+        return self::getReader()->getPropertyAnnotations($this);
+    }
+
+    /**
+     * Returns an annotation reader
+     */
+    private static function getReader(): Reader
+    {
+        if (!self::$annotationReader) {
+            self::$annotationReader = AspectKernel::getInstance()->getContainer()->get('aspect.annotation.reader');
+        }
+
+        return self::$annotationReader;
+    }
+}

--- a/src/Aop/Support/AnnotatedReflectionProperty.php
+++ b/src/Aop/Support/AnnotatedReflectionProperty.php
@@ -18,7 +18,7 @@ use ReflectionProperty;
 /**
  * Extended version of ReflectionProperty with annotation support
  */
-class AnnotatedReflectionProperty extends ReflectionProperty
+class AnnotatedReflectionProperty extends ReflectionProperty implements AnnotationAccess
 {
     /**
      * Annotation reader

--- a/src/Aop/Support/AnnotatedReflectionProperty.php
+++ b/src/Aop/Support/AnnotatedReflectionProperty.php
@@ -28,7 +28,7 @@ class AnnotatedReflectionProperty extends ReflectionProperty implements Annotati
     private static $annotationReader;
 
     /**
-     * Gets a property annotation.
+     * Gets property annotation.
      *
      * @param string $annotationName The name of the annotation.
      * @return mixed The Annotation or NULL, if the requested annotation does not exist.

--- a/src/Aop/Support/AnnotationAccess.php
+++ b/src/Aop/Support/AnnotationAccess.php
@@ -17,7 +17,7 @@ namespace Go\Aop\Support;
 interface AnnotationAccess
 {
     /**
-     * Gets a annotation.
+     * Gets annotation.
      *
      * @param string $annotationName The name of the annotation.
      * @return mixed The Annotation or NULL, if the requested annotation does not exist.

--- a/src/Aop/Support/AnnotationAccess.php
+++ b/src/Aop/Support/AnnotationAccess.php
@@ -1,0 +1,31 @@
+<?php
+declare(strict_types = 1);
+/*
+ * Go! AOP framework
+ *
+ * @copyright Copyright 2014, Lisachenko Alexander <lisachenko.it@gmail.com>
+ *
+ * This source file is subject to the license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Go\Aop\Support;
+
+/**
+ * Provides access to annotations from reflection class/property/method.
+ */
+interface AnnotationAccess
+{
+    /**
+     * Gets a annotation.
+     *
+     * @param string $annotationName The name of the annotation.
+     * @return mixed The Annotation or NULL, if the requested annotation does not exist.
+     */
+    public function getAnnotation(string $annotationName);
+
+    /**
+     * Gets the annotations.
+     */
+    public function getAnnotations(): array;
+}

--- a/tests/Go/Aop/Framework/AbstractMethodInvocationTest.php
+++ b/tests/Go/Aop/Framework/AbstractMethodInvocationTest.php
@@ -3,6 +3,8 @@ declare(strict_types = 1);
 
 namespace Go\Aop\Framework;
 
+use Go\Aop\Support\AnnotationAccess;
+
 class AbstractMethodInvocationTest extends \PHPUnit_Framework_TestCase
 {
     /**
@@ -31,9 +33,6 @@ class AbstractMethodInvocationTest extends \PHPUnit_Framework_TestCase
 
     public function testProvidesAccessToAnnotations()
     {
-        $method = $this->invocation->getMethod();
-
-        $this->assertTrue(method_exists($method, 'getAnnotation'));
-        $this->assertTrue(method_exists($method, 'getAnnotations'));
+        $this->assertInstanceOf(AnnotationAccess::class, $this->invocation->getMethod());
     }
 }

--- a/tests/Go/Aop/Framework/AbstractMethodInvocationTest.php
+++ b/tests/Go/Aop/Framework/AbstractMethodInvocationTest.php
@@ -28,4 +28,12 @@ class AbstractMethodInvocationTest extends \PHPUnit_Framework_TestCase
     {
         $this->assertInstanceOf('ReflectionMethod', $this->invocation->getStaticPart());
     }
+
+    public function testProvidesAccessToAnnotations()
+    {
+        $method = $this->invocation->getMethod();
+
+        $this->assertTrue(method_exists($method, 'getAnnotation'));
+        $this->assertTrue(method_exists($method, 'getAnnotations'));
+    }
 }

--- a/tests/Go/Aop/Framework/ClassFieldAccessTest.php
+++ b/tests/Go/Aop/Framework/ClassFieldAccessTest.php
@@ -1,0 +1,36 @@
+<?php
+declare(strict_types = 1);
+
+namespace Go\Aop\Framework;
+
+class ClassFieldAccessTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var ClassFieldAccess
+     */
+    protected $classField;
+
+    public function setUp()
+    {
+        $this->classField = new ClassFieldAccess(__CLASS__, 'classField', []);
+    }
+
+    public function testClassFiledReturnsProperty()
+    {
+        $this->assertEquals(__CLASS__, $this->classField->getField()->class);
+        $this->assertEquals('classField', $this->classField->getField()->name);
+    }
+
+    public function testStaticPartEqualsToReflectionMethod()
+    {
+        $this->assertInstanceOf('ReflectionProperty', $this->classField->getStaticPart());
+    }
+
+    public function testProvidesAccessToAnnotations()
+    {
+        $field = $this->classField->getField();
+
+        $this->assertTrue(method_exists($field, 'getAnnotation'));
+        $this->assertTrue(method_exists($field, 'getAnnotations'));
+    }
+}

--- a/tests/Go/Aop/Framework/ClassFieldAccessTest.php
+++ b/tests/Go/Aop/Framework/ClassFieldAccessTest.php
@@ -3,6 +3,8 @@ declare(strict_types = 1);
 
 namespace Go\Aop\Framework;
 
+use Go\Aop\Support\AnnotationAccess;
+
 class ClassFieldAccessTest extends \PHPUnit_Framework_TestCase
 {
     /**
@@ -28,9 +30,6 @@ class ClassFieldAccessTest extends \PHPUnit_Framework_TestCase
 
     public function testProvidesAccessToAnnotations()
     {
-        $field = $this->classField->getField();
-
-        $this->assertTrue(method_exists($field, 'getAnnotation'));
-        $this->assertTrue(method_exists($field, 'getAnnotations'));
+        $this->assertInstanceOf(AnnotationAccess::class, $this->classField->getField());
     }
 }


### PR DESCRIPTION
- Allows direct access to class property annotations from aspect
- Added tests for Go\Aop\Framework\ClassField 
- Added test that verifies that access to annotations exists. 

NOTE: Due to singleton implementation of Kernel and access to Reader is done via service locator pattern and static access, it is hard to do a proper testing via injecting mock.

But, at least these tests would detect missing presence of methods which will warn us that we are introducing BC.