### PR TITLE
Use laminas-code instead of zend-code

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "doctrine/annotations": "^1.2.3",
         "goaop/parser-reflection": "~2.0",
         "doctrine/cache": "^1.5",
-        "zendframework/zend-code": "^3.1",
+        "laminas/laminas-code": "^3.1",
         "symfony/finder": "^3.4|^4.2|^5.0"
     },
 

--- a/src/Proxy/ClassProxyGenerator.php
+++ b/src/Proxy/ClassProxyGenerator.php
@@ -29,9 +29,9 @@ use Go\Proxy\Part\JoinPointPropertyGenerator;
 use Go\Proxy\Part\PropertyInterceptionTrait;
 use ReflectionClass;
 use ReflectionMethod;
-use Zend\Code\Generator\ClassGenerator;
-use Zend\Code\Generator\DocBlockGenerator;
-use Zend\Code\Reflection\DocBlockReflection;
+use Laminas\Code\Generator\ClassGenerator;
+use Laminas\Code\Generator\DocBlockGenerator;
+use Laminas\Code\Reflection\DocBlockReflection;
 
 /**
  * Class proxy builder that is used to generate a child class from the list of joinpoints

--- a/src/Proxy/FunctionProxyGenerator.php
+++ b/src/Proxy/FunctionProxyGenerator.php
@@ -19,8 +19,8 @@ use Go\ParserReflection\ReflectionFileNamespace;
 use Go\Proxy\Part\FunctionCallArgumentListGenerator;
 use Go\Proxy\Part\InterceptedFunctionGenerator;
 use ReflectionFunction;
-use Zend\Code\Generator\FileGenerator;
-use Zend\Code\Generator\ValueGenerator;
+use Laminas\Code\Generator\FileGenerator;
+use Laminas\Code\Generator\ValueGenerator;
 
 /**
  * Function proxy builder that is used to generate a proxy-function from the list of joinpoints

--- a/src/Proxy/Part/FunctionCallArgumentListGenerator.php
+++ b/src/Proxy/Part/FunctionCallArgumentListGenerator.php
@@ -12,7 +12,7 @@ declare(strict_types=1);
 namespace Go\Proxy\Part;
 
 use ReflectionFunctionAbstract;
-use Zend\Code\Generator\AbstractGenerator;
+use Laminas\Code\Generator\AbstractGenerator;
 
 /**
  * Prepares the function call argument list

--- a/src/Proxy/Part/FunctionParameterList.php
+++ b/src/Proxy/Part/FunctionParameterList.php
@@ -12,8 +12,8 @@ declare(strict_types=1);
 namespace Go\Proxy\Part;
 
 use ReflectionFunctionAbstract;
-use Zend\Code\Generator\ParameterGenerator;
-use Zend\Code\Generator\ValueGenerator;
+use Laminas\Code\Generator\ParameterGenerator;
+use Laminas\Code\Generator\ValueGenerator;
 
 /**
  * Generates parameters from reflection definition

--- a/src/Proxy/Part/InterceptedConstructorGenerator.php
+++ b/src/Proxy/Part/InterceptedConstructorGenerator.php
@@ -13,7 +13,7 @@ namespace Go\Proxy\Part;
 
 use LogicException;
 use ReflectionMethod;
-use Zend\Code\Generator\MethodGenerator;
+use Laminas\Code\Generator\MethodGenerator;
 use function count;
 
 /**

--- a/src/Proxy/Part/InterceptedFunctionGenerator.php
+++ b/src/Proxy/Part/InterceptedFunctionGenerator.php
@@ -12,11 +12,11 @@ declare(strict_types=1);
 namespace Go\Proxy\Part;
 
 use ReflectionFunction;
-use Zend\Code\Generator\AbstractGenerator;
-use Zend\Code\Generator\DocBlockGenerator;
-use Zend\Code\Generator\ParameterGenerator;
-use Zend\Code\Generator\TypeGenerator;
-use Zend\Code\Reflection\DocBlockReflection;
+use Laminas\Code\Generator\AbstractGenerator;
+use Laminas\Code\Generator\DocBlockGenerator;
+use Laminas\Code\Generator\ParameterGenerator;
+use Laminas\Code\Generator\TypeGenerator;
+use Laminas\Code\Reflection\DocBlockReflection;
 
 /**
  * Prepares the definition of intercepted function

--- a/src/Proxy/Part/InterceptedMethodGenerator.php
+++ b/src/Proxy/Part/InterceptedMethodGenerator.php
@@ -12,9 +12,9 @@ declare(strict_types=1);
 namespace Go\Proxy\Part;
 
 use ReflectionMethod;
-use Zend\Code\Generator\DocBlockGenerator;
-use Zend\Code\Generator\MethodGenerator;
-use Zend\Code\Reflection\DocBlockReflection;
+use Laminas\Code\Generator\DocBlockGenerator;
+use Laminas\Code\Generator\MethodGenerator;
+use Laminas\Code\Reflection\DocBlockReflection;
 
 /**
  * Prepares the definition of intercepted method

--- a/src/Proxy/Part/JoinPointPropertyGenerator.php
+++ b/src/Proxy/Part/JoinPointPropertyGenerator.php
@@ -11,8 +11,8 @@ declare(strict_types=1);
 
 namespace Go\Proxy\Part;
 
-use Zend\Code\Generator\PropertyGenerator;
-use Zend\Code\Generator\PropertyValueGenerator;
+use Laminas\Code\Generator\PropertyGenerator;
+use Laminas\Code\Generator\PropertyValueGenerator;
 
 /**
  * Prepares the definition for joinpoints private property in the class
@@ -29,7 +29,7 @@ final class JoinPointPropertyGenerator extends PropertyGenerator
      *
      * @param array $advices List of advices to apply per class
      *
-     * @throws \Zend\Code\Generator\Exception\InvalidArgumentException
+     * @throws \Laminas\Code\Generator\Exception\InvalidArgumentException
      */
     public function __construct(array $advices)
     {

--- a/src/Proxy/TraitProxyGenerator.php
+++ b/src/Proxy/TraitProxyGenerator.php
@@ -17,10 +17,10 @@ use Go\Core\AspectKernel;
 use Go\Proxy\Part\FunctionCallArgumentListGenerator;
 use ReflectionClass;
 use ReflectionMethod;
-use Zend\Code\Generator\DocBlockGenerator;
-use Zend\Code\Generator\TraitGenerator;
-use Zend\Code\Generator\ValueGenerator;
-use Zend\Code\Reflection\DocBlockReflection;
+use Laminas\Code\Generator\DocBlockGenerator;
+use Laminas\Code\Generator\TraitGenerator;
+use Laminas\Code\Generator\ValueGenerator;
+use Laminas\Code\Reflection\DocBlockReflection;
 
 /**
  * Trait proxy builder that is used to generate a trait from the list of joinpoints

--- a/tests/Go/Proxy/Part/FunctionParameterListTest.php
+++ b/tests/Go/Proxy/Part/FunctionParameterListTest.php
@@ -13,7 +13,7 @@ namespace Go\Proxy\Part;
 
 use function class_exists;
 use PHPUnit\Framework\TestCase;
-use Zend\Code\Generator\ValueGenerator;
+use Laminas\Code\Generator\ValueGenerator;
 
 class FunctionParameterListTest extends TestCase
 {


### PR DESCRIPTION
Zend Framework was rebranded to Laminas last year and all Zend libraries got new names.

Now `composer install` prints these warnings:

> Package zendframework/zend-code is abandoned, you should avoid using it. Use laminas/laminas-code instead.
> Package zendframework/zend-eventmanager is abandoned, you should avoid using it. Use laminas/laminas-eventmanager instead.