### PR TITLE
perf(container): defer aspect construction with class-name registration

### DIFF
--- a/demos/Demo/Aspect/AwesomeAspectKernel.php
+++ b/demos/Demo/Aspect/AwesomeAspectKernel.php
@@ -25,13 +25,13 @@ class AwesomeAspectKernel extends AspectKernel
      */
     protected function configureAop(AspectContainer $container): void
     {
-        $container->registerAspect(new CachingAspect());
-        $container->registerAspect(new LoggingAspect());
-        $container->registerAspect(new IntroductionAspect());
-        $container->registerAspect(new PropertyInterceptorAspect());
-        $container->registerAspect(new FunctionInterceptorAspect());
-        $container->registerAspect(new FluentInterfaceAspect());
-        $container->registerAspect(new HealthyLiveAspect());
-        $container->registerAspect(new DynamicMethodsAspect());
+        $container->registerAspect(CachingAspect::class);
+        $container->registerAspect(LoggingAspect::class);
+        $container->registerAspect(IntroductionAspect::class);
+        $container->registerAspect(PropertyInterceptorAspect::class);
+        $container->registerAspect(FunctionInterceptorAspect::class);
+        $container->registerAspect(FluentInterfaceAspect::class);
+        $container->registerAspect(HealthyLiveAspect::class);
+        $container->registerAspect(DynamicMethodsAspect::class);
     }
 }

--- a/src/Core/AspectContainer.php
+++ b/src/Core/AspectContainer.php
@@ -109,8 +109,20 @@ interface AspectContainer
 
     /**
      * Register an aspect in the container
+     *
+     * Passing an aspect instance registers it immediately, exactly as before.
+     *
+     * Passing a class-name defers construction until the aspect is first needed (first
+     * advice hit, or aspect enumeration during weaving), keeping it off the hot boot path.
+     * An aspect with required constructor arguments must also pass a factory closure that
+     * creates the instance; without a factory the class must be default-constructible,
+     * which is validated when the aspect materializes.
+     *
+     * @param Aspect|class-string<Aspect> $aspectOrClassName Aspect instance or its class-name
+     * @param null|Closure(AspectContainer $container): Aspect $aspectFactory Factory for deferred
+     *        construction (only allowed together with a class-name)
      */
