### PR TITLE
Boot-time profiling: span instrumentation + benchmark harness

### DIFF
--- a/src/Core/AspectKernel.php
+++ b/src/Core/AspectKernel.php
@@ -14,6 +14,7 @@ namespace Go\Core;
 
 use Go\Aop\AspectException;
 use Go\Aop\Features;
+use Go\Instrument\BootTimer;
 use Go\Instrument\ClassLoading\AopComposerLoader;
 use Go\Instrument\ClassLoading\CachePathManager;
 use Go\Instrument\ClassLoading\SourceTransformingLoader;
@@ -120,7 +121,12 @@ abstract class AspectKernel
             return;
         }
 
+        BootTimer::initFromEnv();
+        BootTimer::begin('kernel.init');
+
+        BootTimer::begin('kernel.normalizeOptions');
         $this->options = $this->normalizeOptions($options);
+        BootTimer::end();
         define('AOP_ROOT_DIR', $this->options['appDir']);
         define('AOP_CACHE_DIR', $this->options['cacheDir']);
 
@@ -133,23 +139,34 @@ abstract class AspectKernel
             throw new AspectException("Invalid aspect container class");
         }
 
+        BootTimer::begin('container.construct');
         $container = $this->container = new $this->options['containerClass']($resourcesToTrack);
         $container->add(AspectKernel::class, $this);
         $container->add('kernel.interceptFunctions', $this->hasFeature(Features::INTERCEPT_FUNCTIONS));
         $container->add('kernel.options', $this->options);
+        BootTimer::end();
 
+        BootTimer::begin('kernel.streamFilterRegister');
         SourceTransformingLoader::register();
+        BootTimer::end();
 
+        BootTimer::begin('kernel.registerTransformers');
         foreach ($this->registerTransformers() as $sourceTransformer) {
             SourceTransformingLoader::addTransformer($sourceTransformer);
         }
+        BootTimer::end();
 
+        BootTimer::begin('kernel.aopComposerLoader');
         AopComposerLoader::init($this->options, $container);
+        BootTimer::end();
 
         // Register all AOP configuration in the container
+        BootTimer::begin('kernel.configureAop');
         $this->configureAop($container);
+        BootTimer::end();
 
         $this->wasInitialized = true;
