### PR TITLE
[Feature] Add private properties interception

### DIFF
--- a/demos/Demo/Aspect/PropertyInterceptorAspect.php
+++ b/demos/Demo/Aspect/PropertyInterceptorAspect.php
@@ -28,7 +28,7 @@ class PropertyInterceptorAspect implements Aspect
      *
      * @param FieldAccess $fieldAccess Joinpoint
      *
-     * @Around("access(public|protected Demo\Example\PropertyDemo->*)")
+     * @Around("access(public|protected|private Demo\Example\PropertyDemo->*)")
      * @return mixed
      */
     public function aroundFieldAccess(FieldAccess $fieldAccess)

--- a/demos/Demo/Example/PropertyDemo.php
+++ b/demos/Demo/Example/PropertyDemo.php
@@ -20,6 +20,8 @@ class PropertyDemo
 
     protected $protectedProperty = 456;
 
+    private $privateProperty = 'test';
+
     protected $indirectModificationCheck = [4, 5, 6];
 
     public function showProtected()
@@ -38,5 +40,6 @@ class PropertyDemo
         if (count($this->indirectModificationCheck) !== 6) {
             throw new \RuntimeException("Indirect modification doesn't work!");
         }
+        $this->privateProperty = $this->privateProperty . 'bar';
     }
 }

--- a/src/Aop/Framework/ClassFieldAccess.php
+++ b/src/Aop/Framework/ClassFieldAccess.php
@@ -117,14 +117,20 @@ class ClassFieldAccess extends AbstractJoinpoint implements FieldAccess
      */
     public function ensureScopeRule(int $stackLevel = 2): void
     {
-        $property = $this->reflectionProperty;
-
-        if ($property->isProtected()) {
+        $property    = $this->reflectionProperty;
+        $isProtected = $property->isProtected();
+        $isPrivate   = $property->isPrivate();
+        if ($isProtected || $isPrivate) {
             $backTrace     = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, $stackLevel+1);
             $accessor      = $backTrace[$stackLevel] ?? [];
             $propertyClass = $property->class;
             if (isset($accessor['class'])) {
-                if ($accessor['class'] === $propertyClass || is_subclass_of($accessor['class'], $propertyClass)) {
+                // For private and protected properties its ok to access from the same class
+                if ($accessor['class'] === $propertyClass) {
+                    return;
+                }
+                // For protected properties its ok to access from any subclass
+                if ($isProtected && is_subclass_of($accessor['class'], $propertyClass)) {
                     return;
                 }
             }

--- a/src/Aop/Framework/ClassFieldAccess.php
+++ b/src/Aop/Framework/ClassFieldAccess.php
@@ -134,7 +134,7 @@ class ClassFieldAccess extends AbstractJoinpoint implements FieldAccess
                     return;
                 }
             }
-            throw new AspectException("Cannot access protected property {$propertyClass}::{$property->name}");
+            throw new AspectException("Cannot access property {$propertyClass}::{$property->name}");
         }
     }
 

--- a/src/Core/AdviceMatcher.php
+++ b/src/Core/AdviceMatcher.php
@@ -156,7 +156,7 @@ class AdviceMatcher
 
         // Check properties in class only for property filters
         if ($filterKind & Aop\PointFilter::KIND_PROPERTY) {
-            $mask = ReflectionProperty::IS_PUBLIC | ReflectionProperty::IS_PROTECTED;
+            $mask = ReflectionProperty::IS_PUBLIC | ReflectionProperty::IS_PROTECTED | ReflectionProperty::IS_PRIVATE;
             foreach ($class->getProperties($mask) as $property) {
                 if ($filter->matches($property, $class) && !$property->isStatic()) {
                     $classAdvices[AspectContainer::PROPERTY_PREFIX][$property->name][$advisorId] = $advisor->getAdvice();

--- a/src/Proxy/Part/InterceptedConstructorGenerator.php
+++ b/src/Proxy/Part/InterceptedConstructorGenerator.php
@@ -85,16 +85,19 @@ final class InterceptedConstructorGenerator extends MethodGenerator
         $assocProperties = [];
         $listProperties  = [];
         foreach ($interceptedProperties as $propertyName) {
-            $assocProperties[] = "    '{$propertyName}' => &\$this->{$propertyName}";
-            $listProperties[]  = "    \$this->{$propertyName}";
+            $assocProperties[] = "        '{$propertyName}' => &\$target->{$propertyName}";
+            $listProperties[]  = "        \$target->{$propertyName}";
         }
         $lines = [
-            '$this->__properties = [',
+            '$accessor = function(array &$propertyStorage, object $target) {',
+            '    $propertyStorage = [',
             implode(',' . PHP_EOL, $assocProperties),
-            '];',
-            'unset(',
+            '    ];',
+            '    unset(',
             implode(',' . PHP_EOL, $listProperties),
-            ');'
+            '    );',
+            '};',
+            '($accessor->bindTo($this, parent::class))($this->__properties, $this);'
         ];
 
         return implode(PHP_EOL, $lines);

--- a/tests/Go/Proxy/Part/InterceptedConstructorGeneratorTest.php
+++ b/tests/Go/Proxy/Part/InterceptedConstructorGeneratorTest.php
@@ -93,14 +93,17 @@ class InterceptedConstructorGeneratorTest extends TestCase
         $expectedCode  = preg_replace('/^\s+|\s+$/m', '', '
             public function __construct()
             {
-                $this->__properties = [
-                    \'foo\' => &$this->foo,
-                    \'bar\' => &$this->bar
-                ];
-                unset(
-                    $this->foo,
-                    $this->bar
-                );
+                $accessor = function(array &$propertyStorage, object $target) {
+                    $propertyStorage = [
+                        \'foo\' => &$target->foo,
+                        \'bar\' => &$target->bar
+                    ];
+                    unset(
+                        $target->foo,
+                        $target->bar
+                    );
+                };
+                ($accessor->bindTo($this, parent::class))($this->__properties, $this);
             }'
         );
         $this->assertSame($expectedCode, $generatedCode);


### PR DESCRIPTION
This PR introduces an ability to intercept access to private properties in classes. We use closure binding in generated proxy child class and bind it to the parent scope so we gain a control over private properties of the class as well.

Here is an example of generated constructor for the `Demo\Example\PropertyDemo` proxy class:
```php
    public function __construct()
    {
        $accessor = function(array &$propertyStorage, object $target) {
            $propertyStorage = [
                'publicProperty' => &$target->publicProperty,
                'protectedProperty' => &$target->protectedProperty,
                'privateProperty' => &$target->privateProperty,
                'indirectModificationCheck' => &$target->indirectModificationCheck
            ];
            unset(
                $target->publicProperty,
                $target->protectedProperty,
                $target->privateProperty,
                $target->indirectModificationCheck
            );
        };
        ($accessor->bindTo($this, parent::class))($this->__properties, $this);
        parent::__construct();
    }
```
As we store references to properties from given original object instance, we can read and write them via aspects without additional code logic.

Feature was requested in #411 by @jakzal 