-    public function registerAspect(Aspect $aspect): void;
+    public function registerAspect(Aspect|string $aspectOrClassName, ?Closure $aspectFactory = null): void;
 
     /**
      * Checks if there are any file resources with changes after since given timestamp

--- a/src/Core/Container.php
+++ b/src/Core/Container.php
@@ -20,6 +20,7 @@ use Go\Aop\Pointcut\PointcutLexer;
 use Go\Aop\Pointcut\PointcutParser;
 use Go\Instrument\ClassLoading\CachePathManager;
 use OutOfBoundsException;
+use ReflectionClass;
 use ReflectionObject;
 
 /**
@@ -103,9 +104,78 @@ class Container implements AspectContainer
         ));
     }
 
-    final public function registerAspect(Aspect $aspect): void
+    final public function registerAspect(Aspect|string $aspectOrClassName, ?Closure $aspectFactory = null): void
     {
-        $this->add($aspect::class, $aspect);
+        if ($aspectOrClassName instanceof Aspect) {
+            $this->add($aspectOrClassName::class, $aspectOrClassName);
+
+            return;
+        }
+
+        // Deferred registration by class-name: the aspect is constructed on first use
+        // (first advice hit, or aspect enumeration on the weaving path), so a hot-cache
+        // request never pays for aspects it does not touch.
+        $this->addLazyService($aspectOrClassName, function () use ($aspectOrClassName, $aspectFactory): Aspect {
+            return $this->materializeAspect($aspectOrClassName, $aspectFactory);
+        });
+
+        // In debug mode the aspect's source file must be tracked as a resource right away:
+        // CachingTransformer consults resource freshness before any aspect materializes.
+        // Production skips this - its warm path never checks freshness, and a cache miss
+        // materializes every aspect during weaving anyway.
+        if ($this->isDebug()) {
+            if (!is_subclass_of($aspectOrClassName, Aspect::class)) {
+                throw new AspectException("Aspect class $aspectOrClassName must implement " . Aspect::class);
+            }
+            $aspectFileName = (new ReflectionClass($aspectOrClassName))->getFileName();
+            if (is_string($aspectFileName)) {
+                $this->addResource($aspectFileName);
+            }
+        }
+    }
+
+    /**
+     * Constructs a lazily registered aspect, either through its factory or by validated
+     * default construction
+     *
+     * @param null|Closure(AspectContainer): Aspect $aspectFactory
+     */
+    private function materializeAspect(string $aspectClassName, ?Closure $aspectFactory): Aspect
+    {
+        if (!is_subclass_of($aspectClassName, Aspect::class)) {
+            throw new AspectException("Aspect class $aspectClassName must implement " . Aspect::class);
+        }
+        if ($aspectFactory !== null) {
+            $aspect = $aspectFactory($this);
+            if (!$aspect instanceof $aspectClassName) {
+                throw new AspectException("Aspect factory for $aspectClassName returned an incompatible object");
+            }
+
+            return $aspect;
+        }
+
+        $constructor = (new ReflectionClass($aspectClassName))->getConstructor();
+        if ($constructor !== null && $constructor->getNumberOfRequiredParameters() > 0) {
+            throw new AspectException(
+                "Aspect $aspectClassName has required constructor arguments, "
+                . "pass a factory closure to registerAspect() to create it"
+            );
+        }
+
+        return new $aspectClassName();
+    }
+
+    /**
+     * Whether the kernel that owns this container runs in debug mode
+     */
+    private function isDebug(): bool
+    {
+        if (!$this->has('kernel.options')) {
+            return false;
+        }
+        $options = $this->getValue('kernel.options');
+
+        return is_array($options) && ($options['debug'] ?? false) === true;
     }
 
     final public function add(string $id, mixed $value): void
@@ -173,8 +243,12 @@ class Container implements AspectContainer
         // Deferred services are only tagged once constructed, so materialize the
         // pending ones that implement the requested interface first. This path is
         // only taken during weaving/console runs, never on a hot request.
