### PR TITLE
Add PHP 8.6 to CI matrix as experimental

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -15,7 +15,10 @@ jobs:
 
     runs-on: ${{ matrix.operating-system }}
 
+    continue-on-error: ${{ matrix.experimental }}
+
     strategy:
+      fail-fast: false
       matrix:
         dependencies:
           - "lowest"
@@ -25,6 +28,17 @@ jobs:
           - "8.5"
         operating-system:
           - "ubuntu-latest"
+        experimental:
+          - false
+        include:
+          - php-version: "8.6"
+            dependencies: "lowest"
+            operating-system: "ubuntu-latest"
+            experimental: true
+          - php-version: "8.6"
+            dependencies: "highest"
+            operating-system: "ubuntu-latest"
+            experimental: true
 
     steps:
       - name: "Checkout"

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -63,15 +63,15 @@ jobs:
 
       - name: "Install lowest dependencies"
         if: ${{ matrix.dependencies == 'lowest' }}
-        run: "composer update --prefer-lowest --no-interaction --no-progress"
+        run: "composer update --prefer-lowest --no-interaction --no-progress${{ matrix.experimental && ' --ignore-platform-req=php+' || '' }}"
 
       - name: "Install highest dependencies"
         if: ${{ matrix.dependencies == 'highest' }}
-        run: "composer update --no-interaction --no-progress"
+        run: "composer update --no-interaction --no-progress${{ matrix.experimental && ' --ignore-platform-req=php+' || '' }}"
 
       - name: "Install locked dependencies"
         if: ${{ matrix.dependencies == 'locked' }}
-        run: "composer install --no-interaction --no-progress"
+        run: "composer install --no-interaction --no-progress${{ matrix.experimental && ' --ignore-platform-req=php+' || '' }}"
 
       - name: "Tests"
         run: "vendor/bin/phpunit"


### PR DESCRIPTION
## Summary

Adds PHP 8.6 to the PHPUnit workflow matrix as an experimental version, so early failures on the upcoming PHP release are visible without breaking the build:

- New `experimental` matrix flag (`false` for the existing PHP 8.4 / 8.5 jobs).
- `include` entries running PHP 8.6 with both `lowest` and `highest` dependencies, marked `experimental: true`.
- `continue-on-error: ${{ matrix.experimental }}` on the job, so PHP 8.6 failures don't fail the workflow.
- `fail-fast: false` so one failing combination no longer cancels the remaining matrix jobs.

The `composer.json` constraint (`"php": "^8.4.0"`) already allows 8.6, so no dependency changes are needed.

---
_Generated by [Claude Code](https://claude.ai/code/session_0196qA77VM2Kxaqu6YoiuMLC)_