### PR TITLE
Reflection getFileName fix

### DIFF
--- a/src/Instrument/Transformer/MagicConstantTransformer.php
+++ b/src/Instrument/Transformer/MagicConstantTransformer.php
@@ -71,11 +71,14 @@ class MagicConstantTransformer extends BaseSourceTransformer
      */
     public static function resolveFileName(string $fileName): string
     {
-        return str_replace(
+        $suffix = '.php';
+        $pathParts = explode($suffix, str_replace(
             [self::$rewriteToPath, DIRECTORY_SEPARATOR . '_proxies'],
             [self::$rootPath, ''],
             $fileName
-        );
+        ));
+        // throw away namespaced path from actual filename
+        return $pathParts[0] . $suffix;
     }
 
     /**

--- a/tests/Fixtures/project/src/Application/Main.php
+++ b/tests/Fixtures/project/src/Application/Main.php
@@ -25,4 +25,10 @@ class Main extends AbstractBar
     {
         echo 'I did something else';
     }
+
+    public function getFilename()
+    {
+        $reflectedClass = new \ReflectionClass($this);
+        return $reflectedClass->getFileName();
+    }
 }

--- a/tests/Fixtures/project/src/Aspect/InitializationAspect.php
+++ b/tests/Fixtures/project/src/Aspect/InitializationAspect.php
@@ -25,6 +25,6 @@ class InitializationAspect implements Aspect
      */
     public function afterClassStaticInitialization()
     {
-        echo 'It invokes after class is loaded into memory.';
+        // echo 'It invokes after class is loaded into memory.';
     }
 }

--- a/tests/Go/Functional/BaseFunctionalTest.php
+++ b/tests/Go/Functional/BaseFunctionalTest.php
@@ -68,12 +68,10 @@ abstract class BaseFunctionalTest extends TestCase
 
     /**
      * Warms up Go! AOP cache.
-     *
-     * @return string Command output.
      */
-    protected function warmUp(): string
+    protected function warmUp(): void
     {
-        return $this->execute('cache:warmup:aop');
+        $this->execute('cache:warmup:aop');
     }
 
     /**

--- a/tests/Go/Functional/ReflectionFilenameTest.php
+++ b/tests/Go/Functional/ReflectionFilenameTest.php
@@ -1,0 +1,49 @@
+<?php
+declare(strict_types = 1);
+
+namespace Go\Functional;
+
+use Go\Core\AspectKernel;
+use Go\ParserReflection\ReflectionClass;
+use Go\Tests\TestProject\Application\Main;
+use Go\Instrument\Transformer\FilterInjectorTransformer;
+
+class ReflectionFilenameTest extends BaseFunctionalTest
+{
+    protected function warmUp(): void
+    {
+        $loader = $this->configuration['frontController'];
+        $path = stream_resolve_include_path($loader);
+        if (!is_readable($path)) {
+            throw new \InvalidArgumentException("Invalid loader path: {$loader}");
+        }
+
+        ob_start();
+        include_once $path;
+        ob_end_clean();
+
+        if (!class_exists(AspectKernel::class, false)) {
+            $message = "Kernel was not initialized yet, please configure it in the {$path}";
+            throw new \InvalidArgumentException($message);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function tearDown()
+    {
+        parent::tearDown();
+        $reflectedClass = new \ReflectionClass(FilterInjectorTransformer::class);
+        $reflectedProperty = $reflectedClass->getProperty('kernel');
+        $reflectedProperty->setAccessible(true);
+        $reflectedProperty = $reflectedProperty->setValue(null);
+    }
+
+    public function testReflectionFilenameIsCorrect()
+    {
+        $filename = (new ReflectionClass(Main::class))->getFileName();
+        $main = new Main();
+        $this->assertEquals($filename, $main->getFilename());
+    }
+}


### PR DESCRIPTION
After adding support for multiple classes in a single file (#364), calls to `ReflectionClass->getFilename` within a proxy will return an incorrect path that includes the new namespace fragment.

I've added a test to highlight the issue and included a fix.

The test may need refactoring as the setup (weaving) now occurs in the current thread instead of via a new process.  I did this as I needed access to an instance of the proxy to perform the filename check.  As you can see in the `tearDown` method, I've circumvented some of the side effects of not isolating the proxy creations by resetting the `FilterInjectorTransformer`.  This fixed the only errors that occurred in other tests but I guess it doesn't guarantee that there isn't, or won't be, subtle bugs preventing accurate tests in the future.  Happy to have input here on the best way to achieve this test while still isolating proxy creation.