+        // Both the is_subclass_of() autoload and the factory invocation can re-enter
+        // this method (an aspect class autoloaded here goes through the weaving
+        // pipeline, which enumerates aspects again), consuming pending factories from
+        // under this loop - hence the existence re-check and the tolerant materialization.
         foreach (array_keys($this->factories) as $id) {
-            if (is_subclass_of($id, $interfaceTagClassName)) {
+            if (array_key_exists($id, $this->factories) && is_subclass_of($id, $interfaceTagClassName)) {
                 $this->materializeService($id);
             }
         }
@@ -192,7 +266,11 @@ class Container implements AspectContainer
      */
     private function materializeService(string $id): void
     {
-        $factory = $this->factories[$id];
+        $factory = $this->factories[$id] ?? null;
+        if ($factory === null) {
+            // Already materialized by a re-entrant call (e.g. triggered through autoloading)
+            return;
+        }
         // Unset before invoking the factory so a re-entrant lookup cannot run it twice
         unset($this->factories[$id]);
         $this->add($id, $factory($this));

--- a/tests/Core/ContainerTest.php
+++ b/tests/Core/ContainerTest.php
@@ -19,7 +19,11 @@ use Go\Aop\Pointcut;
 use Go\Aop\Pointcut\PointcutLexer;
 use Go\Aop\Pointcut\PointcutParser;
 use Go\Stubs\First;
+use Go\Tests\TestProject\Aspect\DoSomethingAspect;
+use Go\Tests\TestProject\Aspect\EnumMethodAspect;
+use Go\Tests\TestProject\Aspect\LoggingAspect;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
 use stdClass;
 
 #[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
@@ -205,5 +209,73 @@ class ContainerTest extends TestCase
         $this->expectException(AspectException::class);
         $this->expectExceptionMessageMatches('/Lazy service id must be a valid class name/');
         $this->container->addLazyService('kernel.not-a-class', fn(): PointcutLexer => new PointcutLexer());
+    }
+
+    public function testAspectRegisteredByClassNameIsConstructedOnFirstUse(): void
+    {
+        $constructed = false;
+        $this->container->registerAspect(
+            LoggingAspect::class,
+            function () use (&$constructed): LoggingAspect {
+                $constructed = true;
+
+                return new LoggingAspect(new NullLogger());
+            }
+        );
+
+        $this->assertTrue($this->container->has(LoggingAspect::class));
+        $this->assertFalse($constructed, 'Aspect should not have been constructed at registration');
+
+        $aspect = $this->container->getService(LoggingAspect::class);
+        $this->assertInstanceOf(LoggingAspect::class, $aspect);
+        $this->assertTrue($constructed);
+    }
+
+    public function testLazyAspectAppearsInAspectInterfaceQuery(): void
+    {
+        $this->container->registerAspect(DoSomethingAspect::class);
+
+        $aspects = $this->container->getServicesByInterface(Aspect::class);
+        $this->assertArrayHasKey(DoSomethingAspect::class, $aspects);
+        $this->assertInstanceOf(DoSomethingAspect::class, $aspects[DoSomethingAspect::class]);
+    }
+
+    public function testLazyAspectWithRequiredConstructorArgsNeedsFactory(): void
+    {
+        // LoggingAspect requires a LoggerInterface constructor argument
+        $this->container->registerAspect(LoggingAspect::class);
+
+        $this->expectException(AspectException::class);
+        $this->expectExceptionMessageMatches('/pass a factory closure/');
+        $this->container->getService(LoggingAspect::class);
+    }
+
+    public function testLazyAspectMustImplementAspectInterface(): void
+    {
+        $this->container->registerAspect(stdClass::class);
+
+        $this->expectException(AspectException::class);
+        $this->expectExceptionMessageMatches('/must implement/');
+        $this->container->getService(stdClass::class);
+    }
+
+    public function testInterfaceQuerySurvivesReentrantMaterialization(): void
+    {
+        // A factory that re-enters getServicesByInterface() consumes other pending
+        // factories from under the outer materialization loop (this also happens
+        // implicitly when an aspect class is autoloaded through the weaving pipeline)
+        $this->container->registerAspect(
+            DoSomethingAspect::class,
+            function (AspectContainer $container): DoSomethingAspect {
+                $container->getServicesByInterface(Aspect::class);
+
+                return new DoSomethingAspect();
+            }
+        );
+        $this->container->registerAspect(EnumMethodAspect::class);
+
+        $aspects = $this->container->getServicesByInterface(Aspect::class);
+        $this->assertArrayHasKey(DoSomethingAspect::class, $aspects);
+        $this->assertArrayHasKey(EnumMethodAspect::class, $aspects);
     }
 }

--- a/tests/Fixtures/project/src/Kernel/DefaultAspectKernel.php
+++ b/tests/Fixtures/project/src/Kernel/DefaultAspectKernel.php
@@ -23,14 +23,14 @@ class DefaultAspectKernel extends AspectKernel
      */
     protected function configureAop(AspectContainer $container): void
     {
-        $container->registerAspect(new LoggingAspect(new NullLogger()));
-        $container->registerAspect(new DoSomethingAspect());
-        $container->registerAspect(new ArrayPropertyInterceptAspect());
-        $container->registerAspect(new PropertyInterceptAspect());
-        $container->registerAspect(new Issue293Aspect());
-        $container->registerAspect(new InitializationAspect());
-        $container->registerAspect(new WeavingAspect());
-        $container->registerAspect(new TraitCompositionAspect());
-        $container->registerAspect(new EnumMethodAspect());
+        $container->registerAspect(LoggingAspect::class, fn(): LoggingAspect => new LoggingAspect(new NullLogger()));
+        $container->registerAspect(DoSomethingAspect::class);
+        $container->registerAspect(ArrayPropertyInterceptAspect::class);
+        $container->registerAspect(PropertyInterceptAspect::class);
+        $container->registerAspect(Issue293Aspect::class);
+        $container->registerAspect(InitializationAspect::class);
+        $container->registerAspect(WeavingAspect::class);
+        $container->registerAspect(TraitCompositionAspect::class);
+        $container->registerAspect(EnumMethodAspect::class);
     }
 }