+        BootTimer::end();
     }
 
     /**

--- a/src/Core/Container.php
+++ b/src/Core/Container.php
@@ -18,6 +18,7 @@ use Go\Aop\AspectException;
 use Go\Aop\Pointcut\PointcutGrammar;
 use Go\Aop\Pointcut\PointcutLexer;
 use Go\Aop\Pointcut\PointcutParser;
+use Go\Instrument\BootTimer;
 use Go\Instrument\ClassLoading\CachePathManager;
 use OutOfBoundsException;
 use ReflectionClass;
@@ -101,6 +102,7 @@ class Container implements AspectContainer
 
     final public function registerAspect(Aspect $aspect): void
     {
+        BootTimer::add('container.registerAspect.count');
         $this->add($aspect::class, $aspect);
     }
 
@@ -122,9 +124,11 @@ class Container implements AspectContainer
 
     final public function addLazyService(string $id, Closure $lazyInitializationClosure): void
     {
+        BootTimer::begin('container.lazyService.' . $id);
         $reflectionClass = new ReflectionClass($id);
         $proxy = $reflectionClass->newLazyProxy(fn (object $proxy): object => $lazyInitializationClosure($this));
         $this->add($id, $proxy);
+        BootTimer::end();
     }
 
     final public function getService(string $className): object

--- a/src/Instrument/BootTimer.php
+++ b/src/Instrument/BootTimer.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+/*
+ * Go! AOP framework
+ *
+ * @copyright Copyright 2012, Lisachenko Alexander <lisachenko.it@gmail.com>
+ *
+ * This source file is subject to the license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Go\Instrument;
+
+use function count;
+use function file_put_contents;
+use function get_included_files;
+use function getenv;
+use function hrtime;
+use function json_encode;
+use function memory_get_peak_usage;
+use function memory_get_usage;
+use function register_shutdown_function;
+
+/**
+ * Lightweight boot-time profiler used by the benchmark harness.
+ *
+ * Disabled unless the GO_AOP_BENCH_SPANS environment variable contains a writable
+ * file path; when disabled every call is a single static bool check, so the
+ * instrumentation can stay in the hot path permanently.
+ */
+final class BootTimer
+{
+    public static bool $enabled = false;
+
+    private static string $outputFile = '';
+
+    private static int $originNs = 0;
+
+    /** @var list<array{n: string, s: int, d: int, l: int, f: int, m: int}> */
+    private static array $spans = [];
+
+    /** @var list<array{0: string, 1: int, 2: int, 3: int}> name, startNs, includedFiles, memory */
+    private static array $stack = [];
+
+    /** @var array<string, float|int> */
+    private static array $counters = [];
+
+    public static function initFromEnv(): void
+    {
+        $outputFile = getenv('GO_AOP_BENCH_SPANS');
+        if (!self::$enabled && is_string($outputFile) && $outputFile !== '') {
+            self::$enabled    = true;
+            self::$outputFile = $outputFile;
+            self::$originNs   = hrtime(true);
+            register_shutdown_function(self::dump(...));
+        }
+    }
+
+    public static function begin(string $name): void
+    {
+        if (!self::$enabled) {
+            return;
+        }
+        self::$stack[] = [$name, hrtime(true), count(get_included_files()), memory_get_usage()];
+    }
+
+    public static function end(): void
+    {
+        if (!self::$enabled) {
+            return;
+        }
+        $frame = array_pop(self::$stack);
+        if ($frame === null) {
+            return;
+        }
+        [$name, $startNs, $files, $memory] = $frame;
+        self::$spans[] = [
+            'n' => $name,
+            's' => $startNs - self::$originNs,
+            'd' => hrtime(true) - $startNs,
+            'l' => count(self::$stack),
+            'f' => count(get_included_files()) - $files,
+            'm' => memory_get_usage() - $memory,
+        ];
+    }
+
+    /**
+     * Increments an aggregate counter (used on per-class code paths where
+     * individual spans would be too noisy).
+     */
+    public static function add(string $counter, float|int $value = 1): void
+    {
+        if (!self::$enabled) {
+            return;
+        }
+        self::$counters[$counter] = (self::$counters[$counter] ?? 0) + $value;
+    }
+
+    public static function dump(): void
+    {
+        if (!self::$enabled) {
+            return;
+        }
+        $report = [
+            'php'      => PHP_VERSION,
+            'spans'    => self::$spans,
+            'counters' => self::$counters,
+            'files'    => count(get_included_files()),
+            'peakMem'  => memory_get_peak_usage(),
+            'totalNs'  => hrtime(true) - self::$originNs,
+        ];
+        file_put_contents(self::$outputFile, json_encode($report, JSON_PRETTY_PRINT));
+    }
+}

--- a/src/Instrument/ClassLoading/AopComposerLoader.php
+++ b/src/Instrument/ClassLoading/AopComposerLoader.php
@@ -16,6 +16,7 @@ use Closure;
 use SplFileInfo;
 use Go\Core\AspectContainer;
 use Go\Core\AspectKernel;
+use Go\Instrument\BootTimer;
 use Go\Instrument\FileSystem\Enumerator;
 use Go\Instrument\PathResolver;
 use Go\Instrument\Transformer\FilterInjectorTransformer;
@@ -89,7 +90,9 @@ class AopComposerLoader
 
         $fileEnumerator       = new Enumerator($options['appDir'], $options['includePaths'], $excludePaths);
         $this->fileEnumerator = $fileEnumerator;
+        BootTimer::begin('aopLoader.queryCacheState');
         $this->cacheState     = $container->getService(CachePathManager::class)->queryCacheState() ?? [];
