### PR TITLE
Migrate to doctrine/annotations 2.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
 
     "require": {
         "php": "^7.4.0",
-        "doctrine/annotations": "^1.11.1",
+        "doctrine/annotations": "^2.0",
         "doctrine/cache": "^1.10",
         "goaop/parser-reflection": "^3.0.1",
         "jakubledl/dissect": "~1.0",

--- a/src/Core/GoAspectContainer.php
+++ b/src/Core/GoAspectContainer.php
@@ -13,7 +13,7 @@ declare(strict_types = 1);
 namespace Go\Core;
 
 use Doctrine\Common\Annotations\AnnotationReader;
-use Doctrine\Common\Annotations\CachedReader;
+use Doctrine\Common\Annotations\PsrCachedReader;
 use Doctrine\Common\Cache as DoctrineCache;
 use Go\Aop\Advisor;
 use Go\Aop\Aspect;
@@ -104,10 +104,11 @@ class GoAspectContainer extends Container
 
         $this->share('aspect.annotation.reader', function (Container $container) {
             $options = $container->get('kernel.options');
+            $annotationCache = $container->get('aspect.annotation.cache');
 
-            return new CachedReader(
+            return new PsrCachedReader(
                 new AnnotationReader(),
-                $container->get('aspect.annotation.cache'),
+                new DoctrineCache\Psr6\CacheAdapter($annotationCache),
                 $options['debug'] ?? false
             );
         });

--- a/src/Instrument/ClassLoading/AopComposerLoader.php
+++ b/src/Instrument/ClassLoading/AopComposerLoader.php
@@ -18,7 +18,6 @@ use Go\Instrument\FileSystem\Enumerator;
 use Go\Instrument\PathResolver;
 use Go\Instrument\Transformer\FilterInjectorTransformer;
 use Composer\Autoload\ClassLoader;
-use Doctrine\Common\Annotations\AnnotationRegistry;
 
 /**
  * AopComposerLoader class is responsible to use a weaver for classes instead of original one
@@ -92,13 +91,6 @@ class AopComposerLoader
         foreach ($loaders as &$loader) {
             $loaderToUnregister = $loader;
             if (is_array($loader) && ($loader[0] instanceof ClassLoader)) {
-                $originalLoader = $loader[0];
-                // Configure library loader for doctrine annotation loader
-                AnnotationRegistry::registerLoader(function($class) use ($originalLoader) {
-                    $originalLoader->loadClass($class);
-
-                    return class_exists($class, false);
-                });
                 $loader[0] = new AopComposerLoader($loader[0], $container, $options);
                 self::$wasInitialized = true;
             }


### PR DESCRIPTION
Bumps dependency of doctrine/annotations to ^2.0 and migrates affected code:

* `CachedReader` was removed. Migrated to `PsrCachedReader` using adapter.
* `AnnotationRegistry::registerLoader` was removed. Annotations are now loaded using normal autoloading.