### PR TITLE
test: use strcmp instead of deprecated strcoll in function generator test

### DIFF
--- a/tests/Proxy/Part/InterceptedFunctionGeneratorTest.php
+++ b/tests/Proxy/Part/InterceptedFunctionGeneratorTest.php
@@ -105,9 +105,12 @@ class InterceptedFunctionGeneratorTest extends TestCase
                 'array_pop',
                 'function array_pop(array &$array): mixed'
             ],
-            'strcoll' => [
-                'strcoll',
-                'function strcoll(string $string1, string $string2): int'
+            // strcmp instead of strcoll here: PHP 8.6 deprecated strcoll(), and the
+            // generator (correctly) mirrors the native #[\Deprecated] attribute into
+            // the generated signature, which would make an exact match version-dependent
+            'strcmp' => [
+                'strcmp',
+                'function strcmp(string $string1, string $string2): int'
             ],
             'microtime' => [
                 'microtime',


### PR DESCRIPTION
## What

Fixes the experimental PHP 8.6 CI failure `InterceptedFunctionGeneratorTest::testGenerate@strcoll` by swapping the dataset function from `strcoll` to `strcmp`.

## Why

PHP 8.6 added `#[\Deprecated(message: 'use Collator::compare() instead', since: '8.6')]` to `strcoll()`. The function generator intentionally mirrors native attributes into generated proxy signatures (that behavior is correct — the proxy should carry the deprecation), so on 8.6 the generated code gains the attribute line and the exact-match assertion fails:

```
-'function strcoll(string $string1, string $string2): int'
+'#[\Deprecated(message: 'use Collator::compare() instead', since: '8.6')]
+function strcoll(string $string1, string $string2): int'
```

The dataset only exists to cover "internal function with two string parameters returning `int`" — `strcmp` has the identical shape, is not deprecated, and keeps the expectation exact on every PHP version. Hardcoding the 8.6 deprecation message was rejected because its wording may still change during the beta cycle; attribute propagation itself remains covered by the `funcWithAttributes` dataset.

## Validation

Reproduced the failure on PHP 8.6.0beta2 first, then after the change:
- PHP 8.6.0beta2: full suite green (2474 tests, no failures — previously 1 failure)
- PHP 8.5.9 / PHP 8.4.24: `InterceptedFunctionGeneratorTest` green (10 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V1Z87HZ2iz23WPTtTYqFxE

---
_Generated by [Claude Code](https://claude.ai/code/session_01V1Z87HZ2iz23WPTtTYqFxE)_