### PR TITLE
fix: prevent generating "namespace ;" for classes without declared namespace

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -54,7 +54,8 @@
             "Go\\Tests\\TestProject\\": "tests/Fixtures/project/src/"
         },
         "files": [
-            "tests/functions.php"
+            "tests/functions.php",
+            "tests/Go/Stubs/ClassWithoutNamespace.php"
         ]
     },
 

--- a/src/Aop/Framework/AbstractInterceptor.php
+++ b/src/Aop/Framework/AbstractInterceptor.php
@@ -65,7 +65,7 @@ abstract class AbstractInterceptor implements Interceptor, OrderedAdvice, Serial
     /**
      * Advice order
      */
-    private int $adviceOrder;
+    private int $adviceOrder = 0;
 
     /**
      * Default constructor for interceptor

--- a/src/Aop/Framework/AbstractMethodInvocation.php
+++ b/src/Aop/Framework/AbstractMethodInvocation.php
@@ -27,7 +27,7 @@ abstract class AbstractMethodInvocation extends AbstractInvocation implements Me
     /**
      * Instance of object for invoking
      */
-    protected ?object $instance;
+    protected ?object $instance = null;
 
     /**
      * Instance of reflection method for invocation

--- a/src/Instrument/Transformer/SelfValueVisitor.php
+++ b/src/Instrument/Transformer/SelfValueVisitor.php
@@ -81,7 +81,7 @@ final class SelfValueVisitor extends NodeVisitorAbstract
     public function enterNode(Node $node)
     {
         if ($node instanceof Namespace_) {
-            $this->namespace = $node->name->toString();
+            $this->namespace = !empty($node->name) ? $node->name->toString() : null;
         } elseif ($node instanceof Class_) {
             if ($node->name !== null) {
                 $this->className = new Name($node->name->toString());

--- a/src/Proxy/ClassProxyGenerator.php
+++ b/src/Proxy/ClassProxyGenerator.php
@@ -109,7 +109,7 @@ class ClassProxyGenerator
 
         $this->generator = new ClassGenerator(
             $originalClass->getShortName(),
-            $originalClass->getNamespaceName(),
+            !empty($originalClass->getNamespaceName()) ? $originalClass->getNamespaceName() : null,
             $originalClass->isFinal() ? ClassGenerator::FLAG_FINAL : null,
             $parentClassName,
             $introducedInterfaces,

--- a/tests/Go/Aop/Framework/AbstractMethodInvocationTest.php
+++ b/tests/Go/Aop/Framework/AbstractMethodInvocationTest.php
@@ -29,4 +29,41 @@ class AbstractMethodInvocationTest extends TestCase
     {
         $this->assertInstanceOf(AnnotationAccess::class, $this->invocation->getMethod());
     }
+
+    public function testInstanceIsInitialized(): void
+    {
+        $this->expectNotToPerformAssertions();
+        $o = new class extends AbstractMethodInvocation {
+
+            protected static string $propertyName = 'scope';
+            public function __construct()
+            {
+                parent::__construct([new AroundInterceptor(function () {})], '\Go\Aop\Framework\AbstractMethodInvocationTest', 'testInstanceIsInitialized');
+            }
+
+            public function isDynamic(): bool
+            {
+                return false;
+            }
+
+            public function getThis(): ?object
+            {
+                return null;
+            }
+
+            public function getScope(): string
+            {
+                return 'testScope';
+            }
+
+            public function proceed()
+            {
+                if ($this->level < 3) {
+                    $this->__invoke('testInstance');
+                }
+            }
+        };
+
+        $o->__invoke('testInstance');
+    }
 }

--- a/tests/Go/Instrument/Transformer/SelfValueTransformerTest.php
+++ b/tests/Go/Instrument/Transformer/SelfValueTransformerTest.php
@@ -72,4 +72,14 @@ class SelfValueTransformerTest extends TestCase
         $expected = file_get_contents(__DIR__ . '/_files/file-with-self-transformed.php');
         $this->assertSame($expected, (string) $metadata->source);
     }
+
+    public function testTransformerReplacesAllSelfPlacesWithoutNamespace(): void
+    {
+        $testFile = fopen(__DIR__ . '/_files/file-with-self-no-namespace.php', 'rb');
+        $content  = stream_get_contents($testFile);
+        $metadata = new StreamMetaData($testFile, $content);
+        $this->transformer->transform($metadata);
+        $expected = file_get_contents(__DIR__ . '/_files/file-with-self-no-namespace-transformed.php');
+        $this->assertSame($expected, (string) $metadata->source);
+    }
 }

--- a/tests/Go/Instrument/Transformer/_files/file-with-self-no-namespace-transformed.php
+++ b/tests/Go/Instrument/Transformer/_files/file-with-self-no-namespace-transformed.php
@@ -1,0 +1,61 @@
+<?php
+/** @noinspection PhpIllegalPsrClassPathInspection */
+declare(strict_types=1);
+
+class ClassWithSelfNoNamespace extends \Exception
+{
+    const CLASS_CONST = \ClassWithSelfNoNamespace::class;
+
+    private static $foo = 42;
+
+    private \ClassWithSelfNoNamespace $instance;
+
+    public function acceptsAndReturnsSelf(\ClassWithSelfNoNamespace $instance): \ClassWithSelfNoNamespace
+    {
+        return $instance;
+    }
+
+    public function containsClosureWithSelf()
+    {
+        $func = function (\ClassWithSelfNoNamespace $instance): \ClassWithSelfNoNamespace {
+            return $instance;
+        };
+        $func($this);
+    }
+
+    public function staticMethodCall()
+    {
+        return \ClassWithSelfNoNamespace::staticPropertyAccess();
+    }
+
+    public function classConstantFetch()
+    {
+        return \ClassWithSelfNoNamespace::class . \ClassWithSelfNoNamespace::CLASS_CONST;
+    }
+
+    public static function staticPropertyAccess()
+    {
+        return self::$foo;
+    }
+
+    public function newInstanceCreation()
+    {
+        return new \ClassWithSelfNoNamespace;
+    }
+
+    public function catchSection()
+    {
+        try {
+            throw new \ClassWithSelfNoNamespace;
+        } catch (\ClassWithSelfNoNamespace $exception) {
+            // Nop
+        }
+    }
+
+    public function instanceCheck()
+    {
+        if ($this instanceof \ClassWithSelfNoNamespace) {
+            // Nop
+        }
+    }
+}