+        BootTimer::end();
     }
 
     /**
@@ -148,19 +151,30 @@ class AopComposerLoader
             $this->isProduction    = !$this->options['debug'];
         }
 
-        $file = $this->original->findFile($class);
+        $startNs = BootTimer::$enabled ? hrtime(true) : 0;
+        $file    = $this->original->findFile($class);
+        if (BootTimer::$enabled) {
+            BootTimer::add('findFile.composerNs', hrtime(true) - $startNs);
+            BootTimer::add('findFile.count');
+        }
 
         if ($file !== false) {
+            $startNs  = BootTimer::$enabled ? hrtime(true) : 0;
             $resolved = PathResolver::realpath($file);
+            if (BootTimer::$enabled) {
+                BootTimer::add('findFile.realpathNs', hrtime(true) - $startNs);
+            }
             if (is_string($resolved)) {
                 $file = $resolved;
             }
             $cacheState = $this->cacheState[$file] ?? null;
             if ($cacheState && $this->isProduction) {
+                BootTimer::add('findFile.cacheHit');
                 $cacheUri = is_array($cacheState) && is_string($cacheState['cacheUri'] ?? null) ? $cacheState['cacheUri'] : null;
                 $file     = $cacheUri ?: $file;
             } elseif (($this->isAllowedFilter)(new SplFileInfo($file))) {
                 // can be optimized here with $cacheState even for debug mode, but no needed right now
+                BootTimer::add('findFile.filterRewrite');
                 $file = FilterInjectorTransformer::rewrite($file);
             }
         }

--- a/src/Instrument/ClassLoading/CachePathManager.php
+++ b/src/Instrument/ClassLoading/CachePathManager.php
@@ -14,6 +14,7 @@ namespace Go\Instrument\ClassLoading;
 
 use Go\Aop\Features;
 use Go\Core\AspectKernel;
+use Go\Instrument\BootTimer;
 use InvalidArgumentException;
 
 use function function_exists;
@@ -87,10 +88,13 @@ class CachePathManager
             }
 
             if (file_exists($this->cacheDir . self::CACHE_FILE_NAME)) {
+                BootTimer::begin('cachePathManager.includeCacheState');
                 $cacheData = include $this->cacheDir . self::CACHE_FILE_NAME;
                 if (is_array($cacheData)) {
                     $this->cacheState = $cacheData;
                 }
+                BootTimer::add('cacheState.entries', count($this->cacheState));
+                BootTimer::end();
             }
         }
     }

--- a/src/Instrument/ClassLoading/SourceTransformingLoader.php
+++ b/src/Instrument/ClassLoading/SourceTransformingLoader.php
@@ -98,8 +98,13 @@ class SourceTransformingLoader extends PhpStreamFilter
         if ($closing || feof($this->stream)) {
             $consumed = strlen($this->data);
 
+            $startNs = \Go\Instrument\BootTimer::$enabled ? hrtime(true) : 0;
             // $this->stream contains pointer to the source
             $metadata = new StreamMetaData($this->stream, $this->data);
+            if (\Go\Instrument\BootTimer::$enabled) {
+                \Go\Instrument\BootTimer::add('filter.sourceParseNs', hrtime(true) - $startNs);
+                \Go\Instrument\BootTimer::add('filter.count');
+            }
             self::transformCode($metadata);
 
             $bucket = stream_bucket_new($this->stream, $metadata->source);

--- a/src/Instrument/Transformer/CachingTransformer.php
+++ b/src/Instrument/Transformer/CachingTransformer.php
@@ -15,6 +15,7 @@ namespace Go\Instrument\Transformer;
 use Closure;
 use Go\Core\AspectContainer;
 use Go\Core\AspectKernel;
+use Go\Instrument\BootTimer;
 use Go\Instrument\ClassLoading\CachePathManager;
 use Go\ParserReflection\ReflectionEngine;
 
@@ -76,7 +77,12 @@ class CachingTransformer extends BaseSourceTransformer
             || (isset($cacheState['cacheUri']) && $cacheState['cacheUri'] !== $cacheUri)
             || !$this->container->hasAnyResourceChangedSince($cacheModified)
         ) {
+            $startNs          = BootTimer::$enabled ? hrtime(true) : 0;
             $processingResult = $this->processTransformers($metadata);
+            if (BootTimer::$enabled) {
+                BootTimer::add('transform.weaveNs', hrtime(true) - $startNs);
+                BootTimer::add('transform.weaveCount');
+            }
             if ($processingResult === TransformerResultEnum::RESULT_TRANSFORMED) {
                 if (!str_contains($cacheUri, AspectContainer::AOP_PROXIED_SUFFIX)
                     && str_contains($metadata->source, AspectContainer::AOP_PROXIED_SUFFIX)
@@ -106,11 +112,16 @@ class CachingTransformer extends BaseSourceTransformer
             $processingResult = isset($cacheState['cacheUri']) ? TransformerResultEnum::RESULT_TRANSFORMED : TransformerResultEnum::RESULT_ABORTED;
         }
         if ($processingResult === TransformerResultEnum::RESULT_TRANSFORMED) {
+            $startNs = BootTimer::$enabled ? hrtime(true) : 0;
             // Just replace all tokens in the stream
             ReflectionEngine::parseFile($cacheUri);
             $metadata->setTokenStreamFromRawTokens(
                 ...ReflectionEngine::getParser()->getTokens()
             );
+            if (BootTimer::$enabled) {
+                BootTimer::add('transform.cachedReparseNs', hrtime(true) - $startNs);
+                BootTimer::add('transform.cachedReparseCount');
+            }
         }
 
         return $processingResult;

--- a/tests/Benchmark/bench-request.php
+++ b/tests/Benchmark/bench-request.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+/*
+ * Go! AOP framework — boot-time benchmark request.
+ *
+ * Simulates one application request against the fixture project: boots the
+ * aspect kernel exactly like tests/Fixtures/project/web/index.php, then
+ * autoloads a representative set of woven application classes and triggers
+ * one intercepted call (first advice binding).
+ *
+ * Environment:
+ *   GO_AOP_CONFIGURATION  configuration profile (default|production)
+ *   GO_AOP_BENCH_SPANS    path to write the span/counter JSON report
+ */
+
+use Go\Instrument\BootTimer;
+use Go\Tests\TestProject\Application\ClassUsingTrait;
+use Go\Tests\TestProject\Application\ClassWithPrivateMethods;
+use Go\Tests\TestProject\Application\FinalClass;
+use Go\Tests\TestProject\Application\Main;
+use Go\Tests\TestProject\Application\Php84PropertyHooksClass;
+use Go\Tests\TestProject\Application\SimpleEnum;
+
+require_once __DIR__ . '/../../vendor/autoload.php';
+
+$configuration = getenv('GO_AOP_CONFIGURATION') ?: 'default';
+$settings      = require __DIR__ . '/../Fixtures/project/web/configuration.php';
+
+$kernel = $settings[$configuration]['kernel']::getInstance();
+$kernel->init($settings[$configuration]);
+
+// From here on the kernel is booted; everything below models the application
+// doing its work: autoloading woven classes and hitting one intercepted method.
+BootTimer::begin('app.autoloadWovenClasses');
+$classes = [
+    Main::class,
+    ClassUsingTrait::class,
+    FinalClass::class,
+    ClassWithPrivateMethods::class,
+    Php84PropertyHooksClass::class,
+    SimpleEnum::class,
+];
+foreach ($classes as $class) {
+    class_exists($class) || enum_exists($class);
+}
+BootTimer::end();
+
+BootTimer::begin('app.firstInterceptedCall');
+ob_start();
+(new Main())->doSomething();
+ob_end_clean();
+BootTimer::end();

