### PR TITLE
Add ability for strict_types in proxy class.

### DIFF
--- a/tests/Go/Instrument/Transformer/WeavingTransformerTest.php
+++ b/tests/Go/Instrument/Transformer/WeavingTransformerTest.php
@@ -87,7 +87,7 @@ class WeavingTransformerTest extends \PHPUnit_Framework_TestCase
     /**
      * It's a caution check that multiple namespaces are not yet supported
      */
-    public function testMultipleNamespacesInOneFile()
+    public function testMultipleNamespacesInOneFile(): void
     {
         $metadata = $this->loadTest('multiple-ns');
         $this->transformer->transform($metadata);
@@ -113,7 +113,7 @@ class WeavingTransformerTest extends \PHPUnit_Framework_TestCase
     /**
      * Do not make anything for aspect class
      */
-    public function testAspectIsSkipped()
+    public function testAspectIsSkipped(): void
     {
         $metadata = $this->loadTest('aspect');
         $this->transformer->transform($metadata);
@@ -126,7 +126,7 @@ class WeavingTransformerTest extends \PHPUnit_Framework_TestCase
     /**
      * Main test case for method with typehint
      */
-    public function testWeaverForTypeHint()
+    public function testWeaverForTypeHint(): void
     {
         $metadata = $this->loadTest('class-typehint');
         $this->transformer->transform($metadata);
@@ -142,7 +142,7 @@ class WeavingTransformerTest extends \PHPUnit_Framework_TestCase
     /**
      * Check that weaver can work with PHP7 classes
      */
-    public function testWeaverForPhp7Class()
+    public function testWeaverForPhp7Class(): void
     {
         $metadata = $this->loadTest('php7-class');
         $this->transformer->transform($metadata);
@@ -160,7 +160,7 @@ class WeavingTransformerTest extends \PHPUnit_Framework_TestCase
     /**
      * Transformer verifies include paths
      */
-    public function testTransformerWithIncludePaths()
+    public function testTransformerWithIncludePaths(): void
     {
         $container = $this->getContainerMock();
         $reader    = $this->createMock(Reader::class);
@@ -205,7 +205,7 @@ class WeavingTransformerTest extends \PHPUnit_Framework_TestCase
     /**
      * Testcase for multiple classes (@see https://github.com/lisachenko/go-aop-php/issues/71)
      */
-    public function testMultipleClasses()
+    public function testMultipleClasses(): void
     {
         $metadata = $this->loadTest('multiple-classes');
         $this->transformer->transform($metadata);
@@ -221,7 +221,7 @@ class WeavingTransformerTest extends \PHPUnit_Framework_TestCase
      * @param string $value
      * @return string
      */
-    protected function normalizeWhitespaces($value)
+    protected function normalizeWhitespaces($value): string
     {
         return strtr(
             preg_replace('/\s+$/m', '', $value),
@@ -250,17 +250,13 @@ class WeavingTransformerTest extends \PHPUnit_Framework_TestCase
             true,
             ['getOptions', 'getContainer', 'hasFeature']
         );
-        $mock->expects($this->any())
-            ->method('getOptions')
-            ->will(
-                $this->returnValue($options)
-            );
 
-        $mock->expects($this->any())
-            ->method('getContainer')
-            ->will(
-                $this->returnValue($container)
-            );
+        $mock->method('getOptions')
+            ->willReturn($options);
+
+        $mock->method('getContainer')
+            ->willReturn($container);
+
         return $mock;
     }
 
@@ -272,7 +268,7 @@ class WeavingTransformerTest extends \PHPUnit_Framework_TestCase
     protected function getAdviceMatcherMock()
     {
         $mock = $this->createPartialMock(AdviceMatcher::class, ['getAdvicesForClass']);
-        $mock->expects($this->any())
+        $mock
             ->method('getAdvicesForClass')
             ->will(
                 $this->returnCallback(function (\ReflectionClass $refClass) {
@@ -315,7 +311,6 @@ class WeavingTransformerTest extends \PHPUnit_Framework_TestCase
         $container = $this->createMock(AspectContainer::class);
 
         $container
-            ->expects($this->any())
             ->method('getByTag')
             ->will($this->returnValueMap([
                 ['advisor', []]

--- a/tests/Go/Instrument/Transformer/_files/class-proxy.php
+++ b/tests/Go/Instrument/Transformer/_files/class-proxy.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace Test\ns1;
 
 class TestClass extends TestClass__AopProxied implements \Go\Aop\Proxy

--- a/tests/Go/Instrument/Transformer/_files/php7-class-proxy.php
+++ b/tests/Go/Instrument/Transformer/_files/php7-class-proxy.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace Test\ns1;
 class TestPhp7Class extends TestPhp7Class__AopProxied implements \Go\Aop\Proxy
 {

--- a/tests/Go/Instrument/Transformer/_files/php7-class-woven.php
+++ b/tests/Go/Instrument/Transformer/_files/php7-class-woven.php
@@ -1,5 +1,5 @@
 <?php
-declare(strict_types = 1);
+declare(strict_types=1);
 namespace Test\ns1;
 class TestPhp7Class__AopProxied
 {

--- a/tests/Go/Instrument/Transformer/_files/php7-class.php
+++ b/tests/Go/Instrument/Transformer/_files/php7-class.php
@@ -1,5 +1,5 @@
 <?php
-declare(strict_types = 1);
+declare(strict_types=1);
 namespace Test\ns1;
 
 class TestPhp7Class


### PR DESCRIPTION
Minor return type cleanup for unity test.
This solves #299.
This should also target version `3.x`,