### PR TITLE
chore: bump goaop/parser-reflection to stable ^4.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     "require": {
         "php": "^8.4.0",
         "ext-tokenizer": "*",
-        "goaop/parser-reflection": "4.x-dev",
+        "goaop/parser-reflection": "^4.0",
         "goaop/dissect": "^4.0",
         "nikic/php-parser": "^5.0",
         "symfony/finder": "^7.4 || ^8.0"


### PR DESCRIPTION
## Summary
- `goaop/parser-reflection` was released as [4.0.0](https://github.com/goaop/parser-reflection/releases/tag/4.0.0) — switches the `require` constraint from the `4.x-dev` branch alias to the stable `^4.0` version range.

## Test plan
- [x] `composer update goaop/parser-reflection` resolves to `4.0.0`
- [x] `vendor/bin/phpunit` passes
- [x] `vendor/bin/phpstan analyse` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013xfs2FHTpipY3LRBtC5vLK

---
_Generated by [Claude Code](https://claude.ai/code/session_013xfs2FHTpipY3LRBtC5vLK)_