### PR TITLE
Replace abandoned adlawson/vfs with goaop/virtual-file-system

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,8 +17,8 @@
     },
 
     "require-dev": {
-        "adlawson/vfs": "^0.12.1",
         "doctrine/orm": "^2.5 || ^3.0",
+        "goaop/virtual-file-system": "^1.0",
         "phpstan/phpstan": "^2.0",
         "phpunit/phpunit": "^13.0",
         "symfony/console": "^7.4 || ^8.0",

--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
         "goaop/virtual-file-system": "^1.0",
         "phpstan/phpstan": "^2.0",
         "phpunit/phpunit": "^13.0",
+        "psr/log": "^3.0",
         "symfony/console": "^7.4 || ^8.0",
         "symfony/filesystem": "^7.4 || ^8.0",
         "symfony/process": "^7.4 || ^8.0",

--- a/src/Instrument/Transformer/WeavingTransformer.php
+++ b/src/Instrument/Transformer/WeavingTransformer.php
@@ -729,8 +729,10 @@ class WeavingTransformer extends BaseSourceTransformer
 
         $body = '<?php' . PHP_EOL . $childCode;
 
-        $isVirtualSystem = strpos($proxyFileName, 'vfs') === 0;
-        file_put_contents($proxyFileName, $body, $isVirtualSystem ? 0 : LOCK_EX);
+        // PHP core refuses the LOCK_EX flag for any non-"file://" stream wrapper path,
+        // so it can not be used when the cache is placed on a virtual filesystem
+        $isStreamPath = str_contains($proxyFileName, '://');
+        file_put_contents($proxyFileName, $body, $isStreamPath ? 0 : LOCK_EX);
         // For cache files we don't want executable bits by default
         chmod($proxyFileName, $this->options['cacheFileMode'] & (~0111));
 

--- a/tests/Instrument/FileSystem/EnumeratorTest.php
+++ b/tests/Instrument/FileSystem/EnumeratorTest.php
@@ -12,9 +12,9 @@ declare(strict_types = 1);
 
 namespace Go\Instrument\FileSystem;
 
+use Go\VirtualFileSystem\FileSystem;
 use PHPUnit\Framework\TestCase;
 use SplFileInfo;
-use Vfs\FileSystem;
 
 #[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 class EnumeratorTest extends TestCase
@@ -28,8 +28,7 @@ class EnumeratorTest extends TestCase
      */
     public static function setUpBeforeClass(): void
     {
-        static::$fileSystem = FileSystem::factory('vfs://');
-        static::$fileSystem->mount();
+        static::$fileSystem = FileSystem::mount('vfs');
 
         $testPaths = [
             '/base/sub/test',
@@ -38,8 +37,7 @@ class EnumeratorTest extends TestCase
 
         // Setup some files we test against
         foreach ($testPaths as $path) {
-            mkdir('vfs://' . $path, 0777, true);
-            touch('vfs://' . $path . DIRECTORY_SEPARATOR . 'TestClass.php');
+            static::$fileSystem->createFile($path . '/TestClass.php');
         }
     }
 

--- a/tests/Instrument/Transformer/WeavingTransformerTest.php
+++ b/tests/Instrument/Transformer/WeavingTransformerTest.php
@@ -18,10 +18,10 @@ use Go\Core\AspectContainer;
 use Go\Core\AspectKernel;
 use Go\Core\AspectLoader;
 use Go\Instrument\ClassLoading\CachePathManager;
+use Go\VirtualFileSystem\FileSystem;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
-use Vfs\FileSystem;
 
 #[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 class WeavingTransformerTest extends TestCase
@@ -41,8 +41,12 @@ class WeavingTransformerTest extends TestCase
      */
     public static function setUpBeforeClass(): void
     {
-        static::$fileSystem = FileSystem::factory('vfs://');
-        static::$fileSystem->mount();
+        static::$fileSystem = FileSystem::mount('vfs');
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        static::$fileSystem->unmount();
     }
 
     /**


### PR DESCRIPTION
## Summary

Replaces the abandoned `adlawson/vfs ^0.12.1` dev dependency (PHP 5.x-era code, source of deprecation errors on every modern PHP version) with its purpose-built successor [`goaop/virtual-file-system`](https://github.com/goaop/virtual-file-system) `^1.0` (resolves to 1.1.0 from Packagist).

## Migration analysis

Only two test classes consumed the old library; two small vfs-aware seams exist in `src`:

| Location | Change |
|---|---|
| `composer.json` | `adlawson/vfs ^0.12.1` → `goaop/virtual-file-system ^1.0`; `psr/log ^3.0` added to require-dev (see below) |
| `tests/Instrument/FileSystem/EnumeratorTest.php` | `FileSystem::factory('vfs://')->mount()` → `FileSystem::mount('vfs')`; fixture seeding via the library's `createFile()` API (parents auto-created) instead of `mkdir`/`touch` loops. Data-provider `vfs://…` paths unchanged (same scheme). |
| `tests/Instrument/Transformer/WeavingTransformerTest.php` | Same mount swap, **plus a previously missing `tearDownAfterClass()` unmount** — the new library refuses to double-mount a scheme, which surfaced this leak (adlawson silently tolerated it). |
| `src/Instrument/Transformer/WeavingTransformer.php` (`saveProxyToCache`) | Generalized the `LOCK_EX` workaround from the brittle `strpos($proxyFileName, 'vfs') === 0` to `str_contains($proxyFileName, '://')`. PHP core rejects the `LOCK_EX` flag of `file_put_contents()` for **every** non-`file://` URL before even consulting the wrapper, so the exception is inherent to stream wrapper paths in general, not to one particular vfs library. |

### psr/log was a hidden transitive dependency

The first CI run failed on the three `--prefer-lowest` rows with `Class "Psr\Log\NullLogger" not found`: the test fixtures (`DefaultAspectKernel`, `ContainerTest`) wire `NullLogger` into the container, but `psr/log` was only ever present transitively **through `adlawson/vfs`**. Removing it unmasked the missing declaration; `psr/log ^3.0` is now declared explicitly in require-dev.

### Deliberately kept

- **`tests/functions.php` glob override + `webmozart/glob`** — native `glob()` bypasses userland stream wrappers entirely (no vfs library can fix this), and the override is still exercised: `EnumeratorTest` passes the wildcard include path `vfs://base/*` into `Finder->in()`, which routes through `glob()`.
- **`Enumerator::getFileFullPath()` test seam** — `realpath()` returns `false` on any virtual filesystem, so the mock seam is still needed.

The migration also uncovered a small bug in the new library (`stream_supports_lock()` wrongly reporting `false`); fixed separately in goaop/virtual-file-system#2. This PR does **not** depend on that fix.

## Verification

- Full suite on **highest** deps: 2486 tests, 2927 assertions, OK
- Full suite on **lowest** deps (`composer update --prefer-lowest`, resolves `goaop/virtual-file-system` 1.0.0): 2486 tests, 2927 assertions, OK
- The only remaining deprecation on highest deps is unrelated to vfs (`ReflectionProperty::setValue()` single-arg call in `tests/Functional/ReflectionFilenameTest.php:49`, pre-existing)
- `phpstan analyze --memory-limit=512M` (level 10) — no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0198oqTcvsK2j7x8bmesrf2x