### PR TITLE
AA-0003 fixed the Call to undefined method PhpParser\Node\Expr\Variab…

### DIFF
--- a/src/Instrument/Transformer/MagicConstantTransformer.php
+++ b/src/Instrument/Transformer/MagicConstantTransformer.php
@@ -91,7 +91,7 @@ class MagicConstantTransformer extends BaseSourceTransformer
         /** @var MethodCall[] $methodCalls */
         $methodCalls = $methodCallFinder->getFoundNodes();
         foreach ($methodCalls as $methodCallNode) {
-            if ($methodCallNode->name->toString() !== 'getFileName') {
+            if ($methodCallNode->name instanceof \PhpParser\Node\Identifier && $methodCallNode->name->toString() !== 'getFileName') {
                 continue;
             }
             $startPosition    = $methodCallNode->getAttribute('startTokenPos');

--- a/src/Instrument/Transformer/MagicConstantTransformer.php
+++ b/src/Instrument/Transformer/MagicConstantTransformer.php
@@ -92,7 +92,7 @@ class MagicConstantTransformer extends BaseSourceTransformer
         /** @var MethodCall[] $methodCalls */
         $methodCalls = $methodCallFinder->getFoundNodes();
         foreach ($methodCalls as $methodCallNode) {
-            if (($methodCallNode->name instanceof Identifier) && $methodCallNode->name->toString() === 'getFileName') {
+            if (($methodCallNode->name instanceof Identifier) && ($methodCallNode->name->toString() === 'getFileName')) {
                 $startPosition    = $methodCallNode->getAttribute('startTokenPos');
                 $endPosition      = $methodCallNode->getAttribute('endTokenPos');
                 $expressionPrefix = '\\' . __CLASS__ . '::resolveFileName(';

--- a/src/Instrument/Transformer/MagicConstantTransformer.php
+++ b/src/Instrument/Transformer/MagicConstantTransformer.php
@@ -1,5 +1,5 @@
 <?php
-declare(strict_types = 1);
+declare(strict_types=1);
 /*
  * Go! AOP framework
  *
@@ -13,6 +13,7 @@ namespace Go\Instrument\Transformer;
 
 use Go\Core\AspectKernel;
 use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Identifier;
 use PhpParser\Node\Scalar\MagicConst;
 use PhpParser\Node\Scalar\MagicConst\Dir;
 use PhpParser\Node\Scalar\MagicConst\File;
@@ -68,12 +69,13 @@ class MagicConstantTransformer extends BaseSourceTransformer
      */
     public static function resolveFileName(string $fileName): string
     {
-        $suffix = '.php';
+        $suffix    = '.php';
         $pathParts = explode($suffix, str_replace(
             [self::$rewriteToPath, DIRECTORY_SEPARATOR . '_proxies'],
             [self::$rootPath, ''],
             $fileName
         ));
+
         // throw away namespaced path from actual filename
         return $pathParts[0] . $suffix;
     }
@@ -91,15 +93,14 @@ class MagicConstantTransformer extends BaseSourceTransformer
         /** @var MethodCall[] $methodCalls */
         $methodCalls = $methodCallFinder->getFoundNodes();
         foreach ($methodCalls as $methodCallNode) {
-            if ($methodCallNode->name instanceof \PhpParser\Node\Identifier && $methodCallNode->name->toString() !== 'getFileName') {
-                continue;
-            }
-            $startPosition    = $methodCallNode->getAttribute('startTokenPos');
-            $endPosition      = $methodCallNode->getAttribute('endTokenPos');
-            $expressionPrefix = '\\' . __CLASS__ . '::resolveFileName(';
+            if ($methodCallNode->name instanceof Identifier && $methodCallNode->name->toString() === 'getFileName') {
+                $startPosition    = $methodCallNode->getAttribute('startTokenPos');
+                $endPosition      = $methodCallNode->getAttribute('endTokenPos');
+                $expressionPrefix = '\\' . __CLASS__ . '::resolveFileName(';
 
-            $metadata->tokenStream[$startPosition][1] = $expressionPrefix . $metadata->tokenStream[$startPosition][1];
-            $metadata->tokenStream[$endPosition][1] .= ')';
+                $metadata->tokenStream[$startPosition][1] = $expressionPrefix . $metadata->tokenStream[$startPosition][1];
+                $metadata->tokenStream[$endPosition][1]   .= ')';
+            }
         }
     }
 

--- a/src/Instrument/Transformer/MagicConstantTransformer.php
+++ b/src/Instrument/Transformer/MagicConstantTransformer.php
@@ -1,5 +1,5 @@
 <?php
-declare(strict_types=1);
+declare(strict_types = 1);
 /*
  * Go! AOP framework
  *
@@ -13,11 +13,11 @@ namespace Go\Instrument\Transformer;
 
 use Go\Core\AspectKernel;
 use PhpParser\Node\Expr\MethodCall;
-use PhpParser\Node\Identifier;
 use PhpParser\Node\Scalar\MagicConst;
 use PhpParser\Node\Scalar\MagicConst\Dir;
 use PhpParser\Node\Scalar\MagicConst\File;
 use PhpParser\NodeTraverser;
+use PhpParser\Node\Identifier;
 
 /**
  * Transformer that replaces magic __DIR__ and __FILE__ constants in the source code
@@ -69,13 +69,12 @@ class MagicConstantTransformer extends BaseSourceTransformer
      */
     public static function resolveFileName(string $fileName): string
     {
-        $suffix    = '.php';
+        $suffix = '.php';
         $pathParts = explode($suffix, str_replace(
             [self::$rewriteToPath, DIRECTORY_SEPARATOR . '_proxies'],
             [self::$rootPath, ''],
             $fileName
         ));
-
         // throw away namespaced path from actual filename
         return $pathParts[0] . $suffix;
     }
@@ -93,14 +92,15 @@ class MagicConstantTransformer extends BaseSourceTransformer
         /** @var MethodCall[] $methodCalls */
         $methodCalls = $methodCallFinder->getFoundNodes();
         foreach ($methodCalls as $methodCallNode) {
-            if ($methodCallNode->name instanceof Identifier && $methodCallNode->name->toString() === 'getFileName') {
+            if (($methodCallNode->name instanceof Identifier) && $methodCallNode->name->toString() === 'getFileName') {
                 $startPosition    = $methodCallNode->getAttribute('startTokenPos');
                 $endPosition      = $methodCallNode->getAttribute('endTokenPos');
                 $expressionPrefix = '\\' . __CLASS__ . '::resolveFileName(';
 
                 $metadata->tokenStream[$startPosition][1] = $expressionPrefix . $metadata->tokenStream[$startPosition][1];
-                $metadata->tokenStream[$endPosition][1]   .= ')';
+                $metadata->tokenStream[$endPosition][1] .= ')';
             }
+
         }
     }
 


### PR DESCRIPTION
got this issue :
[Error] Call to undefined method PhpParser\Node\Expr\Variable::toString()

while running some tests using AspectMock caused by this line:

https://github.com/goaop/framework/blob/72521d026692131f4052c1d7b3dad15c846cdd0f/src/Instrument/Transformer/MagicConstantTransformer.php#L94

a suggested solution here: https://github.com/nikic/PHP-Parser/pull/596/files

we can do something here as well as following