### PR TITLE
Use ReflectionNamedType to avoid deprecation notices, resolves #438

### DIFF
--- a/src/Proxy/ClassProxyGenerator.php
+++ b/src/Proxy/ClassProxyGenerator.php
@@ -32,6 +32,7 @@ use ReflectionMethod;
 use Laminas\Code\Generator\ClassGenerator;
 use Laminas\Code\Generator\DocBlockGenerator;
 use Laminas\Code\Reflection\DocBlockReflection;
+use ReflectionNamedType;
 
 /**
  * Class proxy builder that is used to generate a child class from the list of joinpoints
@@ -228,10 +229,10 @@ class ClassProxyGenerator
 
         $argumentList = new FunctionCallArgumentListGenerator($method);
         $argumentCode = $argumentList->generate();
-        $return = 'return ';
+        $return       = 'return ';
         if ($method->hasReturnType()) {
-            $returnType = (string) $method->getReturnType();
-            if ($returnType === 'void') {
+            $returnType = $method->getReturnType();
+            if ($returnType instanceof ReflectionNamedType && $returnType->getName() === 'void') {
                 // void return types should not return anything
                 $return = '';
             }

--- a/src/Proxy/FunctionProxyGenerator.php
+++ b/src/Proxy/FunctionProxyGenerator.php
@@ -21,6 +21,7 @@ use Go\Proxy\Part\InterceptedFunctionGenerator;
 use ReflectionFunction;
 use Laminas\Code\Generator\FileGenerator;
 use Laminas\Code\Generator\ValueGenerator;
+use ReflectionNamedType;
 
 /**
  * Function proxy builder that is used to generate a proxy-function from the list of joinpoints
@@ -108,8 +109,8 @@ class FunctionProxyGenerator
 
         $return = 'return ';
         if ($function->hasReturnType()) {
-            $returnType = (string) $function->getReturnType();
-            if ($returnType === 'void') {
+            $returnType = $function->getReturnType();
+            if ($returnType instanceof ReflectionNamedType && $returnType->getName() === 'void') {
                 // void return types should not return anything
                 $return = '';
             }

--- a/src/Proxy/Part/FunctionParameterList.php
+++ b/src/Proxy/Part/FunctionParameterList.php
@@ -14,6 +14,7 @@ namespace Go\Proxy\Part;
 use ReflectionFunctionAbstract;
 use Laminas\Code\Generator\ParameterGenerator;
 use Laminas\Code\Generator\ValueGenerator;
+use ReflectionNamedType;
 
 /**
  * Generates parameters from reflection definition
@@ -44,9 +45,19 @@ final class FunctionParameterList
                 $defaultValue = new ValueGenerator(null);
             }
 
+            $parameterTypeName = null;
+            if (!$useTypeWidening && $reflectionParameter->hasType()) {
+                $parameterReflectionType = $reflectionParameter->getType();
+                if ($parameterReflectionType instanceof ReflectionNamedType) {
+                    $parameterTypeName = $parameterReflectionType->getName();
+                } else {
+                    $parameterTypeName = (string) $parameterReflectionType;
+                }
+            }
+
             $generatedParameter = new ParameterGenerator(
                 $reflectionParameter->getName(),
-                $useTypeWidening ? '' : $reflectionParameter->getType(),
+                $parameterTypeName,
                 $defaultValue,
                 $reflectionParameter->getPosition(),
                 $reflectionParameter->isPassedByReference()

--- a/src/Proxy/Part/InterceptedFunctionGenerator.php
+++ b/src/Proxy/Part/InterceptedFunctionGenerator.php
@@ -17,6 +17,7 @@ use Laminas\Code\Generator\DocBlockGenerator;
 use Laminas\Code\Generator\ParameterGenerator;
 use Laminas\Code\Generator\TypeGenerator;
 use Laminas\Code\Reflection\DocBlockReflection;
+use ReflectionNamedType;
 
 /**
  * Prepares the definition of intercepted function
@@ -65,7 +66,13 @@ final class InterceptedFunctionGenerator extends AbstractGenerator
         parent::__construct();
 
         if ($reflectionFunction->hasReturnType()) {
-            $this->returnType = TypeGenerator::fromTypeString((string) $reflectionFunction->getReturnType());
+            $reflectionReturnType = $reflectionFunction->getReturnType();
+            if ($reflectionReturnType instanceof ReflectionNamedType) {
+                $returnTypeName = $reflectionReturnType->getName();
+            } else {
+                $returnTypeName = (string) $reflectionReturnType;
+            }
+            $this->returnType = TypeGenerator::fromTypeString($returnTypeName);
         }
 
         if ($reflectionFunction->getDocComment()) {

--- a/src/Proxy/Part/InterceptedMethodGenerator.php
+++ b/src/Proxy/Part/InterceptedMethodGenerator.php
@@ -11,10 +11,12 @@ declare(strict_types=1);
 
 namespace Go\Proxy\Part;
 
+use Laminas\Code\Generator\TypeGenerator;
 use ReflectionMethod;
 use Laminas\Code\Generator\DocBlockGenerator;
 use Laminas\Code\Generator\MethodGenerator;
 use Laminas\Code\Reflection\DocBlockReflection;
+use ReflectionNamedType;
 
 /**
  * Prepares the definition of intercepted method
@@ -36,7 +38,13 @@ final class InterceptedMethodGenerator extends MethodGenerator
         $declaringClass = $reflectionMethod->getDeclaringClass();
 
         if ($reflectionMethod->hasReturnType()) {
-            $this->setReturnType((string) $reflectionMethod->getReturnType());
+            $reflectionReturnType = $reflectionMethod->getReturnType();
+            if ($reflectionReturnType instanceof ReflectionNamedType) {
+                $returnTypeName = $reflectionReturnType->getName();
+            } else {
+                $returnTypeName = (string) $reflectionReturnType;
+            }
+            $this->setReturnType($returnTypeName);
         }
 
         if ($reflectionMethod->getDocComment()) {

--- a/src/Proxy/TraitProxyGenerator.php
+++ b/src/Proxy/TraitProxyGenerator.php
@@ -21,6 +21,7 @@ use Laminas\Code\Generator\DocBlockGenerator;
 use Laminas\Code\Generator\TraitGenerator;
 use Laminas\Code\Generator\ValueGenerator;
 use Laminas\Code\Reflection\DocBlockReflection;
+use ReflectionNamedType;
 
 /**
  * Trait proxy builder that is used to generate a trait from the list of joinpoints
@@ -114,8 +115,8 @@ class TraitProxyGenerator extends ClassProxyGenerator
 
         $return = 'return ';
         if ($method->hasReturnType()) {
-            $returnType = (string) $method->getReturnType();
-            if ($returnType === 'void') {
+            $returnType = $method->getReturnType();
+            if ($returnType instanceof ReflectionNamedType && $returnType->getName() === 'void') {
                 // void return types should not return anything
                 $return = '';
             }


### PR DESCRIPTION
To avoid deprecation notices for PHP7.4, code should use `getName()` on type.