### PR TITLE
fix: Do not use closure binding for property interception

### DIFF
--- a/src/Aop/Framework/ClassFieldAccess.php
+++ b/src/Aop/Framework/ClassFieldAccess.php
@@ -68,11 +68,6 @@ final class ClassFieldAccess extends AbstractJoinpoint implements FieldAccess
     public function __construct(array $advices, string $className, string $fieldName)
     {
         parent::__construct($advices);
-        // We should bind our interceptor to the parent class where property is usually declared
-        $parentClass = get_parent_class($className);
-        if ($parentClass !== false && property_exists($parentClass, $fieldName)) {
-            $className = $parentClass;
-        }
         $this->reflectionProperty = new ReflectionProperty($className, $fieldName);
     }
 

--- a/src/Proxy/Part/InterceptedConstructorGenerator.php
+++ b/src/Proxy/Part/InterceptedConstructorGenerator.php
@@ -45,12 +45,6 @@ final class InterceptedConstructorGenerator
         bool $constructorIsInTrait = false
     ) {
         $constructorBody = count($interceptedProperties) > 0 ? $this->getConstructorBody($interceptedProperties) : '';
-        if ($constructor !== null && $constructor->isPrivate()) {
-            throw new LogicException(
-                "Constructor in the class {$constructor->class} is declared as private. " .
-                'Properties could not be intercepted.'
-            );
-        }
         if ($constructor !== null) {
             if ($constructorGenerator === null) {
                 $callArguments = new FunctionCallArgumentListGenerator($constructor);
@@ -119,19 +113,16 @@ final class InterceptedConstructorGenerator
         $assocProperties = [];
         $listProperties  = [];
         foreach ($interceptedProperties as $propertyName) {
-            $assocProperties[] = "        '{$propertyName}' => &\$target->{$propertyName}";
-            $listProperties[]  = "        \$target->{$propertyName}";
+            $assocProperties[] = "    '{$propertyName}' => &\$this->{$propertyName}";
+            $listProperties[]  = "    \$this->{$propertyName}";
         }
         $lines = [
-            '$accessor = function(array &$propertyStorage, object $target) {',
-            '    $propertyStorage = [',
+            '$this->__properties = [',
             implode(',' . PHP_EOL, $assocProperties),
-            '    ];',
-            '    unset(',
+            '];',
+            'unset(',
             implode(',' . PHP_EOL, $listProperties),
-            '    );',
-            '};',
-            '($accessor->bindTo($this, self::class))($this->__properties, $this);'
+            ');'
         ];
 
         return implode(PHP_EOL, $lines);

--- a/src/Proxy/Part/PropertyInterceptionTrait.php
+++ b/src/Proxy/Part/PropertyInterceptionTrait.php
@@ -43,7 +43,7 @@ trait PropertyInterceptionTrait
             $fieldAccess->ensureScopeRule();
 
             $value = &$fieldAccess->__invoke($this, FieldAccessType::READ, $this->__properties[$name]);
-        } elseif (method_exists(get_parent_class($this), __FUNCTION__)) {
+        } elseif (get_parent_class($this) !== false && method_exists(get_parent_class($this), '__get')) {
             $value = parent::__get($name);
         } else {
             trigger_error("Trying to access undeclared property {$name}");
@@ -71,7 +71,7 @@ trait PropertyInterceptionTrait
                 $this->__properties[$name],
                 $value
             );
-        } elseif (method_exists(get_parent_class($this), __FUNCTION__)) {
+        } elseif (get_parent_class($this) !== false && method_exists(get_parent_class($this), '__set')) {
             parent::__set($name, $value);
         } else {
             $this->$name = $value;

--- a/src/Proxy/Part/PropertyInterceptionTrait.php
+++ b/src/Proxy/Part/PropertyInterceptionTrait.php
@@ -43,7 +43,7 @@ trait PropertyInterceptionTrait
             $fieldAccess->ensureScopeRule();
 
             $value = &$fieldAccess->__invoke($this, FieldAccessType::READ, $this->__properties[$name]);
-        } elseif (get_parent_class($this) !== false && method_exists(get_parent_class($this), '__get')) {
+        } elseif (($parentClass = get_parent_class($this)) !== false && method_exists($parentClass, '__get')) {
             $value = parent::__get($name);
         } else {
             trigger_error("Trying to access undeclared property {$name}");
@@ -71,7 +71,7 @@ trait PropertyInterceptionTrait
                 $this->__properties[$name],
                 $value
             );
-        } elseif (get_parent_class($this) !== false && method_exists(get_parent_class($this), '__set')) {
+        } elseif (($parentClass = get_parent_class($this)) !== false && method_exists($parentClass, '__set')) {
             parent::__set($name, $value);
         } else {
             $this->$name = $value;

--- a/tests/Go/Proxy/ClassProxyGeneratorTest.php
+++ b/tests/Go/Proxy/ClassProxyGeneratorTest.php
@@ -97,16 +97,6 @@ class ClassProxyGeneratorTest extends TestCase
             'Proxy with property advices must use PropertyInterceptionTrait'
         );
         $this->assertStringContainsString(
-            'self::class',
-            $proxyFileContent,
-            'Property accessor closure must be bound with self::class scope (not parent::class)'
-        );
-        $this->assertStringNotContainsString(
-            'parent::class',
-            $proxyFileContent,
-            'Generated proxy must not reference parent::class — the new trait engine has no parent'
-        );
-        $this->assertStringContainsString(
             '__properties',
             $proxyFileContent,
             'Generated proxy must initialise $__properties via the accessor'

--- a/tests/Go/Proxy/Part/InterceptedConstructorGeneratorTest.php
+++ b/tests/Go/Proxy/Part/InterceptedConstructorGeneratorTest.php
@@ -93,11 +93,8 @@ class InterceptedConstructorGeneratorTest extends TestCase
             '
             public function __construct()
             {
-                $accessor = function (array &$propertyStorage, object $target) {
-                    $propertyStorage = [\'foo\' => &$target->foo, \'bar\' => &$target->bar];
-                    unset($target->foo, $target->bar);
-                };
-                $accessor->bindTo($this, self::class)($this->__properties, $this);
+                $this->__properties = [\'foo\' => &$this->foo, \'bar\' => &$this->bar];
+                unset($this->foo, $this->bar);
             }'
         );
         $this->assertSame($expectedCode, $generatedCode);
@@ -132,18 +129,22 @@ class InterceptedConstructorGeneratorTest extends TestCase
             $generatedCode,
             'When constructorIsInTrait=true, must NOT use parent::__construct'
         );
-        $this->assertStringContainsString(
-            'self::class',
+        $this->assertStringNotContainsString(
+            'bindTo',
             $generatedCode,
-            'Property accessor bindTo must use self::class scope, not parent::class'
+            'Property accessor must not use bindTo and closures at all'
         );
     }
 
-    public function testThrowsExceptionForPrivateConstructor(): void
+    public function testNotThrowsExceptionForPrivateConstructor(): void
     {
-        $this->expectException(\LogicException::class);
-
         $reflectionConstructor = (new ReflectionClass(ClassWithPrivateConstructor::class))->getConstructor();
-        new InterceptedConstructorGenerator(['foo', 'bar'], $reflectionConstructor);
+        $generator     = new InterceptedConstructorGenerator(['foo', 'bar'], $reflectionConstructor);
+        $generatedCode = $generator->generate();
+        $this->assertStringContainsString(
+            'private function __construct',
+            $generatedCode,
+            'When constructor is private, must not throw exception'
+        );
     }
 }


### PR DESCRIPTION
This PR updates the proxy/property interception implementation to remove reliance on `Closure::bindTo()` now that the trait-based proxy engine has direct access to members, and relaxes constructor interception so private constructors can be supported.

**Changes:**
- Remove closure binding from generated intercepted constructors and initialize `__properties` directly on `$this`.
- Stop rebinding `ClassFieldAccess` reflection to a parent class (so reflection targets the proxy/trait scope).
- Update property interception parent-fallback checks and adjust tests to match the new generation strategy (including private constructors).