### PR TITLE
fix(kernel): correct the options shape accepted by AspectKernel::init()

### DIFF
--- a/src/Core/AspectKernel.php
+++ b/src/Core/AspectKernel.php
@@ -41,6 +41,16 @@ use function define;
  *   excludePaths: string[],
  *   containerClass: class-string<AspectContainer>
  * }
+ * @phpstan-type UserKernelOptions array{
+ *   debug?: bool,
+ *   appDir?: string,
+ *   cacheDir?: string|null,
+ *   cacheFileMode?: int,
+ *   features?: int,
+ *   includePaths?: string[],
+ *   excludePaths?: string[],
+ *   containerClass?: class-string<AspectContainer>
+ * }
  */
 abstract class AspectKernel
 {
@@ -102,16 +112,7 @@ abstract class AspectKernel
     /**
      * Init the kernel and make adjustments
      *
-     * @phpstan-param array{
-     *   debug?: bool,
-     *   appDir?: literal-string&non-falsy-string,
-     *   cacheDir?: string|null,
-     *   cacheFileMode?: int,
-     *   features?: int,
-     *   includePaths?: array{},
-     *   excludePaths?: array{},
-     *   containerClass?: class-string<AspectContainer>
-     * } $options Additional kernel options
+     * @phpstan-param UserKernelOptions $options Additional kernel options
      */
     public function init(array $options = []): void
     {


### PR DESCRIPTION
## Summary

The inline `@phpstan-param` shape on `AspectKernel::init()` is narrower than what the kernel actually accepts — and narrower than the `KernelOptions` type declared on the same class:

```php
 * @phpstan-param array{
 *   appDir?: literal-string&non-falsy-string,   // KernelOptions says: appDir: string
 *   includePaths?: array{},                     // KernelOptions says: includePaths: string[]
 *   excludePaths?: array{},                     // KernelOptions says: excludePaths: string[]
 *   ...
 * } $options
```

Two consequences for anyone running PHPStan over code that boots the kernel:

- **`appDir` demands a `literal-string`.** Any application that computes its root at runtime — a framework bridge calling `base_path()`, a value read from configuration, `$_SERVER`, `getcwd()` — is reported as passing an invalid argument.
- **`includePaths`/`excludePaths` are typed `array{}`**, i.e. only an empty array literal is accepted, even though listing directories is the entire purpose of both options.

Neither restriction is real: `normalizeOptions()` accepts any string for `appDir` (`is_string($merged['appDir'] ?? null) ? … : ''`) and filters both path lists with `array_filter($raw, is_string(...))`. The annotation was the only thing rejecting valid calls.

It stayed unnoticed because the only in-repo caller is `demos/autoload_aspect.php`, which happens to pass a literal `__DIR__ . '/../demos'` for `appDir` and no include paths at all.

## Changes

- Add a `UserKernelOptions` `@phpstan-type` next to the existing `KernelOptions`: the same value types, with every key optional — that is exactly the contract `init()` offers.
- Point `init()` at it, replacing the inline shape. Keeping the two types adjacent means the accepted input and the normalized output cannot drift apart.

No runtime change — this is a type annotation fix.

## Testing

- `./vendor/bin/phpstan analyze --memory-limit=512M` (level 10) — no errors, baseline unchanged.
- `./vendor/bin/phpunit` — 2474 tests, 2877 assertions, green.
- Verified downstream: with this patch applied to the `goaop/framework` copy in goaop/goaop-laravel-bridge#36, that package analyses clean at PHPStan `level: max` with **no** `@phpstan-ignore` at its `$kernel->init(...)` call. That suppression exists today only because of this annotation, and can be dropped once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HRJrrw79a8r4YTLyAxzJTF


---
_Generated by [Claude Code](https://claude.ai/code/session_01HRJrrw79a8r4YTLyAxzJTF)_