### PR TITLE
feature(composer): Bump all dependencies to use packages with PHP>=8.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,17 +13,17 @@
         "goaop/parser-reflection": "4.x-dev",
         "goaop/dissect": "^3.0",
         "nikic/php-parser": "^5.0",
-        "symfony/finder": "^6.4 || ^7.0"
+        "symfony/finder": "^7.4 || ^8.0"
     },
 
     "require-dev": {
         "adlawson/vfs": "^0.12.1",
         "doctrine/orm": "^2.5 || ^3.0",
         "phpstan/phpstan": "^2.0",
-        "phpunit/phpunit": "^11.0",
-        "symfony/console": "^6.4 || ^7.0",
-        "symfony/filesystem": "^6.4 || ^7.0",
-        "symfony/process": "^6.4 || ^7.0",
+        "phpunit/phpunit": "^13.0",
+        "symfony/console": "^7.4 || ^8.0",
+        "symfony/filesystem": "^7.4 || ^8.0",
+        "symfony/process": "^7.4 || ^8.0",
         "tracy/tracy": "^2.10",
         "webmozart/glob": "^4.1"
     },

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,17 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd" colors="true" bootstrap="./vendor/autoload.php">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/13.0/phpunit.xsd" colors="true" bootstrap="./vendor/autoload.php">
   <testsuites>
     <testsuite name="Go! AOP Test Suite">
       <directory>./tests/Go/</directory>
     </testsuite>
   </testsuites>
-  <coverage>
-    <report>
-      <clover outputFile="./build/logs/clover.xml"/>
-      <crap4j outputFile="./build/logs/crap4j.xml"/>
-      <xml outputDirectory="./build/coverage/xml"/>
-    </report>
-  </coverage>
   <logging>
     <junit outputFile="./build/logs/junit.xml"/>
   </logging>

--- a/tests/Go/Aop/Framework/AbstractInterceptorTestCase.php
+++ b/tests/Go/Aop/Framework/AbstractInterceptorTestCase.php
@@ -51,16 +51,14 @@ abstract class AbstractInterceptorTestCase extends TestCase
         $invocation
             ->expects($this->any())
             ->method('proceed')
-            ->will(
-                $this->returnCallback(
-                    function () use (&$sequenceRecorder, $throwException) {
-                        $sequenceRecorder[] = 'invocation';
-                        if ($throwException) {
-                            throw new RuntimeException('Expected exception');
-                        }
-                        return 'invocation';
+            ->willReturnCallback(
+                function () use (&$sequenceRecorder, $throwException) {
+                    $sequenceRecorder[] = 'invocation';
+                    if ($throwException) {
+                        throw new RuntimeException('Expected exception');
                     }
-                )
+                    return 'invocation';
+                }
             );
 
         return $invocation;

--- a/tests/Go/Aop/Framework/AbstractMethodInvocationTest.php
+++ b/tests/Go/Aop/Framework/AbstractMethodInvocationTest.php
@@ -12,10 +12,10 @@ class AbstractMethodInvocationTest extends TestCase
 
     public function setUp(): void
     {
-        $this->invocation = $this->getMockForAbstractClass(
-            AbstractMethodInvocation::class,
-            [[], self::class, __FUNCTION__]
-        );
+        $this->invocation = $this->getMockBuilder(AbstractMethodInvocation::class)
+            ->setConstructorArgs([[], self::class, __FUNCTION__])
+            ->onlyMethods(['proceed', 'isDynamic', 'getThis', 'getScope'])
+            ->getMock();
     }
 
     public function testInvocationReturnsMethod(): void

--- a/tests/Go/Aop/Framework/BaseInterceptorTest.php
+++ b/tests/Go/Aop/Framework/BaseInterceptorTest.php
@@ -27,10 +27,10 @@ class BaseInterceptorTest extends AbstractInterceptorTestCase
         $sequence = [];
         $advice   = $this->getAdvice($sequence);
 
-        $interceptor = $this->getMockForAbstractClass(
-            AbstractInterceptor::class,
-            [$advice]
-        );
+        $interceptor = $this->getMockBuilder(AbstractInterceptor::class)
+            ->setConstructorArgs([$advice])
+            ->onlyMethods(['invoke'])
+            ->getMock();
         $this->assertEquals($advice, $interceptor->getRawAdvice());
     }
 

--- a/tests/Go/Aop/Framework/DynamicClosureSplatMethodInvocationTest.php
+++ b/tests/Go/Aop/Framework/DynamicClosureSplatMethodInvocationTest.php
@@ -73,11 +73,11 @@ class DynamicClosureSplatMethodInvocationTest extends TestCase
         $child      = $this->createMock(First::class);
         $invocation = new DynamicClosureMethodInvocation([], First::class, 'recursion');
 
-        $child->expects($this->exactly(5))->method('recursion')->will($this->returnCallback(
+        $child->expects($this->exactly(5))->method('recursion')->willReturnCallback(
             function ($value, $level) use ($child, $invocation) {
                 return $invocation($child, [$value, $level]);
             }
-        ));
+        );
 
         $this->assertEquals(5, $child->recursion(5,0));
         $this->assertEquals(20, $child->recursion(5,3));
@@ -90,10 +90,10 @@ class DynamicClosureSplatMethodInvocationTest extends TestCase
         $advice = $this->createMock(Interceptor::class);
         $advice->expects($this->once())
             ->method('invoke')
-            ->will($this->returnCallback(function (MethodInvocation $object) use (&$value) {
+            ->willReturnCallback(function (MethodInvocation $object) use (&$value) {
                 $value = 'ok';
                 return $object->proceed();
-            }));
+            });
 
         $invocation = new DynamicClosureMethodInvocation([$advice], First::class, 'publicMethod');
 

--- a/tests/Go/Instrument/FileSystem/EnumeratorTest.php
+++ b/tests/Go/Instrument/FileSystem/EnumeratorTest.php
@@ -112,9 +112,9 @@ class EnumeratorTest extends TestCase
         // VFS does not support getRealPath()
         $mock->expects($this->any())
             ->method('getFileFullPath')
-            ->will($this->returnCallback(function (SplFileInfo $file) {
+            ->willReturnCallback(function (SplFileInfo $file) {
                 return $file->getPathname();
-            }));
+            });
 
         $iterator = $mock->enumerate();
 

--- a/tests/Go/Instrument/Transformer/FilterInjectorTransformerTest.php
+++ b/tests/Go/Instrument/Transformer/FilterInjectorTransformerTest.php
@@ -52,15 +52,10 @@ class FilterInjectorTransformerTest extends TestCase
      */
     protected function getKernelMock(array $options, AspectContainer $container): AspectKernel
     {
-        $mock = $this->getMockForAbstractClass(
-            AspectKernel::class,
-            [],
-            '',
-            false,
-            true,
-            true,
-            ['getOptions', 'getContainer']
-        );
+        $mock = $this->getMockBuilder(AspectKernel::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['configureAop', 'getOptions', 'getContainer'])
+            ->getMock();
         $mock
             ->method('getOptions')
             ->willReturn($options);

--- a/tests/Go/Instrument/Transformer/MagicConstantTransformerTest.php
+++ b/tests/Go/Instrument/Transformer/MagicConstantTransformerTest.php
@@ -43,25 +43,16 @@ class MagicConstantTransformerTest extends TestCase
      */
     protected function getKernelMock(array $options): AspectKernel
     {
-        $mock = $this->getMockForAbstractClass(
-            AspectKernel::class,
-            [],
-            '',
-            false,
-            true,
-            true,
-            ['getOptions', 'getContainer']
-        );
+        $mock = $this->getMockBuilder(AspectKernel::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['configureAop', 'getOptions', 'getContainer'])
+            ->getMock();
         $mock->expects($this->any())
             ->method('getOptions')
-            ->will(
-                $this->returnValue($options)
-            );
+            ->willReturn($options);
         $mock->expects($this->any())
             ->method('getContainer')
-            ->will(
-                $this->returnValue($this->createMock(AspectContainer::class))
-            );
+            ->willReturn($this->createMock(AspectContainer::class));
 
         return $mock;
     }

--- a/tests/Go/Instrument/Transformer/WeavingTransformerTest.php
+++ b/tests/Go/Instrument/Transformer/WeavingTransformerTest.php
@@ -66,11 +66,7 @@ class WeavingTransformerTest extends TestCase
             ],
             $container
         );