--- a/tests/Benchmark/run-bench.php
+++ b/tests/Benchmark/run-bench.php
@@ -1,0 +1,147 @@
+<?php
+
+declare(strict_types=1);
+/*
+ * Go! AOP framework — boot-time benchmark orchestrator.
+ *
+ * Runs bench-request.php in child PHP processes across a matrix of scenarios
+ * and prints/collects median timings with per-span breakdowns.
+ *
+ * Usage:
+ *   php tests/Benchmark/run-bench.php [--php=php8.5] [--profile=production] \
+ *       [--mode=warm] [--runs=15] [--out=/tmp/bench-results]
+ *
+ * Modes:
+ *   cold  clear aspect cache + opcache file cache, single timed run (weaving happens inline)
+ *   warm  warm the caches (aspect warmup + 2 priming runs), then N timed runs
+ *
+ * CLI opcache does not survive between processes, so an opcache file cache is
+ * used to emulate the persistent opcache of a real FPM/server deployment.
+ */
+
+error_reporting(E_ALL);
+
+$options = getopt('', ['php::', 'profile::', 'mode::', 'runs::', 'out::', 'label::']);
+$php     = $options['php'] ?? 'php';
+$profile = $options['profile'] ?? 'production';
+$mode    = $options['mode'] ?? 'warm';
+$runs    = (int) ($options['runs'] ?? 15);
+$outDir  = rtrim($options['out'] ?? (sys_get_temp_dir() . '/goaop-bench'), '/');
+$label   = $options['label'] ?? sprintf('%s-%s-%s', basename((string) $php), $profile, $mode);
+
+$projectDir      = __DIR__ . '/../Fixtures/project';
+$benchScript     = __DIR__ . '/bench-request.php';
+$aspectCacheDirs = [
+    $projectDir . '/var/cache/aspect',
+    $projectDir . '/var/cache/aspect-prod',
+];
+$opcacheFileCache = $outDir . '/opcache-' . md5((string) $php . $profile);
+
+@mkdir($outDir, 0777, true);
+@mkdir($opcacheFileCache, 0777, true);
+
+/** @param list<string> $extraEnv */
+function runRequest(string $php, string $benchScript, string $profile, string $spanFile, string $opcacheFileCache, bool $opcacheEnabled = true): array
+{
+    $iniOptions = $opcacheEnabled
+        ? sprintf(
+            '-d opcache.enable_cli=1 -d opcache.enable=1 -d opcache.file_cache=%s -d opcache.validate_timestamps=1',
+            escapeshellarg($opcacheFileCache)
+        )
+        : '-d opcache.enable_cli=0';
+
+    $cmd = sprintf(
+        'GO_AOP_CONFIGURATION=%s GO_AOP_BENCH_SPANS=%s %s %s %s 2>&1',
+        escapeshellarg($profile),
+        escapeshellarg($spanFile),
+        escapeshellarg($php),
+        $iniOptions,
+        escapeshellarg($benchScript)
+    );
+
+    $startNs = hrtime(true);
+    exec($cmd, $output, $exitCode);
+    $wallNs = hrtime(true) - $startNs;
+
+    if ($exitCode !== 0) {
+        fwrite(STDERR, "Benchmark request failed (exit $exitCode):\n" . implode("\n", $output) . "\n");
+        exit(1);
+    }
+
+    $report = is_file($spanFile) ? json_decode((string) file_get_contents($spanFile), true) : null;
+
+    return ['wallNs' => $wallNs, 'report' => $report];
+}
+
+function clearDirs(array $dirs): void
+{
+    foreach ($dirs as $dir) {
+        if (is_dir($dir)) {
+            exec('rm -rf ' . escapeshellarg($dir . '/') . '*');
+        }
+    }
+}
+
+/** @param list<float> $values */
+function percentile(array $values, float $p): float
+{
+    sort($values);
+    $index = (int) floor((count($values) - 1) * $p);
+
+    return $values[$index];
+}
+
+$spanFile = $outDir . '/' . $label . '-spans.json';
+$samples  = [];
+
+if ($mode === 'cold') {
+    clearDirs($aspectCacheDirs);
+    clearDirs([$opcacheFileCache]);
+    $samples[] = runRequest($php, $benchScript, $profile, $spanFile, $opcacheFileCache);
+} else {
+    // Warm everything: aspect cache via warmup command + priming requests
+    // (priming also writes the _aspect advisor cache and fills the opcache file cache).
+    $console = $projectDir . '/bin/console';
+    exec(sprintf(
+        'GO_AOP_CONFIGURATION=%s %s %s cache:warmup:aop %s 2>&1',
+        escapeshellarg($profile),
+        escapeshellarg((string) $php),
+        escapeshellarg($console),
+        escapeshellarg($projectDir . '/web/index.php')
+    ));
+    runRequest($php, $benchScript, $profile, $spanFile, $opcacheFileCache);
+    runRequest($php, $benchScript, $profile, $spanFile, $opcacheFileCache);
+
+    for ($i = 0; $i < $runs; $i++) {
+        $samples[] = runRequest($php, $benchScript, $profile, $spanFile, $opcacheFileCache);
+    }
+}
+
+// Aggregate: median by total in-process time, keep that run's span breakdown.
+usort($samples, fn(array $a, array $b): int => ($a['report']['totalNs'] ?? PHP_INT_MAX) <=> ($b['report']['totalNs'] ?? PHP_INT_MAX));
+$median = $samples[intdiv(count($samples), 2)];
+
+$totals = array_map(fn(array $sample): float => (float) ($sample['report']['totalNs'] ?? 0), $samples);
+$walls  = array_map(fn(array $sample): float => (float) $sample['wallNs'], $samples);
+
+$result = [
+    'label'      => $label,
+    'php'        => $median['report']['php'] ?? 'unknown',
+    'profile'    => $profile,
+    'mode'       => $mode,
+    'runs'       => count($samples),
+    'totalMs'    => ['median' => percentile($totals, 0.5) / 1e6, 'p10' => percentile($totals, 0.1) / 1e6, 'p90' => percentile($totals, 0.9) / 1e6],
+    'wallMs'     => ['median' => percentile($walls, 0.5) / 1e6, 'p10' => percentile($walls, 0.1) / 1e6, 'p90' => percentile($walls, 0.9) / 1e6],
+    'medianRun'  => $median['report'],
+];
+
+file_put_contents($outDir . '/' . $label . '.json', json_encode($result, JSON_PRETTY_PRINT));
+
+printf(
+    "%-28s total(median) %8.2f ms   p10 %8.2f   p90 %8.2f   (process wall median %8.2f ms)\n",
+    $label,
+    $result['totalMs']['median'],
+    $result['totalMs']['p10'],
+    $result['totalMs']['p90'],
+    $result['wallMs']['median']
+);