--- a/tests/Fixtures/project/src/Kernel/InconsistentlyWeavingAspectKernel.php
+++ b/tests/Fixtures/project/src/Kernel/InconsistentlyWeavingAspectKernel.php
@@ -21,7 +21,11 @@ class InconsistentlyWeavingAspectKernel extends AspectKernel
      */
     protected function configureAop(AspectContainer $container): void
     {
-        $container->registerAspect(new LoggingAspect(new NullLogger()));
+        $container->registerAspect(LoggingAspect::class, fn(): LoggingAspect => new LoggingAspect(new NullLogger()));
+        // Deliberately eager (instance) registration: the inconsistent-weaving scenario this
+        // kernel exists to reproduce requires the application class to be loaded through the
+        // AOP loader before weaving starts, which only happens when the aspect is constructed
+        // during configureAop() rather than lazily on first use.
         $container->registerAspect(new InconsistentlyWeavingAspect(new InconsistentlyWeavedClass()));
     }
 }


### PR DESCRIPTION
## What

`registerAspect()` now also accepts an aspect **class-name** with an optional **factory closure**, deferring aspect construction to first use (first advice hit, or aspect enumeration during weaving). Today `configureAop()` constructs every aspect on every request — plus a `ReflectionObject`, interface scan and `is_readable()` stat per aspect in `add()` — even when the request never triggers a single advice.

```php
// zero-dependency aspect
$container->registerAspect(DoSomethingAspect::class);

// aspect with constructor dependencies — factory required (per review of the design):
$container->registerAspect(LoggingAspect::class, fn() => new LoggingAspect(new NullLogger()));

// instances keep working unchanged (and stay the right choice when construction
// side effects are intentional — see InconsistentlyWeavingAspectKernel)
$container->registerAspect(new LoggingAspect(new NullLogger()));
```

Details:
- Deferred aspects ride on the factory map from #589; `getServicesByInterface(Aspect::class)` materializes them, so `AspectLoader`, `LazyAdvisorAccessor` and the debug commands observe the same aspects as before.
- Default construction (no factory) is **validated at materialization**: a required constructor argument raises a clear `AspectException` telling you to pass a factory. A non-`Aspect` class is rejected likewise.
- **Debug mode** registers the aspect's source file as a tracked resource at registration (reflection only, no instantiation), preserving the cache-freshness semantics that eager construction used to provide. Production skips it — the warm path never checks freshness, and a cache miss materializes all aspects during weaving anyway.
- Re-entrancy hardening in `getServicesByInterface()` / `materializeService()`: autoloading an aspect class inside the materialization loop goes through the weaving pipeline, which re-enters the same enumeration and consumes pending factories — found by a real cold-boot run, covered by `testInterfaceQuerySurvivesReentrantMaterialization`.

## Why (measured)

Fixture project (9 aspects), warm cache, `debug=false`, opcache file cache, median of 15 (kernel init + 6 woven class autoloads + first intercepted call), PHP 8.5:

| | master (pre-#589) | after #589 | this PR |
|---|---|---|---|
| `AspectKernel::init()` | 1.88 ms | 1.14 ms | **0.78 ms** |
| full request | 3.42 ms | 2.90 ms | **2.63 ms** |
| included files | 142 | 129 | **123** |

## BC note (4.0)

`AspectContainer::registerAspect()` signature widens to `Aspect|string $aspectOrClassName, ?Closure $aspectFactory = null`. Existing instance-based calls compile and behave identically. Custom `AspectContainer` implementations must update the signature.

## Part of the boot-time series

Second of five sequential PRs (container laziness → **lazy aspects** → lazy transformers → trusted prebuilt cache → cache-state split).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V1Z87HZ2iz23WPTtTYqFxE

---
_Generated by [Claude Code](https://claude.ai/code/session_01V1Z87HZ2iz23WPTtTYqFxE)_