### PR TITLE
Memory leaks / method invocation side effects.

### DIFF
--- a/src/Aop/Framework/AbstractMethodInvocation.php
+++ b/src/Aop/Framework/AbstractMethodInvocation.php
@@ -92,6 +92,9 @@ abstract class AbstractMethodInvocation extends AbstractInvocation implements Me
 
             if ($this->level > 0) {
                 [$this->arguments, $this->instance, $this->current] = array_pop($this->stackFrames);
+            } else {
+                $this->arguments = [];
+                $this->instance  = null;
             }
         }
     }


### PR DESCRIPTION
First of all, thank you for your awesome framework!
Unfortunately, a method \Go\Aop\Framework\AbstractMethodInvocation::__invoke doesn't free references to method arguments as soon as have been invoked which results in:
1. Memory leaks
2. Unintended side effect: the argument object destructor isn't called.

I hope my small pull request will help your cool project to become a bit better.
Thank you!