--- a/tests/Fixtures/project/web/configuration.php
+++ b/tests/Fixtures/project/web/configuration.php
@@ -15,6 +15,21 @@ return [
         ],
     ],
 
+    // Same application as 'default' but in production mode (warm-cache fast path),
+    // with a separate cache directory so debug and production caches never mix.
+    // Used by the boot-time benchmark harness in tests/Benchmark.
+    'production' => [
+        'kernel' => \Go\Tests\TestProject\Kernel\DefaultAspectKernel::class,
+        'console' => __DIR__ . '/../bin/console',
+        'frontController' => __DIR__ . '/../web/index.php',
+        'appDir' => __DIR__ . '/../',
+        'debug' => false,
+        'cacheDir'  => __DIR__ . '/../var/cache/aspect-prod',
+        'includePaths' => [
+            __DIR__ . '/../src/'
+        ],
+    ],
+
     'inconsistent_weaving' => [
         'kernel' => \Go\Tests\TestProject\Kernel\InconsistentlyWeavingAspectKernel::class,
         'console' => __DIR__ . '/../bin/console',


### PR DESCRIPTION
## What

First step of the hot-start boot-time optimization work for 4.0: measurement infrastructure.

- **`Go\Instrument\BootTimer`** — a tiny boot profiler that is disabled unless the `GO_AOP_BENCH_SPANS` env var points to an output file (a single static bool check per call when off, so it can live in the hot path permanently). Records hrtime spans with per-span autoloaded-file and memory deltas, plus aggregate counters, and dumps a JSON report on shutdown.
- **Span hooks** around each boot phase: `AspectKernel::init` sub-steps (normalizeOptions, container construction, stream-filter registration, transformer registration, composer-loader init, `configureAop`), per-service `Container::addLazyService`, the `_transformation.cache` include in `CachePathManager`, `AopComposerLoader::findFile` (composer lookup / realpath / cache-hit / filter-rewrite counters), and the transformer cold path (`SourceTransformingLoader::filter` parse, `CachingTransformer` weave + cached-reparse).
- **`tests/Benchmark/`** — `bench-request.php` simulates one request against the fixture project (kernel boot + autoload of woven classes + first intercepted call); `run-bench.php` orchestrates the cold/warm matrix across PHP binaries, using an opcache file cache to emulate a persistent server opcache in CLI runs, and reports median/p10/p90.
- **Fixture project**: new `production` configuration profile (`debug => false`, isolated cache dir) so the warm-cache production fast path can be measured next to the existing debug profile.

## Why

Baseline numbers and a per-phase breakdown are needed before the planned 4.0 boot-time optimizations (lazy transformer registration, truly-lazy container services, lazy aspect registration, real `PREBUILT_CACHE` mode, opcache-friendly cache state). Follow-up commits on this branch will add the measured results and the optimizations themselves.

## Notes

- No behavior change when `GO_AOP_BENCH_SPANS` is not set.
- Benchmark results and analysis will be posted on this PR once the matrix (PHP 8.4/8.5/8.6 × cold/warm × debug/production) has been run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V1Z87HZ2iz23WPTtTYqFxE

---
_Generated by [Claude Code](https://claude.ai/code/session_01V1Z87HZ2iz23WPTtTYqFxE)_