-        $this->cachePathManager = $this
-            ->getMockBuilder(CachePathManager::class)
-            ->setConstructorArgs([$this->kernel])
-            ->enableProxyingToOriginalMethods()
-            ->getMock();
+        $this->cachePathManager = new CachePathManager($this->kernel);
 
         $this->transformer = new WeavingTransformer(
             $this->kernel,
@@ -174,10 +170,7 @@ class WeavingTransformerTest extends TestCase
             ],
             $container
         );
-        $cachePathManager = $this->getMockBuilder(CachePathManager::class)
-            ->setConstructorArgs([$kernel])
-            ->enableProxyingToOriginalMethods()
-            ->getMock();
+        $cachePathManager = new CachePathManager($kernel);
 
         $this->transformer = new WeavingTransformer(
             $kernel,
@@ -236,15 +229,10 @@ class WeavingTransformerTest extends TestCase
      */
     protected function getKernelMock(array $options, AspectContainer $container): AspectKernel
     {
-        $mock = $this->getMockForAbstractClass(
-            AspectKernel::class,
-            [],
-            '',
-            false,
-            true,
-            true,
-            ['getOptions', 'getContainer', 'hasFeature']
-        );
+        $mock = $this->getMockBuilder(AspectKernel::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['configureAop', 'getOptions', 'getContainer', 'hasFeature'])
+            ->getMock();
 
         $mock->method('getOptions')
             ->willReturn($options);
@@ -265,16 +253,14 @@ class WeavingTransformerTest extends TestCase
         $mock = $this->createMock(AdviceMatcherInterface::class);
         $mock
             ->method('getAdvicesForClass')
-            ->will(
-                $this->returnCallback(function (ReflectionClass $refClass) {
-                    $advices  = [];
-                    foreach ($refClass->getMethods() as $method) {
-                        $advisorId = "advisor.{$refClass->name}->{$method->name}";
-                        $advices[AspectContainer::METHOD_PREFIX][$method->name][$advisorId] = true;
-                    }
-                    return $advices;
-                })
-            );
+            ->willReturnCallback(function (ReflectionClass $refClass) {
+                $advices  = [];
+                foreach ($refClass->getMethods() as $method) {
+                    $advisorId = "advisor.{$refClass->name}->{$method->name}";
+                    $advices[AspectContainer::METHOD_PREFIX][$method->name][$advisorId] = true;
+                }
+                return $advices;
+            });
 
         return $mock;
     }


### PR DESCRIPTION
Updates the project’s dev tooling and test suite to align with PHP >= 8.4 by bumping key dependencies (notably PHPUnit and Symfony components) and modernizing PHPUnit mocks/configuration accordingly.

Changes:

- Bump Symfony component constraints and PHPUnit to newer major versions compatible with PHP ^8.4.
- Update PHPUnit test doubles to newer PHPUnit mocking APIs (willReturn*, getMockBuilder()->onlyMethods()).
- Update phpunit.xml.dist to the PHPUnit 13 schema/config structure.