--- a/tests/Go/Instrument/Transformer/_files/file-with-self-no-namespace.php
+++ b/tests/Go/Instrument/Transformer/_files/file-with-self-no-namespace.php
@@ -1,0 +1,61 @@
+<?php
+/** @noinspection PhpIllegalPsrClassPathInspection */
+declare(strict_types=1);
+
+class ClassWithSelfNoNamespace extends \Exception
+{
+    const CLASS_CONST = self::class;
+
+    private static $foo = 42;
+
+    private self $instance;
+
+    public function acceptsAndReturnsSelf(self $instance): self
+    {
+        return $instance;
+    }
+
+    public function containsClosureWithSelf()
+    {
+        $func = function (self $instance): self {
+            return $instance;
+        };
+        $func($this);
+    }
+
+    public function staticMethodCall()
+    {
+        return self::staticPropertyAccess();
+    }
+
+    public function classConstantFetch()
+    {
+        return self::class . self::CLASS_CONST;
+    }
+
+    public static function staticPropertyAccess()
+    {
+        return self::$foo;
+    }
+
+    public function newInstanceCreation()
+    {
+        return new self;
+    }
+
+    public function catchSection()
+    {
+        try {
+            throw new self;
+        } catch (self $exception) {
+            // Nop
+        }
+    }
+
+    public function instanceCheck()
+    {
+        if ($this instanceof self) {
+            // Nop
+        }
+    }
+}

--- a/tests/Go/Proxy/ClassProxyGeneratorTest.php
+++ b/tests/Go/Proxy/ClassProxyGeneratorTest.php
@@ -93,6 +93,7 @@ class ClassProxyGeneratorTest extends TestCase
             [First::class, 'publicMethod'],
             [First::class, 'protectedMethod'],
             [First::class, 'passByReference'],
+            [\ClassWithoutNamespace::class, 'publicMethod'],
         ];
     }
 }

--- a/tests/Go/Stubs/ClassWithoutNamespace.php
+++ b/tests/Go/Stubs/ClassWithoutNamespace.php
@@ -1,0 +1,11 @@
+<?php /** @noinspection PhpIllegalPsrClassPathInspection */
+
+
+class ClassWithoutNamespace
+{
+    public function publicMethod(): int
+    {
+        return 1;
+    }
+
+}


### PR DESCRIPTION
This fixes a bug when trying to work with classes that have no namespace declared - see updated unit test.

Note that the error comes as an rather unspecific
```
ParseError: syntax error, unexpected ';', expecting '{'
```
As the generated code includes `namespace ;`!

It would be very nice if this could be released as a bugfix soon :)

