### PR TITLE
[BC BREAK] Introduce new ClassJoinpoint->getScope() API

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,15 +163,11 @@ class MonitorAspect implements Aspect
      */
     public function beforeMethodExecution(MethodInvocation $invocation)
     {
-        $obj = $invocation->getThis();
-        echo 'Calling Before Interceptor for method: ',
-             is_object($obj) ? get_class($obj) : $obj,
-             $invocation->getMethod()->isStatic() ? '::' : '->',
-             $invocation->getMethod()->getName(),
-             '()',
-             ' with arguments: ',
-             json_encode($invocation->getArguments()),
-             "<br>\n";
+        echo 'Calling Before Interceptor for: ',
+            $invocation,
+            ' with arguments: ',
+            json_encode($invocation->getArguments()),
+            "<br>\n";
     }
 }
 ```

--- a/demos/Demo/Aspect/DynamicMethodsAspect.php
+++ b/demos/Demo/Aspect/DynamicMethodsAspect.php
@@ -33,13 +33,11 @@ class DynamicMethodsAspect implements Aspect
      */
     public function beforeMagicMethodExecution(MethodInvocation $invocation)
     {
-        $obj = $invocation->getThis();
-
         // we need to unpack args from invocation args
         list($methodName, $args) = $invocation->getArguments();
         echo 'Calling Magic Interceptor for method: ',
-            is_object($obj) ? get_class($obj) : $obj,
-            $invocation->getMethod()->isStatic() ? '::' : '->',
+            $invocation->getScope(),
+            '->',
             $methodName,
             '()',
             ' with arguments: ',
@@ -56,8 +54,14 @@ class DynamicMethodsAspect implements Aspect
     public function beforeMagicStaticMethodExecution(MethodInvocation $invocation)
     {
         // we need to unpack args from invocation args
-        list($methodName) = $invocation->getArguments();
-
-        echo "Calling Magic Static Interceptor for method: ", $methodName, PHP_EOL;
+        list($methodName, $args) = $invocation->getArguments();
+        echo 'Calling Static Magic Interceptor for method: ',
+            $invocation->getScope(),
+            '::',
+            $methodName,
+            '()',
+            ' with arguments: ',
+            json_encode($args),
+            PHP_EOL;
     }
 }

--- a/src/Aop/Framework/ClassFieldAccess.php
+++ b/src/Aop/Framework/ClassFieldAccess.php
@@ -196,25 +196,34 @@ class ClassFieldAccess extends AbstractJoinpoint implements FieldAccess
     }
 
     /**
-     * Returns the object that holds the current joinpoint's static
-     * part.
+     * Returns the object for which current joinpoint is invoked
      *
-     * @return object|null the object (can be null if the accessible object is
-     * static).
+     * @return object|null Instance of object or null for static call/unavailable context
      */
-    final public function getThis()
+    final public function getThis(): ?object
     {
         return $this->instance;
     }
 
     /**
-     * Returns the static part of this joinpoint.
+     * Checks if the current joinpoint is dynamic or static
      *
-     * @return object
+     * Dynamic joinpoint contains a reference to an object that can be received via getThis() method call
+     *
+     * @see ClassJoinpoint::getThis()
      */
-    final public function getStaticPart()
+    final public function isDynamic(): bool
     {
-        return $this->getField();
+        return true;
+    }
+
+    /**
+     * Returns the static scope name (class name) of this joinpoint.
+     */
+    final public function getScope(): string
+    {
+        // $this->instance always contains an object, so we can take it's name as a scope name
+        return get_class($this->instance);
     }
 
     /**
@@ -225,7 +234,7 @@ class ClassFieldAccess extends AbstractJoinpoint implements FieldAccess
         return sprintf(
             '%s(%s->%s)',
             $this->accessType === self::READ ? 'get' : 'set',
-            get_class($this->instance),
+            $this->getScope(),
             $this->reflectionProperty->name
         );
     }

--- a/src/Aop/Framework/DynamicClosureMethodInvocation.php
+++ b/src/Aop/Framework/DynamicClosureMethodInvocation.php
@@ -11,6 +11,8 @@ declare(strict_types = 1);
 
 namespace Go\Aop\Framework;
 
+use function get_class;
+
 /**
  * Dynamic closure method invocation is responsible to call dynamic methods via closure
  */
@@ -26,9 +28,14 @@ final class DynamicClosureMethodInvocation extends AbstractMethodInvocation
     /**
      * Previous instance of invocation
      *
-     * @var null|object|string
+     * @var null|object
      */
     protected $previousInstance;
+
+    /**
+     * For dynamic calls we store given argument as 'instance' property
+     */
+    protected static $propertyName = 'instance';
 
     /**
      * Invokes original method and return result from it
@@ -56,5 +63,36 @@ final class DynamicClosureMethodInvocation extends AbstractMethodInvocation
         }
 
         return ($this->closureToCall)(...$this->arguments);
+    }
+
+    /**
+     * Returns the object for which current joinpoint is invoked
+     *
+     * @return object Instance of object or null for static call/unavailable context
+     */
+    final public function getThis(): ?object
+    {
+        return $this->instance;
+    }
+
+    /**
+     * Checks if the current joinpoint is dynamic or static
+     *
+     * Dynamic joinpoint contains a reference to an object that can be received via getThis() method call
+     * @see ClassJoinpoint::getThis()
+     */
+    final public function isDynamic(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Returns the static scope name (class name) of this joinpoint.
+     */
+    final public function getScope(): string
+    {
+        // Due to optimization $this->scope won't be filled for each invocation
+        // However, $this->instance always contains an object, so we can take it's name as a scope name
+        return get_class($this->instance);
     }
 }

--- a/src/Aop/Framework/DynamicInvocationMatcherInterceptor.php
+++ b/src/Aop/Framework/DynamicInvocationMatcherInterceptor.php
@@ -12,8 +12,8 @@ declare(strict_types = 1);
 namespace Go\Aop\Framework;
 
 use Go\Aop\Intercept\Interceptor;
-use Go\Aop\Intercept\Invocation;
 use Go\Aop\Intercept\Joinpoint;
+use Go\Aop\Intercept\MethodInvocation;
 use Go\Aop\PointFilter;
 use ReflectionClass;
 
@@ -53,11 +53,11 @@ class DynamicInvocationMatcherInterceptor implements Interceptor
      */
     final public function invoke(Joinpoint $joinpoint)
     {
-        if ($joinpoint instanceof Invocation) {
-            $point    = $joinpoint->getStaticPart();
-            $instance = $joinpoint->getThis();
-            $context  = new ReflectionClass($instance);
-            if ($this->pointFilter->matches($point, $context, $instance, $joinpoint->getArguments())) {
+        if ($joinpoint instanceof MethodInvocation) {
+            $method       = $joinpoint->getMethod();
+            $context      = $joinpoint->getThis() ?? $joinpoint->getScope();
+            $contextClass = new ReflectionClass($context);
+            if ($this->pointFilter->matches($method, $contextClass, $context, $joinpoint->getArguments())) {
                 return $this->interceptor->invoke($joinpoint);
             }
         }

--- a/src/Aop/Framework/ReflectionConstructorInvocation.php
+++ b/src/Aop/Framework/ReflectionConstructorInvocation.php
@@ -100,25 +100,13 @@ class ReflectionConstructorInvocation extends AbstractInvocation implements Cons
     }
 
     /**
-     * Returns the object that holds the current joinpoint's static
-     * part.
+     * Returns the object for which current joinpoint is invoked
      *
-     * @return object|null the object (can be null if the accessible object is
-     * static).
+     * @return object|null Instance of object or null for static call/unavailable context
      */
-    public function getThis()
+    public function getThis(): ?object
     {
         return $this->instance;
-    }
-
-    /**
-     * Returns the static part of this joinpoint.
-     *
-     * @return null|ReflectionMethod
-     */
-    public function getStaticPart()
-    {
-        return $this->getConstructor();
     }
 
     /**
@@ -135,13 +123,33 @@ class ReflectionConstructorInvocation extends AbstractInvocation implements Cons
     }
 
     /**
+     * Checks if the current joinpoint is dynamic or static
+     *
+     * Dynamic joinpoint contains a reference to an object that can be received via getThis() method call
+     *
+     * @see ClassJoinpoint::getThis()
+     */
+    public function isDynamic(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Returns the static scope name (class name) of this joinpoint.
+     */
+    public function getScope(): string
+    {
+        return $this->class->getName();
+    }
+
+    /**
      * Returns a friendly description of current joinpoint
      */
     final public function __toString(): string
     {
         return sprintf(
             'initialization(%s)',
-            $this->class->name
+            $this->getScope()
         );
     }
 }

--- a/src/Aop/Framework/ReflectionFunctionInvocation.php
+++ b/src/Aop/Framework/ReflectionFunctionInvocation.php
@@ -66,28 +66,6 @@ class ReflectionFunctionInvocation extends AbstractInvocation implements Functio
     }
 
     /**
-     * Returns the object that holds the current joinpoint's static
-     * part.
-     *
-     * @return object|null the object (can be null if the accessible object is
-     * static).
-     */
-    public function getThis()
-    {
-        return null;
-    }
-
-    /**
-     * Returns the static part of this joinpoint.
-     *
-     * @return object
-     */
-    public function getStaticPart()
-    {
-        return $this->reflectionFunction;
-    }
-
-    /**
      * Invokes current function invocation with all interceptors
      *
      * @param array $arguments List of arguments for function invocation

--- a/src/Aop/Framework/StaticInitializationJoinpoint.php
+++ b/src/Aop/Framework/StaticInitializationJoinpoint.php
@@ -11,6 +11,7 @@ declare(strict_types = 1);
 
 namespace Go\Aop\Framework;
 
+use Go\Aop\Intercept\ClassJoinpoint;
 use Go\Core\AspectContainer;
 use ReflectionClass;
 use function strlen;
@@ -18,7 +19,7 @@ use function strlen;
 /**
  * Static initialization joinpoint is invoked after class is loaded into memory
  */
-class StaticInitializationJoinpoint extends AbstractJoinpoint
+class StaticInitializationJoinpoint extends AbstractJoinpoint implements ClassJoinpoint
 {
 
     /**
@@ -64,25 +65,33 @@ class StaticInitializationJoinpoint extends AbstractJoinpoint
     }
 
     /**
-     * Returns the object that holds the current joinpoint's static
-     * part.
+     * Returns the object for which current joinpoint is invoked
      *
-     * @return object|null the object (can be null if the accessible object is
-     * static).
+     * @return object|null Instance of object or null for static call/unavailable context
      */
-    public function getThis()
+    public function getThis(): ?object
     {
         return null;
     }
 
     /**
-     * Returns the static part of this joinpoint.
+     * Checks if the current joinpoint is dynamic or static
      *
-     * @return ReflectionClass
+     * Dynamic joinpoint contains a reference to an object that can be received via getThis() method call
+     *
+     * @see ClassJoinpoint::getThis()
      */
-    public function getStaticPart()
+    public function isDynamic(): bool
     {
-        return $this->reflectionClass;
+        return false;
+    }
+
+    /**
+     * Returns the static scope name (class name) of this joinpoint.
+     */
+    public function getScope(): string
+    {
+        return $this->reflectionClass->getName();
     }
 
     /**
@@ -92,7 +101,7 @@ class StaticInitializationJoinpoint extends AbstractJoinpoint
     {
         return sprintf(
             'staticinitialization(%s)',
-            $this->reflectionClass->getName()
+            $this->getScope()
         );
     }
 }

--- a/src/Aop/Intercept/ClassJoinpoint.php
+++ b/src/Aop/Intercept/ClassJoinpoint.php
@@ -1,0 +1,46 @@
+<?php
+declare(strict_types = 1);
+/*
+ * Go! AOP framework
+ *
+ * @copyright Copyright 2019, Lisachenko Alexander <lisachenko.it@gmail.com>
+ *
+ * This source file is subject to the license that is bundled
+ * with this source code in the file LICENSE.
+ */
+namespace Go\Aop\Intercept;
+
+/**
+ * This interface represents a class joinpoint that can have $this variable and defined scope
+ *
+ * @api
+ */
+interface ClassJoinpoint extends Joinpoint
+{
+
+    /**
+     * Checks if the current joinpoint is dynamic or static
+     *
+     * Dynamic joinpoint contains a reference to an object that can be received via getThis() method call
+     * @see ClassJoinpoint::getThis()
+     *
+     * @api
+     */
+    public function isDynamic(): bool;
+
+    /**
+     * Returns the object for which current joinpoint is invoked
+     *
+     * @api
+     *
+     * @return object|null Instance of object or null for static call/unavailable context
+     */
+    public function getThis(): ?object;
+
+    /**
+     * Returns the static scope name (class name) of this joinpoint.
+     *
+     * @api
+     */
+    public function getScope(): string;
+}

--- a/src/Aop/Intercept/ConstructorInvocation.php
+++ b/src/Aop/Intercept/ConstructorInvocation.php
@@ -20,7 +20,7 @@ use ReflectionMethod;
  * A constructor invocation is a joinpoint and can be intercepted
  * by a constructor interceptor.
  */
-interface ConstructorInvocation extends Invocation
+interface ConstructorInvocation extends Invocation, ClassJoinpoint
 {
 
     /**

--- a/src/Aop/Intercept/FieldAccess.php
+++ b/src/Aop/Intercept/FieldAccess.php
@@ -20,7 +20,7 @@ use ReflectionProperty;
  *
  * @api
  */
-interface FieldAccess extends Joinpoint
+interface FieldAccess extends ClassJoinpoint
 {
 
     /**

--- a/src/Aop/Intercept/Joinpoint.php
+++ b/src/Aop/Intercept/Joinpoint.php
@@ -37,23 +37,6 @@ interface Joinpoint
     public function proceed();
 
     /**
-     * Returns the object that holds the current joinpoint's static
-     * part.
-     *
-     * @api
-     *
-     * @return object|string the object for dynamic call or string with name of scope
-     */
-    public function getThis();
-
-    /**
-     * Returns the static part of this joinpoint.
-     *
-     * @return object
-     */
-    public function getStaticPart();
-
-    /**
      * Returns a friendly description of current joinpoint
      */
     public function __toString(): string;

--- a/src/Aop/Intercept/MethodInvocation.php
+++ b/src/Aop/Intercept/MethodInvocation.php
@@ -21,7 +21,7 @@ use ReflectionMethod;
  * A method invocation is a joinpoint and can be intercepted by a method
  * interceptor.
  */
-interface MethodInvocation extends Invocation
+interface MethodInvocation extends Invocation, ClassJoinpoint
 {
 
     /**

--- a/tests/Go/Aop/Framework/AbstractMethodInvocationTest.php
+++ b/tests/Go/Aop/Framework/AbstractMethodInvocationTest.php
@@ -27,11 +27,6 @@ class AbstractMethodInvocationTest extends TestCase
         $this->assertEquals('setUp', $this->invocation->getMethod()->name);
     }
 
-    public function testStaticPartEqualsToReflectionMethod(): void
-    {
-        $this->assertInstanceOf('ReflectionMethod', $this->invocation->getStaticPart());
-    }
-
     public function testProvidesAccessToAnnotations(): void
     {
         $this->assertInstanceOf(AnnotationAccess::class, $this->invocation->getMethod());

--- a/tests/Go/Aop/Framework/ClassFieldAccessTest.php
+++ b/tests/Go/Aop/Framework/ClassFieldAccessTest.php
@@ -24,11 +24,6 @@ class ClassFieldAccessTest extends TestCase
         $this->assertEquals('classField', $this->classField->getField()->name);
     }
 
-    public function testStaticPartEqualsToReflectionMethod(): void
-    {
-        $this->assertInstanceOf('ReflectionProperty', $this->classField->getStaticPart());
-    }
-
     public function testProvidesAccessToAnnotations(): void
     {
         $this->assertInstanceOf(AnnotationAccess::class, $this->classField->getField());

--- a/tests/Go/Aop/Framework/StaticClosureMethodInvocationTest.php
+++ b/tests/Go/Aop/Framework/StaticClosureMethodInvocationTest.php
@@ -22,26 +22,8 @@ class StaticClosureMethodInvocationTest extends TestCase
      */
     public function testStaticSelfMethodInvocation(string $methodName, int $expectedResult): void
     {
-        $childClass = new First();
-        $invocation = new StaticClosureMethodInvocation(get_class($childClass), $methodName, []);
-
-        $result = $invocation($childClass);
-        $this->assertEquals($expectedResult, $result);
-    }
-
-    /**
-     * Tests static method invocations with self not overridden with parent
-     *
-     * @dataProvider staticSelfMethodsBatch
-     * @param string $methodName Method to invoke
-     * @param int $expectedResult Expected result
-     */
-    public function testStaticSelfNotOverridden($methodName, $expectedResult): void
-    {
-        $childClass = new First();
         $invocation = new StaticClosureMethodInvocation(First::class, $methodName, []);
-
-        $result = $invocation($childClass);
+        $result     = $invocation(First::class);
         $this->assertEquals($expectedResult, $result);
     }
 
@@ -53,20 +35,17 @@ class StaticClosureMethodInvocationTest extends TestCase
      */
     public function testStaticLsbIsWorking($methodName): void
     {
-        $childClass = new First();
         $invocation = new StaticClosureMethodInvocation(First::class, $methodName, []);
-
-        $result = $invocation(get_class($childClass));
-        $this->assertEquals(get_class($childClass), $result);
+        $result     = $invocation(First::class);
+        $this->assertEquals(First::class, $result);
     }
 
     public function testValueChangedByReference(): void
     {
-        $child      = new First();
         $invocation = new StaticClosureMethodInvocation(First::class, 'staticPassByReference', []);
 
         $value  = 'test';
-        $result = $invocation($child, [&$value]);
+        $result = $invocation(First::class, [&$value]);
         $this->assertEquals(null, $result);
         $this->assertEquals(null, $value);
     }
@@ -74,17 +53,14 @@ class StaticClosureMethodInvocationTest extends TestCase
     public function testRecursionWorks(): void
     {
         $invocation = new StaticClosureMethodInvocation(First::class, 'staticLsbRecursion', []);
-        $child      = new FirstStatic($invocation);
+        FirstStatic::init($invocation);
 
-        /** @var First $childClass */
-        $childClass = get_class($child);
-        $this->assertEquals(5, $childClass::staticLsbRecursion(5,0));
-        $this->assertEquals(20, $childClass::staticLsbRecursion(5,3));
+        $this->assertEquals(5, FirstStatic::staticLsbRecursion(5,0));
+        $this->assertEquals(20, FirstStatic::staticLsbRecursion(5,3));
     }
 
     public function testAdviceIsCalledForInvocation(): void
     {
-        $child  = $this->createMock(First::class);
         $value  = 'test';
         $advice = new BeforeInterceptor(function () use (&$value) {
             $value = 'ok';
@@ -92,14 +68,13 @@ class StaticClosureMethodInvocationTest extends TestCase
 
         $invocation = new StaticClosureMethodInvocation(First::class, 'staticSelfPublic', [$advice]);
 
-        $result = $invocation($child, []);
+        $result = $invocation(First::class, []);
         $this->assertEquals('ok', $value);
         $this->assertEquals(T_PUBLIC, $result);
     }
 
     public function testInvocationWithDynamicArguments(): void
     {
-        $child      = $this->createMock(First::class);
         $invocation = new StaticClosureMethodInvocation(First::class, 'staticVariableArgsTest', []);
 
         $args     = [];
@@ -107,14 +82,13 @@ class StaticClosureMethodInvocationTest extends TestCase
         for ($i=0; $i<10; $i++) {
             $args[]   = $i;
             $expected .= $i;
-            $result   = $invocation($child, $args);
+            $result   = $invocation(First::class, $args);
             $this->assertEquals($expected, $result);
         }
     }
 
     public function testInvocationWithVariadicArguments(): void
     {
-        $child      = $this->createMock(First::class);
         $invocation = new StaticClosureMethodInvocation(First::class, 'staticVariadicArgsTest', []);
 
         $args     = [];
@@ -122,7 +96,7 @@ class StaticClosureMethodInvocationTest extends TestCase
         for ($i=0; $i<10; $i++) {
             $args[]   = $i;
             $expected .= $i;
-            $result   = $invocation($child, $args);
+            $result   = $invocation(First::class, $args);
             $this->assertEquals($expected, $result);
         }
     }

--- a/tests/Go/Stubs/FirstStatic.php
+++ b/tests/Go/Stubs/FirstStatic.php
@@ -12,7 +12,7 @@ class FirstStatic extends First
      */
     protected static $invocation;
 
-    public function __construct(Invocation $invocation)
+    public static function init(Invocation $invocation)
     {
         static::$invocation = $invocation;
     }


### PR DESCRIPTION
This PR introduces a new API for working with scope and instances. Previously, all joinpoints have had the `getThis()` method which was strange for `FunctionInvocation` as it couldn't have a reference to the object.
Thus, new `ClassJoinpoint` interface was added to provide explicit information about class joinpoints via `getScope()`, `getThis()` and `isDynamic()` methods.

Notable changes:
 - Removed the Joinpoint->getThis() method, as not all joinpoints belong to classes (eg. FunctionInvocation)
 - Introduce the new ClassJoinpoint interface with getScope(), getThis() and isDynamic() methods
 - Removed the Joinpoint->getStaticPart() method as it can return anything, better to use explicit methods.