### PR TITLE
fix(proxy): add explicit nullable type prefix to generated function/method parameter types

### DIFF
--- a/src/Proxy/Part/FunctionParameterList.php
+++ b/src/Proxy/Part/FunctionParameterList.php
@@ -43,7 +43,8 @@ final class FunctionParameterList
             if (!$useTypeWidening && $reflectionParameter->hasType()) {
                 $parameterReflectionType = $reflectionParameter->getType();
                 if ($parameterReflectionType instanceof ReflectionNamedType) {
-                    $parameterTypeName = $parameterReflectionType->getName();
+                    $typeName          = $parameterReflectionType->getName();
+                    $parameterTypeName = ($parameterReflectionType->allowsNull() && $typeName !== 'mixed' ? '?' : '') . $typeName;
                 } else {
                     $parameterTypeName = (string) $parameterReflectionType;
                 }

--- a/src/Proxy/Part/FunctionParameterList.php
+++ b/src/Proxy/Part/FunctionParameterList.php
@@ -44,7 +44,7 @@ final class FunctionParameterList
                 $parameterReflectionType = $reflectionParameter->getType();
                 if ($parameterReflectionType instanceof ReflectionNamedType) {
                     $typeName          = $parameterReflectionType->getName();
-                    $parameterTypeName = ($parameterReflectionType->allowsNull() && $typeName !== 'mixed' ? '?' : '') . $typeName;
+                    $parameterTypeName = ($parameterReflectionType->allowsNull() && $typeName !== 'mixed' && $typeName !== 'null' ? '?' : '') . $typeName;
                 } else {
                     $parameterTypeName = (string) $parameterReflectionType;
                 }

--- a/src/Proxy/Part/InterceptedFunctionGenerator.php
+++ b/src/Proxy/Part/InterceptedFunctionGenerator.php
@@ -55,7 +55,7 @@ final class InterceptedFunctionGenerator extends AbstractGenerator
             $reflectionReturnType = $reflectionFunction->getReturnType();
             if ($reflectionReturnType instanceof ReflectionNamedType) {
                 $typeName       = $reflectionReturnType->getName();
-                $returnTypeName = ($reflectionReturnType->allowsNull() && $typeName !== 'mixed' ? '?' : '') . $typeName;
+                $returnTypeName = ($reflectionReturnType->allowsNull() && $typeName !== 'mixed' && $typeName !== 'null' ? '?' : '') . $typeName;
             } else {
                 $returnTypeName = (string)$reflectionReturnType;
             }

--- a/src/Proxy/Part/InterceptedFunctionGenerator.php
+++ b/src/Proxy/Part/InterceptedFunctionGenerator.php
@@ -54,7 +54,8 @@ final class InterceptedFunctionGenerator extends AbstractGenerator
         if ($reflectionFunction->hasReturnType()) {
             $reflectionReturnType = $reflectionFunction->getReturnType();
             if ($reflectionReturnType instanceof ReflectionNamedType) {
-                $returnTypeName = $reflectionReturnType->getName();
+                $typeName       = $reflectionReturnType->getName();
+                $returnTypeName = ($reflectionReturnType->allowsNull() && $typeName !== 'mixed' ? '?' : '') . $typeName;
             } else {
                 $returnTypeName = (string)$reflectionReturnType;
             }

--- a/tests/Go/Proxy/Part/InterceptedConstructorGeneratorTest.php
+++ b/tests/Go/Proxy/Part/InterceptedConstructorGeneratorTest.php
@@ -52,14 +52,14 @@ class InterceptedConstructorGeneratorTest extends TestCase
         return [
             [
                 Exception::class,
-                'public function __construct(string $message = \'\', int $code = 0, \Throwable $previous = null)
+                'public function __construct(string $message = \'\', int $code = 0, ?\Throwable $previous = null)
                 {
                     parent::__construct(...\array_slice([$message, $code, $previous], 0, \func_num_args()));
                 }'
             ],
             [
                 ClassWithOptionalArgsConstructor::class,
-                'public function __construct(int $foo = 42, bool $bar = false, \stdClass $instance = null)
+                'public function __construct(int $foo = 42, bool $bar = false, ?\stdClass $instance = null)
                 {
                     parent::__construct(...\array_slice([$foo, $bar, $instance], 0, \func_num_args()));
                 }'

--- a/tests/Go/Proxy/Part/InterceptedFunctionGeneratorTest.php
+++ b/tests/Go/Proxy/Part/InterceptedFunctionGeneratorTest.php
@@ -38,6 +38,14 @@ function funcWithNullableParams(?string $name = null, int $count = 0): ?string
 }
 
 /**
+ * Contains test function with standalone null return type (PHP 8.2+)
+ */
+function funcReturningNull(): null
+{
+    return null;
+}
+
+/**
  * Test case for generated function definition
  */
 class InterceptedFunctionGeneratorTest extends TestCase
@@ -97,6 +105,10 @@ class InterceptedFunctionGeneratorTest extends TestCase
             [
                 '\Go\Proxy\Part\funcWithNullableParams',
                 'function funcWithNullableParams(?string $name = null, int $count = 0) : ?string'
+            ],
+            [
+                '\Go\Proxy\Part\funcReturningNull',
+                'function funcReturningNull() : null'
             ],
         ];
     }

--- a/tests/Go/Proxy/Part/InterceptedFunctionGeneratorTest.php
+++ b/tests/Go/Proxy/Part/InterceptedFunctionGeneratorTest.php
@@ -30,6 +30,14 @@ function funcWithReturnTypeAndDocBlock(): Exception
 }
 
 /**
+ * Contains test function with nullable parameters and nullable return type
+ */
+function funcWithNullableParams(?string $name = null, int $count = 0): ?string
+{
+    return $name !== null ? str_repeat($name, $count) : null;
+}
+
+/**
  * Test case for generated function definition
  */
 class InterceptedFunctionGeneratorTest extends TestCase
@@ -81,6 +89,14 @@ class InterceptedFunctionGeneratorTest extends TestCase
             [
                 '\Go\Proxy\Part\funcWithReturnTypeAndDocBlock',
                 'function funcWithReturnTypeAndDocBlock() : \Exception'
+            ],
+            [
+                'array_slice',
+                'function array_slice(array $array, int $offset, ?int $length = null, bool $preserve_keys = false) : array'
+            ],
+            [
+                '\Go\Proxy\Part\funcWithNullableParams',
+                'function funcWithNullableParams(?string $name = null, int $count = 0) : ?string'
             ],
         ];
     }


### PR DESCRIPTION
Fixes #521

Generated proxy code for intercepted functions was missing the `?` prefix on nullable named types (e.g. `callable $callback = null` instead of `?callable $callback = null`), triggering PHP 8.4+ deprecation notices about implicitly nullable parameters.

- FunctionParameterList: check allowsNull() on ReflectionNamedType and prepend `?` when true (excluding `mixed` which cannot be nullable)
- InterceptedFunctionGenerator: apply the same fix to return type generation (was also silently dropping the `?` prefix)
- Update InterceptedConstructorGeneratorTest expected signatures to use explicit nullable syntax (?\Throwable, ?\stdClass)
- Add test cases for array_slice (builtin with ?int $length) and a custom function with nullable param + nullable return type