### PR TITLE
feat: Create copilot-setup-steps.yml

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -1,0 +1,44 @@
+name: "Copilot Setup Steps"
+
+# Automatically run the setup steps when they are changed to allow for easy validation, and
+# allow manual testing through the repository's "Actions" tab
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - .github/workflows/copilot-setup-steps.yml
+  pull_request:
+    paths:
+      - .github/workflows/copilot-setup-steps.yml
+
+jobs:
+  # The job MUST be called `copilot-setup-steps` or it will not be picked up by Copilot.
+  copilot-setup-steps:
+    runs-on: ubuntu-latest
+
+    # Set the permissions to the lowest permissions possible needed for your steps.
+    # Copilot will be given its own token for its operations.
+    permissions:
+      # If you want to clone the repository as part of your setup steps, for example to install dependencies, you'll need the `contents: read` permission.
+      # If you don't clone the repository in your setup steps, Copilot will do this for you automatically after the steps complete.
+      contents: read
+
+    # You can define any steps you want, and they will run before the agent starts.
+    # If you do not check out your code, Copilot will do this for you.
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Setup PHP 8.4
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.4'
+          tools: composer:v2
+          coverage: none
+        env:
+          COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install Composer dependencies
+        run: composer install --no-interaction --no-progress --prefer-dist
+        env:
+          COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -27,7 +27,7 @@ jobs:
     # If you do not check out your code, Copilot will do this for you.
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v4
 
       - name: Setup PHP 8.4
         uses: shivammathur/setup-php@v2
@@ -35,6 +35,7 @@ jobs:
           php-version: '8.4'
           tools: composer:v2
           coverage: none
+          ini-values: memory_limit=-1
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -33,13 +33,10 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: '8.4'
+          github-token: ${{ secrets.GH_PAT_TOKEN }}
           tools: composer:v2
           coverage: none
           ini-values: memory_limit=-1
-        env:
-          COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
         run: composer install --no-interaction --no-progress --prefer-dist
-        env:
-          COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,6 +8,11 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Package: `goaop/framework` | Namespace root: `Go\` | PHP: `^8.4.0`
 
+## Agent runtime requirement
+
+- Agents must run on PHP **8.4 or higher**.
+- If the runtime is PHP **8.3.x**, stop immediately and report that test/phpstan validation cannot be performed in that environment.
+
 ## Commands
 
 ```bash


### PR DESCRIPTION
Adds a dedicated GitHub Actions workflow to provision PHP 8.4 + Composer dependencies for the Copilot agent so repository tests can run successfully under the required PHP version.

**Changes:**
- Introduces `.github/workflows/copilot-setup-steps.yml` with `copilot-setup-steps` job.
- Checks out the repo, installs PHP 8.4 via `shivammathur/setup-php`, and runs `composer install`.

More details is here: https://docs.github.com/en/enterprise-cloud@latest/copilot/how-tos/use-copilot-agents/cloud-agent/customize-the-agent-environment