### PR TITLE
[PHP7.4]Move ReflectionType::__toString() case to getName()

### DIFF
--- a/src/Proxy/ClassProxyGenerator.php
+++ b/src/Proxy/ClassProxyGenerator.php
@@ -230,7 +230,7 @@ class ClassProxyGenerator
         $argumentCode = $argumentList->generate();
         $return = 'return ';
         if ($method->hasReturnType()) {
-            $returnType = (string) $method->getReturnType();
+            $returnType = $method->getReturnType()->getName();
             if ($returnType === 'void') {
                 // void return types should not return anything
                 $return = '';


### PR DESCRIPTION
Fix implemented in the same way, as PHPUnit framework
Closes #438