### PR TITLE
feat: Use phpstan generic types for core interfaces to have better typing

### DIFF
--- a/demos/Demo/Aspect/HealthyLiveAspect.php
+++ b/demos/Demo/Aspect/HealthyLiveAspect.php
@@ -14,7 +14,7 @@ namespace Demo\Aspect;
 
 use Demo\Example\HumanDemo;
 use Go\Aop\Aspect;
-use Go\Aop\Intercept\MethodInvocation;
+use Go\Aop\Intercept\DynamicMethodInvocation;
 use Go\Lang\Attribute\After;
 use Go\Lang\Attribute\Before;
 use Go\Lang\Attribute\Pointcut;
@@ -34,33 +34,36 @@ class HealthyLiveAspect implements Aspect
 
     /**
      * Washing hands before eating
+     *
+     * @param DynamicMethodInvocation<HumanDemo> $invocation
      */
     #[Before('$this->humanEat')]
-    protected function washUpBeforeEat(MethodInvocation $invocation): void
+    protected function washUpBeforeEat(DynamicMethodInvocation $invocation): void
     {
-        /** @var $person HumanDemo */
         $person = $invocation->getThis();
         $person->washUp();
     }
 
     /**
      * Method that advices to clean the teeth after eating
+     *
+     * @param DynamicMethodInvocation<HumanDemo> $invocation
      */
     #[After('$this->humanEat')]
-    protected function cleanTeethAfterEat(MethodInvocation $invocation): void
+    protected function cleanTeethAfterEat(DynamicMethodInvocation $invocation): void
     {
-        /** @var $person HumanDemo */
         $person = $invocation->getThis();
         $person->cleanTeeth();
     }
 
     /**
      * Method that advice to clean the teeth before going to sleep
+     *
+     * @param DynamicMethodInvocation<HumanDemo> $invocation
      */
     #[Before('execution(public Demo\Example\HumanDemo->sleep(*))')]
-    protected function cleanTeethBeforeSleep(MethodInvocation $invocation): void
+    protected function cleanTeethBeforeSleep(DynamicMethodInvocation $invocation): void
     {
-        /** @var $person HumanDemo */
         $person = $invocation->getThis();
         $person->cleanTeeth();
     }

--- a/demos/Demo/Aspect/IntroductionAspect.php
+++ b/demos/Demo/Aspect/IntroductionAspect.php
@@ -27,8 +27,8 @@ class IntroductionAspect implements Aspect
      */
     #[DeclareParents(
         'within(Demo\Example\IntroductionDemo)',
-        interface: Stringable::class,
-        trait: StringableImpl::class
+        interfaceName: Stringable::class,
+        traitName: StringableImpl::class
     )]
     protected null $introduction;
 }

--- a/demos/Demo/Aspect/LoggingAspect.php
+++ b/demos/Demo/Aspect/LoggingAspect.php
@@ -29,9 +29,7 @@ class LoggingAspect implements Aspect
      * We use "Before" type of advice to log only class name, method name and arguments before
      * method execution.
      * You can choose your own logger, for example, monolog or log4php.
-     * Also you can choose "After" or "Around" advice to access an return value from method.
-     *
-     * To inject logger into this aspect you can look at Warlock framework with DI+AOP
+     * Also, you can choose "After" or "Around" advice to access a return value from method.
      */
     #[Before("@execution(Demo\Attribute\Loggable)")]
     public function beforeMethodExecution(MethodInvocation $invocation): void

--- a/demos/Demo/Aspect/PropertyInterceptorAspect.php
+++ b/demos/Demo/Aspect/PropertyInterceptorAspect.php
@@ -12,20 +12,21 @@ declare(strict_types=1);
 
 namespace Demo\Aspect;
 
