### PR TITLE
feat: Add return type as second generic variable to core interfaces

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,13 +79,13 @@ class Foo extends OriginalParent implements OriginalInterfaces, \Go\Aop\Proxy
         // ... one alias per intercepted method (including private ones)
     }
 
-    public function interceptedMethod(...) {
-        /** @var \Go\Aop\Intercept\DynamicMethodInvocation<self>|null $__joinPoint */
+    public function interceptedMethod(ArgType $arg): ReturnType {
+        /** @var \Go\Aop\Intercept\DynamicMethodInvocation<self, ReturnType>|null $__joinPoint */
         static $__joinPoint;
         if ($__joinPoint === null) {
             $__joinPoint = \Go\Aop\Framework\InterceptorInjector::forMethod(self::class, 'interceptedMethod', [...]);
         }
-        return $__joinPoint->__invoke($this, [...]);
+        return $__joinPoint->__invoke($this, [$arg]);
     }
     // ... one override per intercepted method
 }
@@ -112,10 +112,17 @@ Key properties of this engine:
 - `src/Proxy/Generator/` — low-level AST generators:
   - `ClassGenerator` — builds the proxy class AST node; `addTraitAlias()` registers both the trait and an alias in a single `use { ... }` block; deduplicates traits
   - `AttributeGroupsGenerator` — copies PHP 8 attributes from reflection to proxy AST, preserving named arguments
+  - `TypeGenerator` — converts PHP types (string or `ReflectionType`) to AST nodes or phpDoc strings; `renderTypeForPhpDoc()` is used by all proxy generators to produce the second generic argument in `@var` annotations for `$__joinPoint`
 
 ### AOP core (`src/Aop/`)
 
 - `src/Aop/Intercept/` — interfaces: `Joinpoint`, `Invocation`, `MethodInvocation`, `ConstructorInvocation`, `FunctionInvocation`, `FieldAccess`
+  - **Generic template variables** — all callable join-point interfaces carry PHPStan generics to enable type-aware static analysis in aspect advice:
+    - `MethodInvocation<T of object, V = mixed>` — `T` is the class holding the method (narrows `getThis()`/`getScope()`); `V` is the method return type (narrows `__invoke()` return)
+    - `DynamicMethodInvocation<T, V>` and `StaticMethodInvocation<T, V>` — subtypes with covariant narrowing (`getThis()` always returns `T` / always `null` respectively)
+    - `FunctionInvocation<V = mixed>` — `V` is the function return type
+    - `FieldAccess<T of object, V = mixed>` — `T` is the declaring class; `V` is the property type (narrows `getValue()`, `getValueToSet()`, `__invoke()` return)
+  - The proxy generators (`ClassProxyGenerator`, `TraitProxyGenerator`, `EnumProxyGenerator`, `FunctionProxyGenerator`) use `TypeGenerator::renderTypeForPhpDoc()` to extract the return type from `ReflectionMethod`/`ReflectionFunction` and emit it as the second generic argument in the per-method `@var` annotation. This gives IDE and PHPStan full type-awareness on `$__joinPoint->__invoke(...)` calls.
 - `src/Aop/Framework/` — concrete invocation implementations:
   - `AbstractMethodInvocation` — base class; holds `protected Closure $closureToCall` (set in each subclass constructor via `Closure::bind`); `TRAIT_ALIAS_PREFIX = '__aop__'` constant; manages recursive/cross-call stack frames
   - `DynamicTraitAliasMethodInvocation` — instance-method invocation; builds `Closure::bind(fn($i, $a) => $i->__aop__method(...$a), null, $class)` once at construction; `proceed()` calls `($this->closureToCall)($this->instance, $this->arguments)`

--- a/src/Aop/Framework/AbstractMethodInvocation.php
+++ b/src/Aop/Framework/AbstractMethodInvocation.php
@@ -25,8 +25,9 @@ use function count;
  *
  * @phpstan-type MethodInvocationFrame array{list<mixed>, mixed, int}
  *
