### PR TITLE
[FIX] Library generates non-nullable return type for nullable return …

### DIFF
--- a/src/Proxy/Part/InterceptedMethodGenerator.php
+++ b/src/Proxy/Part/InterceptedMethodGenerator.php
@@ -39,7 +39,7 @@ final class InterceptedMethodGenerator extends MethodGenerator
         if ($reflectionMethod->hasReturnType()) {
             $reflectionReturnType = $reflectionMethod->getReturnType();
             if ($reflectionReturnType instanceof ReflectionNamedType) {
-                $returnTypeName = $reflectionReturnType->getName();
+                $returnTypeName = ($reflectionReturnType->allowsNull() ? '?' : '') . $reflectionReturnType->getName();
             } else {
                 $returnTypeName = (string)$reflectionReturnType;
             }


### PR DESCRIPTION
 Library generates non-nullable return type for nullable return methods #482 
Library version 3.0.0

For below method proxy is generating non-null return
```
/**
     * @AopAnnotation()
     * @return null|int
     */
    public function getSomeRandomValueAllowOnNull(): ?int
    {
        return random_int(0, 666);
    }
```
result:
```
/**
     * @AopAnnotation()
     * @return null|int
     */
    public function getSomeRandomValueAllowOnNull() : int
    {
        return self::$__joinPoints['method:getSomeRandomValueAllowOnNull']->__invoke($this);
    }
```