### PR TITLE
Finder glob pattern

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,3 @@ composer.lock
 phpunit.xml
 tests/Fixtures/project/var/cache/*
 build/
-.idea

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ composer.lock
 phpunit.xml
 tests/Fixtures/project/var/cache/*
 build/
+.idea

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,8 @@
         "doctrine/annotations": "^1.2.3",
         "goaop/parser-reflection": "~2.0",
         "doctrine/cache": "^1.5",
-        "symfony/finder": "^3.4|^4.2"
+        "symfony/finder": "^3.4|^4.2",
+        "webmozart/glob": "^4.1"
     },
 
     "require-dev": {
@@ -49,7 +50,10 @@
         "psr-4": {
             "Go\\": "tests/Go/",
             "Go\\Tests\\TestProject\\": "tests/Fixtures/project/src/"
-        }
+        },
+        "files": [
+            "tests/functions.php"
+        ]
     },
 
     "minimum-stability": "stable",

--- a/composer.json
+++ b/composer.json
@@ -13,8 +13,7 @@
         "doctrine/annotations": "^1.2.3",
         "goaop/parser-reflection": "~2.0",
         "doctrine/cache": "^1.5",
-        "symfony/finder": "^3.4|^4.2",
-        "webmozart/glob": "^4.1"
+        "symfony/finder": "^3.4|^4.2"
     },
 
     "require-dev": {
@@ -23,7 +22,8 @@
         "phpunit/phpunit": "^5.7",
         "doctrine/orm": "^2.5",
         "symfony/filesystem": "^3.3",
-        "symfony/process": "^3.3"
+        "symfony/process": "^3.3",
+        "webmozart/glob": "^4.1"
     },
 
     "suggest": {

--- a/src/Instrument/FileSystem/Enumerator.php
+++ b/src/Instrument/FileSystem/Enumerator.php
@@ -11,10 +11,8 @@
 namespace Go\Instrument\FileSystem;
 
 use ArrayIterator;
-use CallbackFilterIterator;
 use InvalidArgumentException;
 use LogicException;
-use RecursiveIteratorIterator;
 use SplFileInfo;
 use Symfony\Component\Finder\Finder;
 use UnexpectedValueException;
@@ -102,7 +100,6 @@ class Enumerator
                 throw new UnexpectedValueException(sprintf('Path %s is not in %s', $path, $this->rootDirectory));
             }
 
-            $path = str_replace('*', '', $path);
             $inPaths[] = $path;
         }
 

--- a/tests/functions.php
+++ b/tests/functions.php
@@ -1,0 +1,20 @@
+<?php
+declare(strict_types=1);
+
+/*
+ * @author Martin Fris <rasta@lj.sk>
+ */
+namespace Symfony\Component\Finder;
+
+/**
+ * This helper function overrides the PHP glob() function so it is able to be run with virtual file system,
+ * which is supported by Webmozart\Glob\Glob
+ *
+ * @param      $pattern
+ * @param null $flags
+ *
+ * @return string[]
+ */
+function glob($pattern, $flags = null) {
+    return \Webmozart\Glob\Glob::glob($pattern, $flags);
+}


### PR DESCRIPTION
The former change of spl file iterators to symfony finder didn't have support for glob patterns (or possibly broke the former support) 

This change is supposed to add support for glob patterns into the include_paths config section