- * @template T of object = object
- * @implements MethodInvocation<T>
+ * @template T of object Declares the instance type of the method invocation.
+ * @template V Declares the generic return type of the method invocation.
+ * @implements MethodInvocation<T, V>
  */
 abstract class AbstractMethodInvocation extends AbstractInvocation implements MethodInvocation
 {

--- a/src/Aop/Framework/DynamicTraitAliasMethodInvocation.php
+++ b/src/Aop/Framework/DynamicTraitAliasMethodInvocation.php
@@ -17,13 +17,14 @@ use ReflectionMethod;
 
 /**
  * Dynamic trait-alias method invocation calls instance methods via a pre-bound Closure::bind closure
- * targeting the private __aop__<method> alias created in the proxy's trait-use block.
+ * targeting the private `__aop__<method>` alias created in the proxy's trait-use block.
  *
  * The closure is built once at construction time so that every invocation needs zero reflection.
  *
- * @template T of object
- * @extends AbstractMethodInvocation<T>
- * @implements DynamicMethodInvocation<T>
+ * @template T of object = object Declares the instance type of the method invocation.
+ * @template V = mixed Declares the generic return type of the method invocation.
+ * @extends AbstractMethodInvocation<T, V>
+ * @implements DynamicMethodInvocation<T, V>
  */
 final class DynamicTraitAliasMethodInvocation extends AbstractMethodInvocation implements DynamicMethodInvocation
 {
@@ -68,7 +69,7 @@ final class DynamicTraitAliasMethodInvocation extends AbstractMethodInvocation i
     }
 
     /**
-     * @return mixed Covariant, always mixed
+     * @return V Covariant, always mixed
      */
     public function proceed(): mixed
     {

--- a/src/Aop/Framework/ReflectionFunctionInvocation.php
+++ b/src/Aop/Framework/ReflectionFunctionInvocation.php
@@ -20,6 +20,9 @@ use function array_pop;
 
 /**
  * Function invocation implementation
+ *
+ * @template V = mixed Declares the generic return type of the result.
+ * @implements FunctionInvocation<V>
  */
 final class ReflectionFunctionInvocation extends AbstractInvocation implements FunctionInvocation
 {
@@ -49,8 +52,7 @@ final class ReflectionFunctionInvocation extends AbstractInvocation implements F
     }
 
     /**
-     * @inheritdoc
-     * @return mixed Covariant, always mixed
+     * @return V Covariant, always mixed
      */
     public function proceed(): mixed
     {
@@ -73,6 +75,8 @@ final class ReflectionFunctionInvocation extends AbstractInvocation implements F
      *
      * @param list<mixed> $arguments         List of arguments for function invocation
      * @param list<mixed> $variadicArguments Additional list of variadic arguments
+     *
+     * @return V Templated return type (mixed by default)
      */
     final public function __invoke(array $arguments = [], array $variadicArguments = []): mixed
     {

--- a/src/Aop/Framework/StaticTraitAliasMethodInvocation.php
+++ b/src/Aop/Framework/StaticTraitAliasMethodInvocation.php
@@ -17,13 +17,14 @@ use Go\Aop\Intercept\StaticMethodInvocation;
 
 /**
  * Static trait-alias method invocation calls static methods via a pre-bound Closure::bind closure
- * targeting the private __aop__<method> alias created in the proxy's trait-use block.
+ * targeting the private `__aop__<method>` alias created in the proxy's trait-use block.
  *
  * The closure is built once at construction time so that every invocation needs zero reflection.
  *
- * @template T of object = object
- * @extends AbstractMethodInvocation<T>
- * @implements StaticMethodInvocation<T>
+ * @template T of object = object Declares the instance type of the method invocation.
+ * @template V = mixed Declares the generic return type of the method invocation.
+ * @extends AbstractMethodInvocation<T, V>
+ * @implements StaticMethodInvocation<T, V>
  */
 final class StaticTraitAliasMethodInvocation extends AbstractMethodInvocation implements StaticMethodInvocation
 {
@@ -67,7 +68,7 @@ final class StaticTraitAliasMethodInvocation extends AbstractMethodInvocation im
     }
 
     /**
-     * @return mixed Covariant, always mixed
+     * @return V Covariant, always mixed
      */
     public function proceed(): mixed
     {

--- a/src/Aop/Intercept/DynamicMethodInvocation.php
+++ b/src/Aop/Intercept/DynamicMethodInvocation.php
@@ -24,8 +24,11 @@ namespace Go\Aop\Intercept;
  * Without this interface, aspect advice should use the null-safe operator `$invocation->getThis()?->method()` to avoid
  * type errors.
  *
- * @template T of object = object
- * @extends MethodInvocation<T>
+ * @api
+ *
+ * @template T of object = object Declares the instance type of the method invocation.
+ * @template V = mixed Declares the generic return type of the method invocation.
+ * @extends MethodInvocation<T, V>
  *
  * @link https://wiki.php.net/rfc/nullsafe_operator
  */

--- a/src/Aop/Intercept/FieldAccess.php
+++ b/src/Aop/Intercept/FieldAccess.php
@@ -45,7 +45,7 @@ use ReflectionProperty;
  * @api
  *
  * @template T of object = object Declares the class, which holds the property(field)
- * @template V of mixed = mixed Declares the type of property
+ * @template V = mixed Declares the type of property
  * @extends ClassJoinpoint<T>
  */
 interface FieldAccess extends ClassJoinpoint

--- a/src/Aop/Intercept/FunctionInvocation.php
+++ b/src/Aop/Intercept/FunctionInvocation.php
@@ -18,6 +18,10 @@ use ReflectionFunction;
  * Description of an invocation to a function, given to an interceptor upon function-call.
  *
  * A function invocation is a joinpoint and can be intercepted by a function interceptor.
+ *
+ * @api
+ *`
+ * @template V = mixed Declares the generic return type of the result.
  */
 interface FunctionInvocation extends Invocation
 {
@@ -31,6 +35,8 @@ interface FunctionInvocation extends Invocation
      *
      * @param list<mixed> $arguments         List of arguments for function invocation
      * @param list<mixed> $variadicArguments Additional list of variadic arguments
+     *
+     * @phpstan-return V Templated return type (mixed by default)
      */
     public function __invoke(array $arguments = [], array $variadicArguments = []): mixed;
 }

--- a/src/Aop/Intercept/MethodInvocation.php
+++ b/src/Aop/Intercept/MethodInvocation.php
@@ -29,12 +29,16 @@ use ReflectionMethod;
  * returning proper type for instance `SomeConcreteType`. Same applies to the {@see self::getScope()} method -
  * it will return proper type for instance `SomeConcreteType`.
  *
+ * Second generic variable `<V>` declares the generic return type of the method invocation. Specify it to have better
+ * code type completion and validation of return types. Take original method return type and put it here.
+ *
  * If your pointcut targets only dynamic method calls, you can use {@see DynamicMethodInvocation} interface instead
  * to give IDE and static analysis tools information about non-static context of the method call.
  *
  * @api
  *
- * @template T of object = object
+ * @template T of object = object Declares the instance type of the method invocation.
+ * @template V = mixed Declares the generic return type of the method invocation.
  * @extends ClassJoinpoint<T>
  */
 interface MethodInvocation extends Invocation, ClassJoinpoint
@@ -52,6 +56,8 @@ interface MethodInvocation extends Invocation, ClassJoinpoint
      * @phpstan-param T|class-string<T> $instanceOrScope Invocation instance (or class name for static methods)
      * @param list<mixed>         $arguments          List of arguments for method invocation
      * @param list<mixed>         $variadicArguments  Additional list of variadic arguments
+     *
+     * @return V Templated return type (mixed by default)
      */
     public function __invoke(object|string $instanceOrScope, array $arguments = [], array $variadicArguments = []): mixed;
 }

--- a/src/Aop/Intercept/StaticMethodInvocation.php
+++ b/src/Aop/Intercept/StaticMethodInvocation.php
@@ -15,8 +15,11 @@ namespace Go\Aop\Intercept;
 /**
  * Static method invocation extends MethodInvocation with type information about static method calls.
  *
- * @template T of object = object
- * @extends MethodInvocation<T>
+ * @api
+ *
+ * @template T of object = object Declares the instance type of the method invocation.
+ * @template V = mixed Declares the generic return type of the method invocation.
+ * @extends MethodInvocation<T, V>
  */
 interface StaticMethodInvocation extends MethodInvocation
 {

--- a/src/Proxy/ClassProxyGenerator.php
+++ b/src/Proxy/ClassProxyGenerator.php
@@ -28,6 +28,7 @@ use Go\Proxy\Generator\ValueGenerator;
 use Go\Proxy\Part\FunctionCallArgumentListGenerator;
 use Go\Proxy\Part\InterceptedMethodGenerator;
 use Go\Proxy\Part\InterceptedPropertyGenerator;
+use PhpParser\Node\Stmt\ClassMethod;
 use ReflectionClass;
 use ReflectionMethod;
 use ReflectionNamedType;
@@ -283,6 +284,15 @@ class ClassProxyGenerator
         $advicesArrayValue->setArrayDepth(1);
         $advicesCode = $advicesArrayValue->generate();
         $returnTypeString   = $method->hasReturnType() ? ', ' . TypeGenerator::renderTypeForPhpDoc($method->getReturnType()) : '';
+        // On PHP 8.5+, ReflectionNamedType::getName() resolves 'self'/'parent' to the actual FQCN.
+        // Use the raw AST return-type node when available (goaop/parser-reflection) to preserve keywords.
+        if ($method->hasReturnType() && method_exists($method, 'getNode')) {
+            $node = $method->getNode();
+            if ($node instanceof ClassMethod) {
+                $astReturnType = $node->getReturnType();
+                $returnTypeString = $astReturnType !== null ? ', ' . TypeGenerator::renderAstTypeForPhpDoc($astReturnType) : '';
+            }
+        }
         $joinPointType = $isStatic
             ? '\\Go\\Aop\\Intercept\\StaticMethodInvocation<self' . $returnTypeString . '>|null'
             : '\\Go\\Aop\\Intercept\\DynamicMethodInvocation<self' . $returnTypeString . '>|null';

--- a/src/Proxy/ClassProxyGenerator.php
+++ b/src/Proxy/ClassProxyGenerator.php
@@ -282,9 +282,10 @@ class ClassProxyGenerator
         $advicesArrayValue = new ValueGenerator($adviceNames);
         $advicesArrayValue->setArrayDepth(1);
         $advicesCode = $advicesArrayValue->generate();
+        $returnTypeString   = $method->hasReturnType() ? ', ' . TypeGenerator::renderTypeForPhpDoc($method->getReturnType()) : '';
         $joinPointType = $isStatic
-            ? '\\Go\\Aop\\Intercept\\StaticMethodInvocation<self>|null'
-            : '\\Go\\Aop\\Intercept\\DynamicMethodInvocation<self>|null';
+            ? '\\Go\\Aop\\Intercept\\StaticMethodInvocation<self' . $returnTypeString . '>|null'
+            : '\\Go\\Aop\\Intercept\\DynamicMethodInvocation<self' . $returnTypeString . '>|null';
 
         $body = <<<BODY
         /** @var {$joinPointType} \$__joinPoint */

--- a/src/Proxy/EnumProxyGenerator.php
+++ b/src/Proxy/EnumProxyGenerator.php
@@ -16,6 +16,7 @@ use Go\Aop\Framework\AbstractMethodInvocation;
 use Go\Aop\Proxy;
 use Go\Core\AspectContainer;
 use Go\Proxy\Generator\EnumGenerator;
+use Go\Proxy\Generator\TypeGenerator;
 use Go\Proxy\Generator\ValueGenerator;
 use Go\Proxy\Part\FunctionCallArgumentListGenerator;
 use PhpParser\Node\Scalar\Int_;
@@ -206,9 +207,10 @@ class EnumProxyGenerator extends ClassProxyGenerator
         $advicesArrayValue = new ValueGenerator($adviceNames);
         $advicesArrayValue->setArrayDepth(1);
         $advicesCode = $advicesArrayValue->generate();
+        $returnTypeString = $method->hasReturnType() ? ', ' . TypeGenerator::renderTypeForPhpDoc($method->getReturnType()) : '';
         $joinPointType = $isStatic
-            ? '\\Go\\Aop\\Intercept\\StaticMethodInvocation<self>|null'
-            : '\\Go\\Aop\\Intercept\\DynamicMethodInvocation<self>|null';
+            ? '\\Go\\Aop\\Intercept\\StaticMethodInvocation<self' . $returnTypeString . '>|null'
+            : '\\Go\\Aop\\Intercept\\DynamicMethodInvocation<self' . $returnTypeString . '>|null';
 
         return <<<BODY
         /** @var {$joinPointType} \$__joinPoint */

--- a/src/Proxy/EnumProxyGenerator.php
+++ b/src/Proxy/EnumProxyGenerator.php
@@ -21,6 +21,7 @@ use Go\Proxy\Generator\ValueGenerator;
 use Go\Proxy\Part\FunctionCallArgumentListGenerator;
 use PhpParser\Node\Scalar\Int_;
 use PhpParser\Node\Scalar\String_;
+use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\EnumCase;
 use PhpParser\Node\Stmt\Enum_ as EnumNode;
 use ReflectionClass;
@@ -208,6 +209,15 @@ class EnumProxyGenerator extends ClassProxyGenerator
         $advicesArrayValue->setArrayDepth(1);
         $advicesCode = $advicesArrayValue->generate();
         $returnTypeString = $method->hasReturnType() ? ', ' . TypeGenerator::renderTypeForPhpDoc($method->getReturnType()) : '';
+        // On PHP 8.5+, ReflectionNamedType::getName() resolves 'self'/'parent' to the actual FQCN.
+        // Use the raw AST return-type node when available (goaop/parser-reflection) to preserve keywords.
+        if ($method->hasReturnType() && method_exists($method, 'getNode')) {
+            $node = $method->getNode();
+            if ($node instanceof ClassMethod) {
+                $astReturnType = $node->getReturnType();
+                $returnTypeString = $astReturnType !== null ? ', ' . TypeGenerator::renderAstTypeForPhpDoc($astReturnType) : '';
+            }
+        }
         $joinPointType = $isStatic
             ? '\\Go\\Aop\\Intercept\\StaticMethodInvocation<self' . $returnTypeString . '>|null'
             : '\\Go\\Aop\\Intercept\\DynamicMethodInvocation<self' . $returnTypeString . '>|null';

--- a/src/Proxy/FunctionProxyGenerator.php
+++ b/src/Proxy/FunctionProxyGenerator.php
@@ -16,6 +16,7 @@ use Go\Core\AspectContainer;
 use Go\ParserReflection\ReflectionFileNamespace;
 use Go\Proxy\Generator\FileGenerator;
 use Go\Proxy\Generator\FunctionGenerator;
+use Go\Proxy\Generator\TypeGenerator;
 use Go\Proxy\Generator\ValueGenerator;
 use Go\Proxy\Part\FunctionCallArgumentListGenerator;
 use ReflectionException;
@@ -99,9 +100,10 @@ class FunctionProxyGenerator
         $advicesArray    = new ValueGenerator($functionAdvices);
         $advicesArray->setArrayDepth(1);
         $advicesCode = $advicesArray->generate();
+        $returnTypeString = $function->hasReturnType() ? '<' . TypeGenerator::renderTypeForPhpDoc($function->getReturnType()) . '>' : '';
 
         return <<<BODY
-        /** @var \\Go\\Aop\\Intercept\\FunctionInvocation|null \$__joinPoint */
+        /** @var \\Go\\Aop\\Intercept\\FunctionInvocation{$returnTypeString}|null \$__joinPoint */
         static \$__joinPoint;
         if (\$__joinPoint === null) {
             \$__joinPoint = \\Go\\Aop\\Framework\\InterceptorInjector::forFunction('{$function->name}', {$advicesCode});

--- a/src/Proxy/Generator/TypeGenerator.php
+++ b/src/Proxy/Generator/TypeGenerator.php
@@ -119,6 +119,47 @@ final class TypeGenerator
         return $type->getName();
     }
 
+    /**
+     * Renders a ReflectionType as a phpDoc type string suitable for use in @var or @template annotations.
+     *
+     * - Builtin types and keywords (self, static, parent) are returned as-is.
+     * - Class types are prefixed with a leading backslash (FQCN).
+     * - Nullable types are rendered as `?Type` (only for simple named types, not for union with null).
+     * - Union types are rendered as `Type1|Type2`.
+     * - Intersection types are rendered as `Type1&Type2`.
+     * - A null $type renders as `mixed`.
+     */
+    public static function renderTypeForPhpDoc(?ReflectionType $type): string
+    {
+        if ($type === null) {
+            return 'mixed';
+        }
+
+        if ($type instanceof ReflectionNamedType) {
+            $name = self::resolveReflectionNamedTypeName($type);
+
+            if (!$type->isBuiltin() && !in_array($name, ['self', 'static', 'parent'], true)) {
+                $name = str_starts_with($name, '\\') ? $name : '\\' . $name;
+            }
+
+            if ($type->allowsNull() && $name !== 'mixed' && $name !== 'null') {
+                return '?' . $name;
+            }
+
+            return $name;
+        }
+
+        if ($type instanceof ReflectionUnionType) {
+            return implode('|', array_map(self::renderTypeForPhpDoc(...), $type->getTypes()));
+        }
+
+        if ($type instanceof ReflectionIntersectionType) {
+            return implode('&', array_map(self::renderTypeForPhpDoc(...), $type->getTypes()));
+        }
+
+        return 'mixed';
+    }
+
     private static function buildNodeFromReflection(ReflectionType $type): Identifier|Name|NullableType|UnionType|IntersectionType
     {
         if ($type instanceof ReflectionNamedType) {

--- a/src/Proxy/Generator/TypeGenerator.php
+++ b/src/Proxy/Generator/TypeGenerator.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace Go\Proxy\Generator;
 
 use InvalidArgumentException;
+use PhpParser\Node\ComplexType;
 use PhpParser\Node\Identifier;
 use PhpParser\Node\IntersectionType;
 use PhpParser\Node\Name;
@@ -117,6 +118,66 @@ final class TypeGenerator
         }
 
         return $type->getName();
+    }
+
+    /**
+     * Renders a PhpParser AST type node as a phpDoc type string.
+     *
+     * Use this instead of renderTypeForPhpDoc() whenever the raw AST node is available
+     * (e.g. via ReflectionMethod::getNode()->getReturnType()). This avoids the PHP 8.5+
+     * behaviour where ReflectionNamedType::getName() resolves 'self'/'parent' to the
+     * actual FQCN, and instead preserves the type exactly as declared in the source.
+     *
+     * The `ComplexType` parameter covers NullableType, UnionType, and IntersectionType —
+     * the three composite type node classes that PhpParser's ClassMethod/Property AST nodes
+     * report via their `returnType`/`type` properties.
+     *
+     * - Identifier nodes (int, string, void, etc.) are returned as-is.
+     * - Keyword Name nodes (self, parent, static) are returned as-is.
+     * - Other Name nodes are rendered as FQCN with a leading backslash, using the
+     *   'resolvedName' attribute set by PhpParser's NameResolver when available.
+     * - NullableType: `?InnerType`.
+     * - UnionType / IntersectionType: members joined with `|` / `&`.
+     * - null input returns `mixed`.
+     */
+    public static function renderAstTypeForPhpDoc(
+        Identifier|Name|ComplexType|null $node
+    ): string {
+        if ($node === null) {
+            return 'mixed';
+        }
+
+        if ($node instanceof Identifier) {
+            return $node->name;
+        }
+
+        if ($node instanceof Name) {
+            $name = $node->toString();
+            // Keyword types are preserved as-is (never resolved to FQCN)
+            if (in_array($name, ['self', 'parent', 'static'], true)) {
+                return $name;
+            }
+            // Use the resolved FQCN added by NameResolver when available
+            if ($node->hasAttribute('resolvedName') && ($resolved = $node->getAttribute('resolvedName')) instanceof Name) {
+                $name = $resolved->toString();
+            }
+
+            return '\\' . ltrim($name, '\\');
+        }
+
+        if ($node instanceof NullableType) {
+            return '?' . self::renderAstTypeForPhpDoc($node->type);
+        }
+
+        if ($node instanceof UnionType) {
+            return implode('|', array_map(self::renderAstTypeForPhpDoc(...), $node->types));
+        }
+
+        if ($node instanceof IntersectionType) {
+            return implode('&', array_map(self::renderAstTypeForPhpDoc(...), $node->types));
+        }
+
+        return 'mixed';
     }
 
     /**

--- a/src/Proxy/Part/AbstractInterceptedPropertyGenerator.php
+++ b/src/Proxy/Part/AbstractInterceptedPropertyGenerator.php
@@ -18,6 +18,8 @@ use Go\Proxy\Generator\PropertyNodeProvider;
 use Go\Proxy\Generator\TypeGenerator;
 use InvalidArgumentException;
 use PhpParser\Comment\Doc;
+use PhpParser\Node\Param;
+use PhpParser\Node\Stmt\Property;
 use ReflectionIntersectionType;
 use ReflectionNamedType;
 use ReflectionProperty;
@@ -86,6 +88,16 @@ abstract class AbstractInterceptedPropertyGenerator implements PropertyNodeProvi
 
     private function getPropertyTypeForPhpDoc(): string
     {
+        // Use the raw AST type node when available (goaop/parser-reflection) to preserve keyword
+        // types like 'self' and 'parent' as declared — bypassing PHP 8.5+ FQCN resolution.
+        if (method_exists($this->property, 'getTypeNode')) {
+            $typeNode = $this->property->getTypeNode();
+            // getTypeNode() returns Property for regular properties or Param for constructor-promoted ones.
+            if ($typeNode instanceof Property || $typeNode instanceof Param) {
+                return TypeGenerator::renderAstTypeForPhpDoc($typeNode->type);
+            }
+        }
+
         return $this->renderTypeForPhpDoc($this->property->getType());
     }
 

--- a/src/Proxy/TraitProxyGenerator.php
+++ b/src/Proxy/TraitProxyGenerator.php
@@ -20,6 +20,7 @@ use Go\Proxy\Generator\TypeGenerator;
 use Go\Proxy\Generator\ValueGenerator;
 use Go\Proxy\Part\FunctionCallArgumentListGenerator;
 use Go\Proxy\Part\TraitInterceptedPropertyGenerator;
+use PhpParser\Node\Stmt\ClassMethod;
 use ReflectionClass;
 use ReflectionMethod;
 use ReflectionNamedType;
@@ -114,6 +115,15 @@ class TraitProxyGenerator extends ClassProxyGenerator
         $advicesArrayValue->setArrayDepth(1);
         $advicesCode = $advicesArrayValue->generate();
         $returnTypeString = $method->hasReturnType() ? ', ' . TypeGenerator::renderTypeForPhpDoc($method->getReturnType()) : '';
+        // On PHP 8.5+, ReflectionNamedType::getName() resolves 'self'/'parent' to the actual FQCN.
+        // Use the raw AST return-type node when available (goaop/parser-reflection) to preserve keywords.
+        if ($method->hasReturnType() && method_exists($method, 'getNode')) {
+            $node = $method->getNode();
+            if ($node instanceof ClassMethod) {
+                $astReturnType = $node->getReturnType();
+                $returnTypeString = $astReturnType !== null ? ', ' . TypeGenerator::renderAstTypeForPhpDoc($astReturnType) : '';
+            }
+        }
         $joinPointType = $isStatic
             ? '\\Go\\Aop\\Intercept\\StaticMethodInvocation<self' . $returnTypeString . '>|null'
             : '\\Go\\Aop\\Intercept\\DynamicMethodInvocation<self' . $returnTypeString . '>|null';

--- a/src/Proxy/TraitProxyGenerator.php
+++ b/src/Proxy/TraitProxyGenerator.php
@@ -16,6 +16,7 @@ use Go\Aop\Framework\AbstractMethodInvocation;
 use Go\Core\AspectContainer;
 use Go\Proxy\Generator\DocBlockGenerator;
 use Go\Proxy\Generator\TraitGenerator;
+use Go\Proxy\Generator\TypeGenerator;
 use Go\Proxy\Generator\ValueGenerator;
 use Go\Proxy\Part\FunctionCallArgumentListGenerator;
 use Go\Proxy\Part\TraitInterceptedPropertyGenerator;
@@ -112,9 +113,10 @@ class TraitProxyGenerator extends ClassProxyGenerator
         $advicesArrayValue = new ValueGenerator($adviceNames);
         $advicesArrayValue->setArrayDepth(1);
         $advicesCode = $advicesArrayValue->generate();
+        $returnTypeString = $method->hasReturnType() ? ', ' . TypeGenerator::renderTypeForPhpDoc($method->getReturnType()) : '';
         $joinPointType = $isStatic
-            ? '\\Go\\Aop\\Intercept\\StaticMethodInvocation<self>|null'
-            : '\\Go\\Aop\\Intercept\\DynamicMethodInvocation<self>|null';
+            ? '\\Go\\Aop\\Intercept\\StaticMethodInvocation<self' . $returnTypeString . '>|null'
+            : '\\Go\\Aop\\Intercept\\DynamicMethodInvocation<self' . $returnTypeString . '>|null';
 
         return <<<BODY
         /** @var {$joinPointType} \$__joinPoint */

--- a/tests/Instrument/Transformer/_files/final-readonly-class-proxy.php
+++ b/tests/Instrument/Transformer/_files/final-readonly-class-proxy.php
@@ -10,7 +10,7 @@ final readonly class TestReadonlyClass implements \Go\Aop\Proxy
     }
     public function publicMethod(): string
     {
-        /** @var \Go\Aop\Intercept\DynamicMethodInvocation<self>|null $__joinPoint */
+        /** @var \Go\Aop\Intercept\DynamicMethodInvocation<self, string>|null $__joinPoint */
         static $__joinPoint;
         if ($__joinPoint === null) {
             $__joinPoint = \Go\Aop\Framework\InterceptorInjector::forMethod(self::class, 'publicMethod', ['advisor.Test\ns1\TestReadonlyClass->publicMethod']);
@@ -19,7 +19,7 @@ final readonly class TestReadonlyClass implements \Go\Aop\Proxy
     }
     public function anotherMethod(int $x): int
     {
-        /** @var \Go\Aop\Intercept\DynamicMethodInvocation<self>|null $__joinPoint */
+        /** @var \Go\Aop\Intercept\DynamicMethodInvocation<self, int>|null $__joinPoint */
         static $__joinPoint;
         if ($__joinPoint === null) {
             $__joinPoint = \Go\Aop\Framework\InterceptorInjector::forMethod(self::class, 'anotherMethod', ['advisor.Test\ns1\TestReadonlyClass->anotherMethod']);
@@ -28,7 +28,7 @@ final readonly class TestReadonlyClass implements \Go\Aop\Proxy
     }
     public static function staticMethod(): string
     {
-        /** @var \Go\Aop\Intercept\StaticMethodInvocation<self>|null $__joinPoint */
+        /** @var \Go\Aop\Intercept\StaticMethodInvocation<self, string>|null $__joinPoint */
         static $__joinPoint;
         if ($__joinPoint === null) {
             $__joinPoint = \Go\Aop\Framework\InterceptorInjector::forStaticMethod(self::class, 'staticMethod', ['advisor.Test\ns1\TestReadonlyClass->staticMethod']);

--- a/tests/Instrument/Transformer/_files/php7-class-proxy.php
+++ b/tests/Instrument/Transformer/_files/php7-class-proxy.php
@@ -96,7 +96,7 @@ class TestPhp7Class implements \Go\Aop\Proxy
     }
     public function stringRth(string $arg): string
     {
-        /** @var \Go\Aop\Intercept\DynamicMethodInvocation<self>|null $__joinPoint */
+        /** @var \Go\Aop\Intercept\DynamicMethodInvocation<self, string>|null $__joinPoint */
         static $__joinPoint;
         if ($__joinPoint === null) {
             $__joinPoint = \Go\Aop\Framework\InterceptorInjector::forMethod(self::class, 'stringRth', ['advisor.Test\ns1\TestPhp7Class->stringRth']);
@@ -105,7 +105,7 @@ class TestPhp7Class implements \Go\Aop\Proxy
     }
     public function floatRth(float $arg): float
     {
-        /** @var \Go\Aop\Intercept\DynamicMethodInvocation<self>|null $__joinPoint */
+        /** @var \Go\Aop\Intercept\DynamicMethodInvocation<self, float>|null $__joinPoint */
         static $__joinPoint;
         if ($__joinPoint === null) {
             $__joinPoint = \Go\Aop\Framework\InterceptorInjector::forMethod(self::class, 'floatRth', ['advisor.Test\ns1\TestPhp7Class->floatRth']);
@@ -114,7 +114,7 @@ class TestPhp7Class implements \Go\Aop\Proxy
     }
     public function boolRth(bool $arg): bool
     {
-        /** @var \Go\Aop\Intercept\DynamicMethodInvocation<self>|null $__joinPoint */
+        /** @var \Go\Aop\Intercept\DynamicMethodInvocation<self, bool>|null $__joinPoint */
         static $__joinPoint;
         if ($__joinPoint === null) {
             $__joinPoint = \Go\Aop\Framework\InterceptorInjector::forMethod(self::class, 'boolRth', ['advisor.Test\ns1\TestPhp7Class->boolRth']);
@@ -123,7 +123,7 @@ class TestPhp7Class implements \Go\Aop\Proxy
     }
     public function intRth(int $arg): int
     {
-        /** @var \Go\Aop\Intercept\DynamicMethodInvocation<self>|null $__joinPoint */
+        /** @var \Go\Aop\Intercept\DynamicMethodInvocation<self, int>|null $__joinPoint */
         static $__joinPoint;
         if ($__joinPoint === null) {
             $__joinPoint = \Go\Aop\Framework\InterceptorInjector::forMethod(self::class, 'intRth', ['advisor.Test\ns1\TestPhp7Class->intRth']);
@@ -132,7 +132,7 @@ class TestPhp7Class implements \Go\Aop\Proxy
     }
     public function callableRth(callable $arg): callable
     {
-        /** @var \Go\Aop\Intercept\DynamicMethodInvocation<self>|null $__joinPoint */
+        /** @var \Go\Aop\Intercept\DynamicMethodInvocation<self, callable>|null $__joinPoint */
         static $__joinPoint;
         if ($__joinPoint === null) {
             $__joinPoint = \Go\Aop\Framework\InterceptorInjector::forMethod(self::class, 'callableRth', ['advisor.Test\ns1\TestPhp7Class->callableRth']);
@@ -141,7 +141,7 @@ class TestPhp7Class implements \Go\Aop\Proxy
     }
     public function arrayRth(array $arg): array
     {
-        /** @var \Go\Aop\Intercept\DynamicMethodInvocation<self>|null $__joinPoint */
+        /** @var \Go\Aop\Intercept\DynamicMethodInvocation<self, array>|null $__joinPoint */
         static $__joinPoint;
         if ($__joinPoint === null) {
             $__joinPoint = \Go\Aop\Framework\InterceptorInjector::forMethod(self::class, 'arrayRth', ['advisor.Test\ns1\TestPhp7Class->arrayRth']);
@@ -150,7 +150,7 @@ class TestPhp7Class implements \Go\Aop\Proxy
     }
     public function exceptionRth(\Exception $exception): \Exception
     {
-        /** @var \Go\Aop\Intercept\DynamicMethodInvocation<self>|null $__joinPoint */
+        /** @var \Go\Aop\Intercept\DynamicMethodInvocation<self, \Exception>|null $__joinPoint */
         static $__joinPoint;
         if ($__joinPoint === null) {
             $__joinPoint = \Go\Aop\Framework\InterceptorInjector::forMethod(self::class, 'exceptionRth', ['advisor.Test\ns1\TestPhp7Class->exceptionRth']);
@@ -168,7 +168,7 @@ class TestPhp7Class implements \Go\Aop\Proxy
     }
     public function returnSelf(): self
     {
-        /** @var \Go\Aop\Intercept\DynamicMethodInvocation<self>|null $__joinPoint */
+        /** @var \Go\Aop\Intercept\DynamicMethodInvocation<self, self>|null $__joinPoint */
         static $__joinPoint;
         if ($__joinPoint === null) {
             $__joinPoint = \Go\Aop\Framework\InterceptorInjector::forMethod(self::class, 'returnSelf', ['advisor.Test\ns1\TestPhp7Class->returnSelf']);

--- a/tests/Instrument/Transformer/_files/php81-enum-proxy.php
+++ b/tests/Instrument/Transformer/_files/php81-enum-proxy.php
@@ -10,7 +10,7 @@ enum TestStatus : string implements \Go\Aop\Proxy
     case Inactive = 'inactive';
     public function label(): string
     {
-        /** @var \Go\Aop\Intercept\DynamicMethodInvocation<self>|null $__joinPoint */
+        /** @var \Go\Aop\Intercept\DynamicMethodInvocation<self, string>|null $__joinPoint */
         static $__joinPoint;
         if ($__joinPoint === null) {
             $__joinPoint = \Go\Aop\Framework\InterceptorInjector::forMethod(self::class, 'label', ['advisor.Test\ns1\TestStatus->label']);

--- a/tests/Instrument/Transformer/_files/php83-override-proxy.php
+++ b/tests/Instrument/Transformer/_files/php83-override-proxy.php
@@ -15,7 +15,7 @@ class TestClassWithOverride implements \Go\Aop\Proxy
     #[\Override]
     public function overriddenMethod(): string
     {
-        /** @var \Go\Aop\Intercept\DynamicMethodInvocation<self>|null $__joinPoint */
+        /** @var \Go\Aop\Intercept\DynamicMethodInvocation<self, string>|null $__joinPoint */
         static $__joinPoint;
         if ($__joinPoint === null) {
             $__joinPoint = \Go\Aop\Framework\InterceptorInjector::forMethod(self::class, 'overriddenMethod', ['advisor.Test\ns1\TestClassWithOverride->overriddenMethod']);
@@ -24,7 +24,7 @@ class TestClassWithOverride implements \Go\Aop\Proxy
     }
     public function normalMethod(): int
     {
-        /** @var \Go\Aop\Intercept\DynamicMethodInvocation<self>|null $__joinPoint */
+        /** @var \Go\Aop\Intercept\DynamicMethodInvocation<self, int>|null $__joinPoint */
         static $__joinPoint;
         if ($__joinPoint === null) {
             $__joinPoint = \Go\Aop\Framework\InterceptorInjector::forMethod(self::class, 'normalMethod', ['advisor.Test\ns1\TestClassWithOverride->normalMethod']);


### PR DESCRIPTION
Extend core interfaces to support generic return type as second template variable.

MethodInvocation uses V as generic return type
FunctionInvocation uses V as generic return type
FieldAccess uses V as generic property type