+use Demo\Example\PropertyDemo;
 use Go\Aop\Aspect;
 use Go\Aop\Intercept\FieldAccess;
 use Go\Aop\Intercept\FieldAccessType;
 use Go\Lang\Attribute\Around;
 
 /**
- * Property interceptor can intercept an access to the public and protected properties
- *
- * Be aware, it's very tricky and will not work for indirect modification, such as array_pop($this->property);
+ * Property interceptor can intercept access to class properties
  */
 class PropertyInterceptorAspect implements Aspect
 {
     /**
-     * Advice that controls an access to the properties
+     * Advice that controls access to the properties
+     *
+     * @param FieldAccess<PropertyDemo> $fieldAccess
      */
     #[Around("access(public|protected|private Demo\Example\PropertyDemo->*)")]
     public function aroundFieldAccess(FieldAccess $fieldAccess): void

--- a/src/Aop/Framework/AbstractMethodInvocation.php
+++ b/src/Aop/Framework/AbstractMethodInvocation.php
@@ -24,6 +24,9 @@ use function count;
  * Abstract method invocation implementation
  *
  * @phpstan-type MethodInvocationFrame array{list<mixed>, mixed, int}
+ *
+ * @template T of object = object
+ * @implements MethodInvocation<T>
  */
 abstract class AbstractMethodInvocation extends AbstractInvocation implements MethodInvocation
 {
@@ -59,7 +62,7 @@ abstract class AbstractMethodInvocation extends AbstractInvocation implements Me
      * Constructor for method invocation
      *
      * @param array<Interceptor> $advices    List of advices for this invocation
-     * @param class-string       $className  Class, containing method to invoke
+     * @param class-string<T>    $className  Class, containing method to invoke
      * @param non-empty-string   $methodName Name of the method to invoke
      */
     public function __construct(array $advices, string $className, string $methodName)

--- a/src/Aop/Framework/ClassFieldAccess.php
+++ b/src/Aop/Framework/ClassFieldAccess.php
@@ -20,18 +20,22 @@ use ReflectionProperty;
 
 /**
  * Represents a field access joinpoint
+ *
+ * @template T of object = object
+ * @implements FieldAccess<T>
  */
 final class ClassFieldAccess extends AbstractJoinpoint implements FieldAccess
 {
     /**
      * Stack frames to work with recursive calls or with cross-calls inside object
      *
-     * @var array<int, array{object, FieldAccessType, mixed, mixed}>
+     * @var array<int, array{T, FieldAccessType, mixed, mixed}>
      */
     private array $stackFrames = [];
 
     /**
      * Instance of object for accessing
+     * @phpstan-var T Instance of object for accessing
      */
     private object $instance;
 
@@ -59,7 +63,7 @@ final class ClassFieldAccess extends AbstractJoinpoint implements FieldAccess
      * Constructor for field access
      *
      * @param array<Interceptor> $advices List of advices for this invocation
-     * @param class-string $className
+     * @param class-string<T> $className
      */
     public function __construct(array $advices, string $className, string $fieldName)
     {
@@ -125,8 +129,6 @@ final class ClassFieldAccess extends AbstractJoinpoint implements FieldAccess
     }
 
     /**
-     * @inheritdoc
-     *
      * @return void Covariant, as for field interceptor there is no return value
      */
     final public function proceed(): void
@@ -141,7 +143,8 @@ final class ClassFieldAccess extends AbstractJoinpoint implements FieldAccess
     /**
      * Invokes current field access with all interceptors
      *
-     * @param mixed $originalValue Original value of property, passed by reference
+     * @phpstan-param T $instance Instance of object for accessing
+     * @param FieldAccessType $accessType Access type for field access
      *
      * @return mixed
      */
@@ -178,17 +181,11 @@ final class ClassFieldAccess extends AbstractJoinpoint implements FieldAccess
         }
     }
 
-    /**
-     * @return object Covariant, always instance of object, can not be null
-     */
     final public function getThis(): object
     {
         return $this->instance;
     }
 
-    /**
-     * @return true Covariance, always true for class properties
-     */
     final public function isDynamic(): true
     {
         return true;

--- a/src/Aop/Framework/DynamicTraitAliasMethodInvocation.php
+++ b/src/Aop/Framework/DynamicTraitAliasMethodInvocation.php
@@ -13,14 +13,19 @@ declare(strict_types=1);
 namespace Go\Aop\Framework;
 
 use Closure;
+use Go\Aop\Intercept\DynamicMethodInvocation;
 
 /**
  * Dynamic trait-alias method invocation calls instance methods via a pre-bound Closure::bind closure
  * targeting the private __aop__<method> alias created in the proxy's trait-use block.
  *
  * The closure is built once at construction time so that every invocation needs zero reflection.
+ *
+ * @template T of object
+ * @extends AbstractMethodInvocation<T>
+ * @implements DynamicMethodInvocation<T>
  */
-final class DynamicTraitAliasMethodInvocation extends AbstractMethodInvocation
+final class DynamicTraitAliasMethodInvocation extends AbstractMethodInvocation implements DynamicMethodInvocation
 {
     /**
      * For dynamic calls we store given argument as 'instance' property
@@ -31,11 +36,16 @@ final class DynamicTraitAliasMethodInvocation extends AbstractMethodInvocation
     protected static string $propertyName = 'instance';
 
     /**
-     * @var object Instance of object for invoking, should be protected as it's read in parent class
+     * @phpstan-var T Instance of object for invoking, should be protected as it's read in parent class
      * @see parent::__invoke() where this variable is accessed via {@see $propertyName} value
      */
     protected object $instance;
 
+    /**
+     * Constructor for method invocation
+     *
+     * @param class-string<T> $className  Class, containing method to invoke
+     */
     public function __construct(array $advices, string $className, string $methodName)
     {
         parent::__construct($advices, $className, $methodName);
@@ -62,7 +72,7 @@ final class DynamicTraitAliasMethodInvocation extends AbstractMethodInvocation
     }
 
     /**
-     * @return object Covariance, always instance of object
+     * @phpstan-return T Covariance, always instance of object
      */
     final public function getThis(): object
     {

--- a/src/Aop/Framework/ReflectionConstructorInvocation.php
+++ b/src/Aop/Framework/ReflectionConstructorInvocation.php
@@ -20,9 +20,10 @@ use ReflectionMethod;
 /**
  * Reflection constructor invocation implementation
  *
- * @template T of object
+ * @template T of object = object
+ * @implements ConstructorInvocation<T>
  */
-class ReflectionConstructorInvocation extends AbstractInvocation implements ConstructorInvocation
+final class ReflectionConstructorInvocation extends AbstractInvocation implements ConstructorInvocation
 {
     /**
      * @var ReflectionClass<T> Reflection of given class
@@ -30,7 +31,7 @@ class ReflectionConstructorInvocation extends AbstractInvocation implements Cons
     private readonly ReflectionClass $class;
 
     /**
-     * @var null|T Instance of created class, can be used for Around or After types of advices.
+     * @phpstan-var null|T Instance of created class, can be used for Around or After types of advices.
      */
     private ?object $instance = null;
 
@@ -54,8 +55,6 @@ class ReflectionConstructorInvocation extends AbstractInvocation implements Cons
     }
 
     /**
-     * @inheritdoc
-     *
      * @return mixed|T Covariant, always new object.
      * @throws \ReflectionException If class is internal and cannot be created without constructor
      */
@@ -84,7 +83,7 @@ class ReflectionConstructorInvocation extends AbstractInvocation implements Cons
     /**
      * Returns the object for which current joinpoint is invoked
      *
-     * @return T|null Instance of object or null if object hasn't been created yet (Before)
+     * @phpstan-return T|null Instance of object or null if object hasn't been created yet (Before)
      */
     public function getThis(): ?object
     {

--- a/src/Aop/Framework/StaticInitializationJoinpoint.php
+++ b/src/Aop/Framework/StaticInitializationJoinpoint.php
@@ -19,7 +19,8 @@ use ReflectionClass;
 /**
  * Static initialization joinpoint is invoked after class is loaded into memory
  *
- * @template T of object
+ * @template T of object = object
+ * @implements ClassJoinpoint<T>
  */
 class StaticInitializationJoinpoint extends AbstractJoinpoint implements ClassJoinpoint
 {
@@ -32,7 +33,7 @@ class StaticInitializationJoinpoint extends AbstractJoinpoint implements ClassJo
      * Constructor for the class static initialization joinpoint
      *
      * @param array<Interceptor> $advices List of advices for this invocation
-     * @phpstan-param class-string<T> $className Name of the class
+     * @param class-string<T> $className Name of the class
      */
     public function __construct(array $advices, string $className)
     {
@@ -41,7 +42,6 @@ class StaticInitializationJoinpoint extends AbstractJoinpoint implements ClassJo
     }
 
     /**
-     * @inheritdoc
      * @return void Covariant, as static initializtion could not return anything
      */
     public function proceed(): void
@@ -62,8 +62,6 @@ class StaticInitializationJoinpoint extends AbstractJoinpoint implements ClassJo
     }
 
     /**
-     * @inheritdoc
-     *
      * @return null Covariance, always null for static initialization
      */
     public function getThis(): null

--- a/src/Aop/Framework/StaticInitializationJoinpoint.php
+++ b/src/Aop/Framework/StaticInitializationJoinpoint.php
@@ -42,7 +42,7 @@ class StaticInitializationJoinpoint extends AbstractJoinpoint implements ClassJo
     }
 
     /**
-     * @return void Covariant, as static initializtion could not return anything
+     * @return void Covariant, as static initialization could not return anything
      */
     public function proceed(): void
     {

--- a/src/Aop/Framework/StaticTraitAliasMethodInvocation.php
+++ b/src/Aop/Framework/StaticTraitAliasMethodInvocation.php
@@ -13,14 +13,19 @@ declare(strict_types=1);
 namespace Go\Aop\Framework;
 
 use Closure;
+use Go\Aop\Intercept\StaticMethodInvocation;
 
 /**
  * Static trait-alias method invocation calls static methods via a pre-bound Closure::bind closure
  * targeting the private __aop__<method> alias created in the proxy's trait-use block.
  *
  * The closure is built once at construction time so that every invocation needs zero reflection.
+ *
+ * @template T of object = object
+ * @extends AbstractMethodInvocation<T>
+ * @implements StaticMethodInvocation<T>
  */
-final class StaticTraitAliasMethodInvocation extends AbstractMethodInvocation
+final class StaticTraitAliasMethodInvocation extends AbstractMethodInvocation implements StaticMethodInvocation
 {
     /**
      * For static calls we store given argument as 'scope' property
@@ -31,10 +36,15 @@ final class StaticTraitAliasMethodInvocation extends AbstractMethodInvocation
     protected static string $propertyName = 'scope';
 
     /**
-     * @var class-string Class name scope for static invocation
+     * @var class-string<T> Class name scope for static invocation
      */
     protected string $scope;
 
+    /**
+     * Constructor for method invocation
+     *
+     * @param class-string<T> $className  Class, containing method to invoke
+     */
     public function __construct(array $advices, string $className, string $methodName)
     {
         parent::__construct($advices, $className, $methodName);

--- a/src/Aop/Framework/TraitIntroductionInfo.php
+++ b/src/Aop/Framework/TraitIntroductionInfo.php
@@ -17,10 +17,13 @@ use Go\Aop\IntroductionInfo;
 /**
  * Advice for introduction that holds trait and interface for the concrete class
  */
-readonly class TraitIntroductionInfo implements IntroductionInfo
+final readonly class TraitIntroductionInfo implements IntroductionInfo
 {
     /**
      * Creates a TraitIntroductionInfo with given trait name and interface name.
+     *
+     * @param trait-string $introducedTrait     Trait name
+     * @param class-string $introducedInterface Interface name
      */
     public function __construct(
         private string $introducedTrait,

--- a/src/Aop/Intercept/ClassJoinpoint.php
+++ b/src/Aop/Intercept/ClassJoinpoint.php
@@ -16,6 +16,8 @@ namespace Go\Aop\Intercept;
  * This interface represents a class joinpoint that can have $this variable and defined scope
  *
  * @api
+ *
+ * @template T of object = object
  */
 interface ClassJoinpoint extends Joinpoint
 {
@@ -34,13 +36,14 @@ interface ClassJoinpoint extends Joinpoint
      * Returns the object for which current joinpoint is invoked or null for static calls
      *
      * @api
+     * @phpstan-return T|null
      */
     public function getThis(): ?object;
 
     /**
      * Returns the static scope name (class name) of this joinpoint.
      *
-     * @return class-string
+     * @return class-string<T>
      *
      * @api
      */

--- a/src/Aop/Intercept/ConstructorInvocation.php
+++ b/src/Aop/Intercept/ConstructorInvocation.php
@@ -20,6 +20,9 @@ use ReflectionMethod;
  * A constructor invocation is a joinpoint and can be intercepted by a constructor interceptor.
  *
  * @api
+ *
+ * @template T of object = object
+ * @extends ClassJoinpoint<T>
  */
 interface ConstructorInvocation extends Invocation, ClassJoinpoint
 {

--- a/src/Aop/Intercept/DynamicMethodInvocation.php
+++ b/src/Aop/Intercept/DynamicMethodInvocation.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+/*
+ * Go! AOP framework
+ *
+ * @copyright Copyright 2026, Lisachenko Alexander <lisachenko.it@gmail.com>
+ *
+ * This source file is subject to the license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Go\Aop\Intercept;
+
+/**
+ * Dynamic method invocation extends the `MethodInvocation` with type information about dynamic method calls.
+ *
+ * This type is mostly used for the PhpStan nullable type-safety, ensuring that the {@see self::getThis()} method
+ * always returns an instance of object for all dynamic calls.
+ *
+ * Interface overrides the return type of {@see MethodInvocation::getThis()} method and narrows its return type to
+ * the generic object for all dynamic calls, removing the nullability of the return type.
+ *
+ * Without this interface, aspect advice should use the null-safe operator `$invocation->getThis()?->method()` to avoid
+ * type errors.
+ *
+ * @template T of object = object
+ * @extends MethodInvocation<T>
+ *
+ * @link https://wiki.php.net/rfc/nullsafe_operator
+ */
+interface DynamicMethodInvocation extends MethodInvocation
+{
+    /**
+     * @phpstan-return T Covariance, always instance of object
+     */
+    public function getThis(): object;
+
+    /**
+     * @return true Covariance, always true for dynamic method calls
+     */
+    public function isDynamic(): true;
+}

--- a/src/Aop/Intercept/FieldAccess.php
+++ b/src/Aop/Intercept/FieldAccess.php
@@ -22,8 +22,8 @@ use ReflectionProperty;
  *
  * This interface is declared as generic, to get better code completion, specify concrete generic type for
  * your parameter as `FieldAccess<SomeConcreteType>` in your aspects to make {@see self::getThis()} method
- * returning proper type for instance `SomeConcreteType`. Same applied to the {@see self::getScope()} method -
- * it will return proper type for instance `SomeConcreteType`.
+ * returning proper type for instance `SomeConcreteType`. The same applies to the {@see self::getScope()} method -
+ * it will return the proper type for an instance of `SomeConcreteType`.
  *
  * Interface overrides the return type of {@see ClassJoinpoint::getThis()} method and narrows its return type to
  * the generic object for all field accesses, removing the nullability of the return type.

--- a/src/Aop/Intercept/FieldAccess.php
+++ b/src/Aop/Intercept/FieldAccess.php
@@ -17,9 +17,21 @@ use ReflectionProperty;
 /**
  * This interface represents a field access in the program.
  *
- * A field access is a joinpoint and can be intercepted by a field interceptor.
+ * Detailed information about the intercepted field access can be obtained via {@see self::getField()} method which
+ * returns {@see ReflectionProperty} instance of relevant field.
+ *
+ * This interface is declared as generic, to get better code completion, specify concrete generic type for
+ * your parameter as `FieldAccess<SomeConcreteType>` in your aspects to make {@see self::getThis()} method
+ * returning proper type for instance `SomeConcreteType`. Same applied to the {@see self::getScope()} method -
+ * it will return proper type for instance `SomeConcreteType`.
+ *
+ * Interface overrides the return type of {@see ClassJoinpoint::getThis()} method and narrows its return type to
+ * the generic object for all field accesses, removing the nullability of the return type.
  *
  * @api
+ *
+ * @template T of object = object
+ * @extends ClassJoinpoint<T>
  */
 interface FieldAccess extends ClassJoinpoint
 {
@@ -50,4 +62,14 @@ interface FieldAccess extends ClassJoinpoint
      * @api
      */
     public function getAccessType(): FieldAccessType;
+
+    /**
+     * @phpstan-return T Covariant, always instance of object, can not be null
+     */
+    public function getThis(): object;
+
+    /**
+     * @return true Covariance, always true for class properties
+     */
+    public function isDynamic(): true;
 }

--- a/src/Aop/Intercept/MethodInvocation.php
+++ b/src/Aop/Intercept/MethodInvocation.php
@@ -17,12 +17,25 @@ use ReflectionMethod;
 /**
  * MethodInvocation interface represents an invocation of given method in the program.
  *
- * A method invocation is a joinpoint and can be intercepted by a method interceptor.
+ * Detailed information about the method can be obtained via {@see self::getMethod()} method which
+ * returns {@see ReflectionMethod} instance of relevant method.
  *
- * Interceptor can read or modify invocation arguments via {@see Invocation} interface or
- * receive full information about invoked method via {@see self::getMethod()} method.
+ * Interceptor can read or modify invocation arguments via {@see Invocation} interface:
+ *  - {@see Invocation::getArguments()} to read arguments
+ *  - {@see Invocation::setArguments()} to modify arguments
+ *
+ * This interface is declared as generic. To get better code type completion, specify concrete generic type for
+ * your parameter as `MethodInvocation<SomeConcreteType>` in your aspects to make {@see self::getThis()} method
+ * returning proper type for instance `SomeConcreteType`. Same applied to the {@see self::getScope()} method -
+ * it will return proper type for instance `SomeConcreteType`.
+ *
+ * If your pointcut targets only dynamic method calls, you can use {@see DynamicMethodInvocation} interface instead
+ * to give IDE and static analysis tools information about non-static context of the method call.
  *
  * @api
+ *
+ * @template T of object = object
+ * @extends ClassJoinpoint<T>
  */
 interface MethodInvocation extends Invocation, ClassJoinpoint
 {
@@ -36,7 +49,7 @@ interface MethodInvocation extends Invocation, ClassJoinpoint
     /**
      * Invokes current method invocation with all interceptors
      *
-     * @param object|class-string $instanceOrScope    Invocation instance (or class name for static methods)
+     * @phpstan-param T|class-string<T> $instanceOrScope Invocation instance (or class name for static methods)
      * @param list<mixed>         $arguments          List of arguments for method invocation
      * @param list<mixed>         $variadicArguments  Additional list of variadic arguments
      */

--- a/src/Aop/Intercept/MethodInvocation.php
+++ b/src/Aop/Intercept/MethodInvocation.php
@@ -26,7 +26,7 @@ use ReflectionMethod;
  *
  * This interface is declared as generic. To get better code type completion, specify concrete generic type for
  * your parameter as `MethodInvocation<SomeConcreteType>` in your aspects to make {@see self::getThis()} method
- * returning proper type for instance `SomeConcreteType`. Same applied to the {@see self::getScope()} method -
+ * returning proper type for instance `SomeConcreteType`. Same applies to the {@see self::getScope()} method -
  * it will return proper type for instance `SomeConcreteType`.
  *
  * If your pointcut targets only dynamic method calls, you can use {@see DynamicMethodInvocation} interface instead

--- a/src/Aop/Intercept/StaticMethodInvocation.php
+++ b/src/Aop/Intercept/StaticMethodInvocation.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+/*
+ * Go! AOP framework
+ *
+ * @copyright Copyright 2026, Lisachenko Alexander <lisachenko.it@gmail.com>
+ *
+ * This source file is subject to the license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Go\Aop\Intercept;
+
+/**
+ * Static method invocation extends MethodInvocation with type information about static method calls.
+ *
+ * @template T of object = object
+ * @extends MethodInvocation<T>
+ */
+interface StaticMethodInvocation extends MethodInvocation
+{
+    /**
+     * @phpstan-return null Covariance, always null for static method calls
+     */
+    public function getThis(): null;
+
+    /**
+     * @return false Covariance, always false for static method calls
+     */
+    public function isDynamic(): false;
+}

--- a/src/Aop/IntroductionInfo.php
+++ b/src/Aop/IntroductionInfo.php
@@ -15,7 +15,7 @@ namespace Go\Aop;
 /**
  * Interface supplying the information necessary to describe an introduction of trait.
  *
- * If an Advice implements this, it may be used as an introduction without an IntroductionAdvisor.
+ * If Advice implements this, it may be used as an introduction without an IntroductionAdvisor.
  * In this case, the advice is self-describing, providing not only the necessary behavior,
  * but describing the interfaces it introduces.
  */
@@ -23,11 +23,15 @@ interface IntroductionInfo extends Advice
 {
     /**
      * Returns the additional interface introduced by this Advisor or Advice.
+     *
+     * @return class-string
      */
     public function getInterface(): string;
 
     /**
      * Return the additional trait with realization of introduced interface
+     *
+     * @return trait-string
      */
     public function getTrait(): string;
 }

--- a/src/Core/AspectContainer.php
+++ b/src/Core/AspectContainer.php
@@ -95,8 +95,10 @@ interface AspectContainer
      *
      * @param string $key Given key
      *
-     * @return mixed
+     * @return ($key is class-string<T> ? T : mixed)
      * @throws OutOfBoundsException if key was not found
+     *
+     * @template T
      */
     public function getValue(string $key): mixed;
 
@@ -128,8 +130,10 @@ interface AspectContainer
     /**
      * Adds a lazy service in the container, uses lazy-initialization Closure to optimize init time
      *
-     * @param class-string $id Identifier of value to store, must be equal to the class-name
-     * @param Closure(AspectContainer $container): object $lazyInitializationClosure
+     * @param class-string<T> $id Identifier of value to store, must be equal to the class-name
+     * @param Closure(AspectContainer $container): T $lazyInitializationClosure
+     *
+     * @template T of object
      */
     public function addLazyService(string $id, Closure $lazyInitializationClosure): void;
 }

--- a/src/Core/AspectContainer.php
+++ b/src/Core/AspectContainer.php
@@ -95,10 +95,10 @@ interface AspectContainer
      *
      * @param string $key Given key
      *
-     * @return ($key is class-string<T> ? T : mixed)
+     * @return ($key is class-string<T> ? (T|Closure(AspectContainer):void) : mixed)
      * @throws OutOfBoundsException if key was not found
      *
-     * @template T
+     * @template T of object
      */
     public function getValue(string $key): mixed;
 

--- a/src/Core/AspectKernel.php
+++ b/src/Core/AspectKernel.php
@@ -236,7 +236,14 @@ abstract class AspectKernel
 
         $containerClass       = static::$containerClass;
         $containerClassOption = $merged['containerClass'] ?? null;
-        if (is_string($containerClassOption) && class_exists($containerClassOption) && is_a($containerClassOption, AspectContainer::class, true)) {
+        if (is_string($containerClassOption) && class_exists($containerClassOption)) {
+            if (!is_a($containerClassOption, AspectContainer::class, true)) {
+                throw new RuntimeException(sprintf(
+                    'Container class "%s" must extend %s.',
+                    $containerClassOption,
+                    AspectContainer::class
+                ));
+            }
             $containerClass = $containerClassOption;
         }
 

--- a/src/Core/AspectKernel.php
+++ b/src/Core/AspectKernel.php
@@ -39,7 +39,7 @@ use function define;
  *   features: int,
  *   includePaths: string[],
  *   excludePaths: string[],
- *   containerClass: class-string
+ *   containerClass: class-string<AspectContainer>
  * }
  */
 abstract class AspectKernel
@@ -67,7 +67,7 @@ abstract class AspectKernel
 
     /**
      * Default class name for container, can be redefined in children
-     * @var class-string
+     * @var class-string<AspectContainer>
      */
     protected static string $containerClass = Container::class;
 
@@ -82,7 +82,7 @@ abstract class AspectKernel
     protected AspectContainer $container;
 
     /**
-     * Protected constructor is used to prevent direct creation, but allows customization if needed
+     * Protected constructor is used to prevent direct creation of kernel
      */
     final protected function __construct() {}
 
@@ -110,7 +110,7 @@ abstract class AspectKernel
      *   features?: int,
      *   includePaths?: array{},
      *   excludePaths?: array{},
-     *   containerClass?: class-string
+     *   containerClass?: class-string<AspectContainer>
      * } $options Additional kernel options
      */
     public function init(array $options = []): void
@@ -236,7 +236,7 @@ abstract class AspectKernel
 
         $containerClass       = static::$containerClass;
         $containerClassOption = $merged['containerClass'] ?? null;
-        if (is_string($containerClassOption) && class_exists($containerClassOption)) {
+        if (is_string($containerClassOption) && class_exists($containerClassOption) && is_a($containerClassOption, AspectContainer::class, true)) {
             $containerClass = $containerClassOption;
         }
 

--- a/src/Core/Container.php
+++ b/src/Core/Container.php
@@ -115,7 +115,7 @@ class Container implements AspectContainer
     {
         $this->values[$id] = $value;
 
-        // For objects we would like to use interface names as tags, eg Pointcut, Advisor, Aspect, etc
+        // For objects, we would like to use interface names as tags, eg Pointcut, Advisor, Aspect, etc
         if (is_object($value)) {
             // If it is real object (not a lazy closure), then we use it directly
             if (!$value instanceof Closure) {

--- a/src/Core/IntroductionAspectExtension.php
+++ b/src/Core/IntroductionAspectExtension.php
@@ -79,7 +79,7 @@ class IntroductionAspectExtension extends AbstractAspectLoaderExtension
             $interceptorAttribute instanceof DeclareError =>
                 $this->createDeclareErrorAdvice($aspectProperty, $interceptorAttribute),
             $interceptorAttribute instanceof DeclareParents =>
-                new TraitIntroductionInfo($interceptorAttribute->trait, $interceptorAttribute->interface),
+                new TraitIntroductionInfo($interceptorAttribute->traitName, $interceptorAttribute->interfaceName),
             default =>
                 throw new UnexpectedValueException('Unsupported attribute class: ' . get_class($interceptorAttribute)),
         };

--- a/src/Lang/Attribute/DeclareParents.php
+++ b/src/Lang/Attribute/DeclareParents.php
@@ -21,8 +21,8 @@ use Attribute;
 class DeclareParents extends AbstractAttribute
 {
     /**
-     * @param trait-string $traitName     Default implementation (trait name)
      * @param class-string $interfaceName Interface name to add
+     * @param trait-string $traitName     Default implementation (trait name)
      */
     public function __construct(
         string                 $expression,

--- a/src/Lang/Attribute/DeclareParents.php
+++ b/src/Lang/Attribute/DeclareParents.php
@@ -21,14 +21,13 @@ use Attribute;
 class DeclareParents extends AbstractAttribute
 {
     /**
-     * @inheritdoc
-     * @param string $trait Default implementation (trait name)
-     * @param string $interface Interface name to add
+     * @param trait-string $traitName     Default implementation (trait name)
+     * @param class-string $interfaceName Interface name to add
      */
     public function __construct(
         string                 $expression,
-        readonly public string $interface,
-        readonly public string $trait,
+        readonly public string $interfaceName,
+        readonly public string $traitName,
         int                    $order = 0,
     )
     {

--- a/src/Proxy/Part/PropertyInterceptionTrait.php
+++ b/src/Proxy/Part/PropertyInterceptionTrait.php
@@ -21,6 +21,8 @@ use function method_exists;
 
 /**
  * Trait that holds all general logic for working with intercepted properties
+ *
+ * @template T of object
  */
 trait PropertyInterceptionTrait
 {
@@ -36,7 +38,7 @@ trait PropertyInterceptionTrait
     {
         if (array_key_exists($name, $this->__properties)) {
             // prop:* entries are ClassFieldAccess, not MethodInvocation — explicit cast required
-            /** @var ClassFieldAccess $fieldAccess */
+            /** @var ClassFieldAccess<T> $fieldAccess */
             $fieldAccess = self::$__joinPoints["prop:$name"];
             $fieldAccess->ensureScopeRule();
 
@@ -59,7 +61,7 @@ trait PropertyInterceptionTrait
     {
         if (array_key_exists($name, $this->__properties)) {
             // prop:* entries are ClassFieldAccess, not MethodInvocation — explicit cast required
-            /** @var ClassFieldAccess $fieldAccess */
+            /** @var ClassFieldAccess<T> $fieldAccess */
             $fieldAccess = self::$__joinPoints["prop:$name"];
             $fieldAccess->ensureScopeRule();
 


### PR DESCRIPTION
This PR improves static analysis and IDE support by introducing PHPStan generics across core AOP joinpoint/interception interfaces and updating framework/demo implementations to leverage the improved typing.

**Changes:**
- Add PHPStan generic templates to core joinpoint interfaces (eg. `ClassJoinpoint`, `MethodInvocation`, `FieldAccess`) and introduce specialized `DynamicMethodInvocation` / `StaticMethodInvocation` interfaces for non-null vs null `$this` contexts.
- Tighten typing across framework joinpoint implementations (method/field/constructor/static-init invocations) and update demos to show the new generic usage patterns.
- Refine container/kernel PHPDoc types (eg. `class-string<AspectContainer>`) and adjust runtime validation around `containerClass`.
