### PR TITLE
fix error with "self" references in top level ns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,3 @@ composer.lock
 phpunit.xml
 tests/Fixtures/project/var/cache/*
 build/
-.idea

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ composer.lock
 phpunit.xml
 tests/Fixtures/project/var/cache/*
 build/
+.idea

--- a/src/Instrument/Transformer/SelfValueVisitor.php
+++ b/src/Instrument/Transformer/SelfValueVisitor.php
@@ -114,7 +114,7 @@ final class SelfValueVisitor extends NodeVisitorAbstract
         $name->setAttribute('originalName', $originalName);
 
         $fullClassName    = Name::concat($this->namespace, $this->className);
-        $resolvedSelfName = new FullyQualified('\\' . $fullClassName->toString(), $name->getAttributes());
+        $resolvedSelfName = new FullyQualified('\\' . ltrim($fullClassName->toString(), '\\'), $name->getAttributes());
 
         $this->replacedNodes[] = $resolvedSelfName;
 


### PR DESCRIPTION
This fixes an error when a class with top level namespace uses `self::` to reference a class constant.

The error manifests for example as: 
```
PHP Parse error:  syntax error, unexpected '\' (T_NS_SEPARATOR), expecting identifier (T_STRING)
```