### PR TITLE
Copy attribute arguments from AST — fix non-scalar and global-const attribute args (#601, #602)

### DIFF
--- a/src/Proxy/ClassProxyGenerator.php
+++ b/src/Proxy/ClassProxyGenerator.php
@@ -150,7 +150,7 @@ class ClassProxyGenerator
 
         // Copy PHP 8+ attributes from original class to proxy so that runtime
         // attribute inspection on proxy objects returns the same attributes
-        $classAttrGroups = AttributeGroupsGenerator::fromReflectionAttributes($originalClass->getAttributes());
+        $classAttrGroups = AttributeGroupsGenerator::fromReflector($originalClass);
         if (!empty($classAttrGroups)) {
             $classGenerator->addAttributeGroups($classAttrGroups);
         }

--- a/src/Proxy/Generator/AttributeGroupsGenerator.php
+++ b/src/Proxy/Generator/AttributeGroupsGenerator.php
@@ -12,11 +12,25 @@ declare(strict_types=1);
 
 namespace Go\Proxy\Generator;
 
+use LogicException;
 use PhpParser\BuilderFactory;
+use PhpParser\Node;
 use PhpParser\Node\Attribute;
 use PhpParser\Node\AttributeGroup;
 use PhpParser\Node\Name;
+use PhpParser\Node\Param;
+use PhpParser\Node\Stmt\ClassLike;
+use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\Node\Stmt\Function_;
+use PhpParser\Node\Stmt\Property;
+use PhpParser\NodeTraverser;
+use PhpParser\NodeVisitor\CloningVisitor;
+use PhpParser\NodeVisitorAbstract;
 use ReflectionAttribute;
+use ReflectionClass;
+use ReflectionFunctionAbstract;
+use ReflectionParameter;
+use ReflectionProperty;
 
 /**
  * Converts PHP reflection attributes to PhpParser AttributeGroup AST nodes.
@@ -31,13 +45,87 @@ final class AttributeGroupsGenerator
     private static ?BuilderFactory $factory = null;
 
     /**
-     * Converts an array of reflection attributes to PhpParser AttributeGroup nodes.
+     * Converts the attributes of a reflection element to PhpParser AttributeGroup nodes.
      *
-     * Each ReflectionAttribute produces one AttributeGroup (one #[...] line).
+     * When the reflection element exposes its AST node (Go\ParserReflection classes
+     * used during weaving), attribute name and argument expressions are cloned from
+     * the original AST verbatim. This never evaluates argument expressions, so
+     * non-scalar arguments (enum cases, new-in-initializer objects, closures in
+     * constant expressions) and environment-dependent constants (PHP_INT_MAX)
+     * are preserved exactly as written in the source (see issues #601 and #602).
+     *
+     * For native reflection the value-based {@see fromReflectionAttributes} fallback
+     * is used instead.
+     *
+     * @param ReflectionClass<object>|ReflectionFunctionAbstract|ReflectionParameter|ReflectionProperty $reflection
+     *
+     * @return list<AttributeGroup>
+     */
+    public static function fromReflector(
+        ReflectionClass|ReflectionFunctionAbstract|ReflectionParameter|ReflectionProperty $reflection
+    ): array {
+        $node = null;
+
+        // Duck-typed check for Go\ParserReflection classes exposing their AST node.
+        // For properties the attribute groups live on the Property statement (or the
+        // promoted constructor Param), not on the PropertyItem returned by getNode().
+        if ($reflection instanceof ReflectionProperty && method_exists($reflection, 'getTypeNode')) {
+            $node = $reflection->getTypeNode();
+        } elseif (method_exists($reflection, 'getNode')) {
+            $node = $reflection->getNode();
+        }
+
+        if ($node instanceof ClassLike
+            || $node instanceof ClassMethod
+            || $node instanceof Function_
+            || $node instanceof Param
+            || $node instanceof Property
+        ) {
+            return self::fromAttributeGroupNodes($node->attrGroups);
+        }
+
+        return self::fromReflectionAttributes($reflection->getAttributes());
+    }
+
+    /**
+     * Clones original AttributeGroup AST nodes for use in generated proxy code.
+     *
+     * Each original attribute produces one AttributeGroup (one #[...] line) with:
+     *  - the attribute name resolved to its fully-qualified form (via the resolvedName
+     *    attribute set by parser-reflection's NameResolver, falling back to the name
+     *    as written);
+     *  - argument expressions deep-cloned as-is, with any resolved class/function/const
+     *    names inside them fully qualified, so the expressions keep their meaning in
+     *    the generated proxy context and are never constant-folded.
+     *
+     * @param AttributeGroup[] $attrGroups
+     *
+     * @return list<AttributeGroup>
+     */
+    public static function fromAttributeGroupNodes(array $attrGroups): array
+    {
+        $groups = [];
+
+        foreach ($attrGroups as $attrGroup) {
+            foreach ($attrGroup->attrs as $attr) {
+                $groups[] = new AttributeGroup([self::cloneAttribute($attr)]);
+            }
+        }
+
+        return $groups;
+    }
+
+    /**
+     * Converts an array of reflection attributes to PhpParser AttributeGroup nodes
+     * using their evaluated argument values (native reflection fallback).
+     *
      * Attribute names are always emitted as fully-qualified to avoid namespace
-     * ambiguity inside generated proxy namespaces.
+     * ambiguity inside generated proxy namespaces. Attributes whose argument values
+     * cannot be represented as PHP code (e.g. arbitrary objects from new-in-initializer
+     * expressions) are skipped best-effort instead of aborting the whole generation.
      *
      * @param ReflectionAttribute<object>[] $reflectionAttributes
+     *
      * @return list<AttributeGroup>
      */
     public static function fromReflectionAttributes(array $reflectionAttributes): array
@@ -54,14 +142,63 @@ final class AttributeGroupsGenerator
             // the generated proxy's namespace context
             $fqName = new Name\FullyQualified(ltrim($attr->getName(), '\\'));
 
-            // BuilderFactory::args() handles named args (string key → Arg::$name)
-            // and normalises PHP scalar/array values to AST Expr nodes
-            $args = $factory->args($attr->getArguments());
+            try {
+                // BuilderFactory::args() handles named args (string key → Arg::$name)
+                // and normalises PHP scalar/array/enum values to AST Expr nodes
+                $args = $factory->args($attr->getArguments());
+            } catch (LogicException) {
+                // Argument value has no PHP-code representation (e.g. an object created
+                // by a new-in-initializer expression evaluated by native reflection).
+                // Skip this attribute instead of aborting the whole proxy generation.
+                continue;
+            }
 
             $groups[] = new AttributeGroup([new Attribute($fqName, $args)]);
         }
 
         return $groups;
+    }
+
+    /**
+     * Clones a single Attribute node with a fully-qualified name and deep-cloned
+     * argument expressions, leaving the original AST untouched.
+     */
+    private static function cloneAttribute(Attribute $attr): Attribute
+    {
+        // Prefer the fully-resolved class name attached by parser-reflection's
+        // NameResolver (preserveOriginalNames + replaceNodes=false mode)
+        $nameNode = $attr->name;
+        $resolved = $nameNode->getAttribute('resolvedName');
+        $fqName   = $resolved instanceof Name
+            ? new Name\FullyQualified($resolved->toString())
+            : new Name\FullyQualified(ltrim($nameNode->toString(), '\\'));
+
+        // Deep-clone argument expressions so the proxy AST shares no nodes with the
+        // original file AST, and fully qualify resolved names inside them so class
+        // constant fetches, enum cases etc. stay unambiguous in the proxy context.
+        // Unresolved names (e.g. unqualified global constants like PHP_INT_MAX with
+        // namespace fallback semantics) are kept as written.
+        $traverser = new NodeTraverser(
+            new CloningVisitor(),
+            new class extends NodeVisitorAbstract {
+                public function leaveNode(Node $node): ?Node
+                {
+                    if ($node instanceof Name && !($node instanceof Name\FullyQualified)) {
+                        $resolved = $node->getAttribute('resolvedName');
+                        if ($resolved instanceof Name) {
+                            return new Name\FullyQualified($resolved->toString(), $node->getAttributes());
+                        }
+                    }
+
+                    return null;
+                }
+            }
+        );
+
+        /** @var list<Node\Arg> $clonedArgs */
+        $clonedArgs = array_values($traverser->traverse($attr->args));
+
+        return new Attribute($fqName, $clonedArgs);
     }
 
     private static function getFactory(): BuilderFactory

--- a/src/Proxy/Generator/FunctionGenerator.php
+++ b/src/Proxy/Generator/FunctionGenerator.php
@@ -18,7 +18,6 @@ use PhpParser\Node\Stmt\Function_;
 use PhpParser\Parser;
 use PhpParser\ParserFactory;
 use PhpParser\PrettyPrinter\Standard;
-use ReflectionAttribute;
 use ReflectionFunction;
 use ReflectionNamedType;
 
@@ -47,8 +46,8 @@ final class FunctionGenerator
     /** @var Stmt[] */
     private array $stmts = [];
 
-    /** @var ReflectionAttribute<object>[] */
-    private array $reflectionAttributes = [];
+    /** @var \PhpParser\Node\AttributeGroup[] */
+    private array $attributeGroups = [];
 
     public function __construct(string $name)
     {
@@ -89,8 +88,9 @@ final class FunctionGenerator
             $generator->addParameter(ParameterGenerator::fromReflection($reflectionParam, $useWidening));
         }
 
-        // Attributes
-        $generator->reflectionAttributes = $function->getAttributes();
+        // Attributes: cloned from the AST when available (parser-reflection), so that
+        // argument expressions are never evaluated at weave time (issues #601, #602)
+        $generator->attributeGroups = AttributeGroupsGenerator::fromReflector($function);
 
         return $generator;
     }
@@ -189,7 +189,7 @@ final class FunctionGenerator
             $builder->addParam($param->getNode());
         }
 
-        foreach (AttributeGroupsGenerator::fromReflectionAttributes($this->reflectionAttributes) as $attrGroup) {
+        foreach ($this->attributeGroups as $attrGroup) {
             $builder->addAttribute($attrGroup);
         }
 

--- a/src/Proxy/Generator/MethodGenerator.php
+++ b/src/Proxy/Generator/MethodGenerator.php
@@ -20,7 +20,6 @@ use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Parser;
 use PhpParser\ParserFactory;
 use PhpParser\PrettyPrinter\Standard;
-use ReflectionAttribute;
 use ReflectionMethod;
 use ReflectionNamedType;
 
@@ -55,8 +54,8 @@ final class MethodGenerator
     /** @var ParameterGenerator[] */
     private array $parameters = [];
 
-    /** @var ReflectionAttribute<object>[] */
-    private array $reflectionAttributes = [];
+    /** @var \PhpParser\Node\AttributeGroup[] */
+    private array $attributeGroups = [];
 
     /** @var Stmt[]|null null for abstract methods */
     private ?array $stmts = [];
@@ -131,8 +130,9 @@ final class MethodGenerator
             $generator->addParameter(ParameterGenerator::fromReflection($reflectionParam, $useWidening));
         }
 
-        // Attributes
-        $generator->reflectionAttributes = $method->getAttributes();
+        // Attributes: cloned from the AST when available (parser-reflection), so that
+        // argument expressions are never evaluated at weave time (issues #601, #602)
+        $generator->attributeGroups = AttributeGroupsGenerator::fromReflector($method);
 
         return $generator;
     }
@@ -278,7 +278,7 @@ final class MethodGenerator
             $builder->addParam($param->getNode());
         }
 
-        foreach (AttributeGroupsGenerator::fromReflectionAttributes($this->reflectionAttributes) as $attrGroup) {
+        foreach ($this->attributeGroups as $attrGroup) {
             $builder->addAttribute($attrGroup);
         }
 

--- a/src/Proxy/Generator/ParameterGenerator.php
+++ b/src/Proxy/Generator/ParameterGenerator.php
@@ -16,7 +16,6 @@ use Go\ParserReflection\Resolver\TypeExpressionResolver;
 use PhpParser\BuilderFactory;
 use PhpParser\Node;
 use PhpParser\PrettyPrinter\Standard;
-use ReflectionAttribute;
 use ReflectionNamedType;
 use ReflectionParameter;
 
@@ -34,8 +33,8 @@ final class ParameterGenerator
     private bool $variadic;
     private ?ValueGenerator $defaultValue;
 
-    /** @var ReflectionAttribute<object>[] */
-    private array $reflectionAttributes = [];
+    /** @var Node\AttributeGroup[] */
+    private array $attributeGroups = [];
 
     public function __construct(
         string $name,
@@ -128,7 +127,9 @@ final class ParameterGenerator
             $defaultValue,
         );
 
-        $generator->reflectionAttributes = $param->getAttributes();
+        // Attributes: cloned from the AST when available (parser-reflection), so that
+        // argument expressions are never evaluated at weave time (issues #601, #602)
+        $generator->attributeGroups = AttributeGroupsGenerator::fromReflector($param);
 
         return $generator;
     }
@@ -183,7 +184,7 @@ final class ParameterGenerator
             $builder->setDefault($this->defaultValue->getNode());
         }
 
-        foreach (AttributeGroupsGenerator::fromReflectionAttributes($this->reflectionAttributes) as $attrGroup) {
+        foreach ($this->attributeGroups as $attrGroup) {
             $builder->addAttribute($attrGroup);
         }
 

--- a/src/Proxy/Part/AbstractInterceptedPropertyGenerator.php
+++ b/src/Proxy/Part/AbstractInterceptedPropertyGenerator.php
@@ -82,7 +82,7 @@ abstract class AbstractInterceptedPropertyGenerator implements PropertyNodeProvi
             }
         }
 
-        $attributeGroups = AttributeGroupsGenerator::fromReflectionAttributes($this->property->getAttributes());
+        $attributeGroups = AttributeGroupsGenerator::fromReflector($this->property);
         if ($attributeGroups !== []) {
             $generator->addAttributeGroups($attributeGroups);
         }

--- a/tests/Instrument/Transformer/WeavingTransformerTest.php
+++ b/tests/Instrument/Transformer/WeavingTransformerTest.php
@@ -316,6 +316,66 @@ class WeavingTransformerTest extends TestCase
         $this->assertStringContainsString('#[\FakeAttr]', $actual);
     }
 
+    /**
+     * PHP 8.0/8.1 non-scalar and non-foldable attribute arguments must be copied to the
+     * proxy from the AST verbatim: enum cases, new-in-initializer objects and global
+     * constants must never be evaluated at weave time.
+     *
+     * @see https://github.com/goaop/framework/issues/601
+     * @see https://github.com/goaop/framework/issues/602
+     */
+    public function testWeaverCopiesNonScalarAttributeArgumentsFromAst(): void
+    {
+        $adviceMatcher = $this->createMock(AdviceMatcherInterface::class);
+        $adviceMatcher
+            ->method('getAdvicesForClass')
+            ->willReturnCallback(function (ReflectionClass $refClass) {
+                // Only weave the target class — leave the enum and the attribute class alone
+                if ($refClass->getShortName() !== 'TestAttributeArgsClass') {
+                    return [];
+                }
+                $advices = [];
+                foreach ($refClass->getMethods() as $method) {
+                    $advisorId = "advisor.{$refClass->name}->{$method->name}";
+                    $advices[AspectContainer::METHOD_PREFIX][$method->name][$advisorId] = true;
+                }
+                return $advices;
+            });
+        $adviceMatcher
+            ->method('getAdvicesForFunctions')
+            ->willReturn([]);
+
+        $loader = $this
+            ->getMockBuilder(AspectLoader::class)
+            ->setConstructorArgs([$this->getContainerMock()])
+            ->getMock();
+        $transformer = new WeavingTransformer(
+            $this->kernel,
+            $adviceMatcher,
+            $this->cachePathManager,
+            $loader
+        );
+
+        $metadata = $this->loadTestMetadata('php81-attr-args');
+        $transformer->transform($metadata);
+
+        $actual   = $this->normalizeWhitespaces($metadata->source);
+        $expected = $this->normalizeWhitespaces($this->loadTestMetadata('php81-attr-args-woven')->source);
+        $this->assertEquals($expected, $actual);
+
+        $matches = [];
+        $this->assertSame(1, preg_match("/AOP_CACHE_DIR . '(.+)';$/m", $actual, $matches));
+        $actualProxyContent   = $this->normalizeWhitespaces((string) file_get_contents('vfs://' . $matches[1]));
+        $expectedProxyContent = $this->normalizeWhitespaces($this->loadTestMetadata('php81-attr-args-proxy')->source);
+        $this->assertEquals($expectedProxyContent, $actualProxyContent);
+
+        // The argument expressions must be preserved, not evaluated/constant-folded
+        $this->assertStringContainsString('\Test\ns1\AttrStatus::Active', $actualProxyContent);
+        $this->assertStringContainsString('new \ArrayObject([1, 2])', $actualProxyContent);
+        $this->assertStringContainsString('PHP_INT_MAX', $actualProxyContent);
+        $this->assertStringNotContainsString((string) PHP_INT_MAX, $actualProxyContent);
+    }
+
     public function testWeaverMovesInterceptedPropertiesToProxyHooks(): void
     {
         $adviceMatcher = $this->createMock(AdviceMatcherInterface::class);

--- a/tests/Instrument/Transformer/_files/php81-attr-args-proxy.php
+++ b/tests/Instrument/Transformer/_files/php81-attr-args-proxy.php
@@ -1,0 +1,30 @@
+<?php
+declare(strict_types=1);
+namespace Test\ns1;
+
+use Go\Aop\Framework\InterceptorInjector;
+use Go\Aop\Intercept\DynamicMethodInvocation;
+class TestAttributeArgsClass implements \Go\Aop\Proxy
+{
+    use TestAttributeArgsClass__AopProxied {
+        TestAttributeArgsClass__AopProxied::tagged as private __aop__tagged;
+        TestAttributeArgsClass__AopProxied::collected as private __aop__collected;
+    }
+    #[\Test\ns1\RichValueAttr(\Test\ns1\AttrStatus::Disabled, PHP_INT_MAX)]
+    public function tagged(
+        #[\Test\ns1\RichValueAttr(\Test\ns1\AttrStatus::Active)]
+        int $x = 8
+    ): int
+    {
+        /** @var DynamicMethodInvocation<self, int> $__joinPoint */
+        static $__joinPoint = InterceptorInjector::forMethod(self::class, 'tagged', ['advisor.Test\ns1\TestAttributeArgsClass->tagged'], $this->__aop__tagged(...));
+        return $__joinPoint->__invoke($this, \array_slice([$x], 0, \func_num_args()));
+    }
+    #[\Test\ns1\RichValueAttr(\Test\ns1\AttrStatus::Active, new \ArrayObject([1, 2]))]
+    public function collected(): array
+    {
+        /** @var DynamicMethodInvocation<self, array> $__joinPoint */
+        static $__joinPoint = InterceptorInjector::forMethod(self::class, 'collected', ['advisor.Test\ns1\TestAttributeArgsClass->collected'], $this->__aop__collected(...));
+        return $__joinPoint->__invoke($this);
+    }
+}

--- a/tests/Instrument/Transformer/_files/php81-attr-args-woven.php
+++ b/tests/Instrument/Transformer/_files/php81-attr-args-woven.php
@@ -1,0 +1,42 @@
+<?php
+declare(strict_types=1);
+namespace Test\ns1;
+
+/**
+ * PHP 8.0/8.1 — non-scalar and non-foldable attribute arguments on methods and
+ * parameters. Weaving must copy the attribute argument expressions from the AST
+ * verbatim: enum cases, new-in-initializer objects and global constants must
+ * never be evaluated at weave time (see issues #601 and #602).
+ * (Class-level attributes are tracked separately in issue #598.)
+ */
+enum AttrStatus: string
+{
+    case Active = 'active';
+    case Disabled = 'disabled';
+}
+
+#[\Attribute(\Attribute::TARGET_ALL)]
+class RichValueAttr
+{
+    public function __construct(
+        public mixed $value = null,
+        public mixed $extra = null,
+    ) {
+    }
+}
+
+trait TestAttributeArgsClass__AopProxied
+{
+    #[RichValueAttr(AttrStatus::Disabled, PHP_INT_MAX)]
+    public function tagged(#[RichValueAttr(AttrStatus::Active)] int $x = 8): int
+    {
+        return $x;
+    }
+
+    #[RichValueAttr(AttrStatus::Active, new \ArrayObject([1, 2]))]
+    public function collected(): array
+    {
+        return [];
+    }
+}
+include_once AOP_CACHE_DIR . '/Transformer/_files/php81-attr-args.php';

--- a/tests/Instrument/Transformer/_files/php81-attr-args.php
+++ b/tests/Instrument/Transformer/_files/php81-attr-args.php
@@ -1,0 +1,41 @@
+<?php
+declare(strict_types=1);
+namespace Test\ns1;
+
+/**
+ * PHP 8.0/8.1 — non-scalar and non-foldable attribute arguments on methods and
+ * parameters. Weaving must copy the attribute argument expressions from the AST
+ * verbatim: enum cases, new-in-initializer objects and global constants must
+ * never be evaluated at weave time (see issues #601 and #602).
+ * (Class-level attributes are tracked separately in issue #598.)
+ */
+enum AttrStatus: string
+{
+    case Active = 'active';
+    case Disabled = 'disabled';
+}
+
+#[\Attribute(\Attribute::TARGET_ALL)]
+class RichValueAttr
+{
+    public function __construct(
+        public mixed $value = null,
+        public mixed $extra = null,
+    ) {
+    }
+}
+
+class TestAttributeArgsClass
+{
+    #[RichValueAttr(AttrStatus::Disabled, PHP_INT_MAX)]
+    public function tagged(#[RichValueAttr(AttrStatus::Active)] int $x = 8): int
+    {
+        return $x;
+    }
+
+    #[RichValueAttr(AttrStatus::Active, new \ArrayObject([1, 2]))]
+    public function collected(): array
+    {
+        return [];
+    }
+}

--- a/tests/Proxy/Generator/AttributeGroupsGeneratorTest.php
+++ b/tests/Proxy/Generator/AttributeGroupsGeneratorTest.php
@@ -12,7 +12,10 @@ declare(strict_types=1);
 
 namespace Go\Proxy\Generator;
 
+use Go\ParserReflection\ReflectionFileNamespace;
 use Go\Proxy\Generator\Stubs\AttrGenHelperClass;
+use Go\Proxy\Generator\Stubs\AttrGenRichHelperClass;
+use PHPUnit\Framework\Attributes\RequiresPhp;
 use PHPUnit\Framework\TestCase;
 use PhpParser\Node\AttributeGroup;
 use PhpParser\PrettyPrinter\Standard;
@@ -113,5 +116,147 @@ class AttributeGroupsGeneratorTest extends TestCase
         $this->assertCount(1, $groups);
         $output = $this->generateGroups($groups);
         $this->assertStringContainsString('TestNoArgsAttr', $output);
+    }
+
+    /**
+     * Native reflection path: enum case arguments are representable as PHP code
+     * and must be emitted as fully-qualified class constant fetches (issue #601).
+     */
+    public function testNativeReflectionEnumCaseArgument(): void
+    {
+        $func   = new ReflectionFunction(self::STUBS_NS . '\attrGenHelper_enumArg');
+        $groups = AttributeGroupsGenerator::fromReflectionAttributes($func->getAttributes());
+        $this->assertCount(1, $groups);
+        $output = $this->generateGroups($groups);
+        $this->assertStringContainsString('\\' . self::STUBS_NS . '\\TestStatusEnum::Active', $output);
+    }
+
+    /**
+     * Native reflection path: attribute arguments without a PHP-code representation
+     * (objects from new-in-initializer) are skipped best-effort instead of aborting
+     * the whole proxy generation with a LogicException (issue #601).
+     */
+    public function testNativeReflectionSkipsUnrepresentableObjectArgument(): void
+    {
+        $func   = new ReflectionFunction(self::STUBS_NS . '\attrGenHelper_objectArg');
+        $groups = AttributeGroupsGenerator::fromReflectionAttributes($func->getAttributes());
+        $this->assertSame([], $groups);
+    }
+
+    /**
+     * AST path (fromReflector on parser-reflection): enum case arguments are cloned
+     * from the source expression with the enum name fully qualified (issue #601).
+     */
+    public function testAstPathPreservesEnumCaseArgument(): void
+    {
+        $func   = $this->getParserReflectionNamespace()->getFunction('attrGenHelper_enumArg');
+        $groups = AttributeGroupsGenerator::fromReflector($func);
+        $this->assertCount(1, $groups);
+        $output = $this->generateGroups($groups);
+        $this->assertStringContainsString('\\' . self::STUBS_NS . '\\TestRichAttr', $output);
+        $this->assertStringContainsString('\\' . self::STUBS_NS . '\\TestStatusEnum::Active', $output);
+    }
+
+    /**
+     * AST path: new-in-initializer arguments are preserved as expressions instead of
+     * crashing on the evaluated object value (issue #601).
+     */
+    public function testAstPathPreservesNewInInitializerArgument(): void
+    {
+        $func   = $this->getParserReflectionNamespace()->getFunction('attrGenHelper_objectArg');
+        $groups = AttributeGroupsGenerator::fromReflector($func);
+        $this->assertCount(1, $groups);
+        $output = $this->generateGroups($groups);
+        $this->assertStringContainsString('new \ArrayObject([1, 2])', $output);
+    }
+
+    /**
+     * AST path: global constants in attribute arguments are preserved as constant
+     * fetches — never evaluated (which crashes parser-reflection for global constants
+     * in namespaced files) and never constant-folded (issue #602).
+     */
+    public function testAstPathPreservesGlobalConstantArgument(): void
+    {
+        $func   = $this->getParserReflectionNamespace()->getFunction('attrGenHelper_globalConstArg');
+        $groups = AttributeGroupsGenerator::fromReflector($func);
+        $this->assertCount(1, $groups);
+        $output = $this->generateGroups($groups);
+        $this->assertStringContainsString('PHP_INT_MAX', $output);
+        $this->assertStringNotContainsString((string) PHP_INT_MAX, $output);
+    }
+
+    /**
+     * AST path via MethodGenerator: a method annotated with a global constant argument
+     * must generate without evaluating the attribute arguments (issue #602 crashed
+     * here with "Namespace  was not found in the file" during weaving).
+     */
+    public function testMethodGeneratorWithGlobalConstantAttributeArgument(): void
+    {
+        $method = $this->getParserReflectionNamespace()
+            ->getClass(AttrGenRichHelperClass::class)
+            ->getMethod('limited');
+        $gen    = MethodGenerator::fromReflection($method);
+        $output = $gen->generate();
+        $this->assertStringContainsString('#[\\' . self::STUBS_NS . '\\TestRichAttr(PHP_INT_MAX)]', $output);
+    }
+
+    /**
+     * AST path via MethodGenerator/ParameterGenerator: enum case arguments on methods
+     * and parameters are preserved as class constant fetches (issue #601).
+     */
+    public function testMethodGeneratorWithEnumCaseAttributeArguments(): void
+    {
+        $method = $this->getParserReflectionNamespace()
+            ->getClass(AttrGenRichHelperClass::class)
+            ->getMethod('tagged');
+        $gen    = MethodGenerator::fromReflection($method);
+        $output = $gen->generate();
+        $this->assertStringContainsString('\\' . self::STUBS_NS . '\\TestStatusEnum::Disabled', $output);
+        $this->assertStringContainsString('123', $output);
+        // Parameter attribute
+        $this->assertStringContainsString('\\' . self::STUBS_NS . '\\TestStatusEnum::Active', $output);
+    }
+
+    /**
+     * AST path: PHP 8.5 first-class callable syntax in attribute arguments (issue #601).
+     */
+    #[RequiresPhp('>= 8.5.0')]
+    public function testAstPathPreservesFccArgument(): void
+    {
+        require_once __DIR__ . '/Stubs/AttributeGroupsGenerator85Stubs.php';
+        $func   = $this->getParserReflectionNamespace(__DIR__ . '/Stubs/AttributeGroupsGenerator85Stubs.php')
+            ->getFunction('attrGenHelper85_fccArg');
+        $groups = AttributeGroupsGenerator::fromReflector($func);
+        $this->assertCount(1, $groups);
+        $output = $this->generateGroups($groups);
+        $this->assertStringContainsString('strlen(...)', $output);
+    }
+
+    /**
+     * AST path: PHP 8.5 closures in attribute arguments (issue #601).
+     */
+    #[RequiresPhp('>= 8.5.0')]
+    public function testAstPathPreservesClosureArgument(): void
+    {
+        require_once __DIR__ . '/Stubs/AttributeGroupsGenerator85Stubs.php';
+        $func   = $this->getParserReflectionNamespace(__DIR__ . '/Stubs/AttributeGroupsGenerator85Stubs.php')
+            ->getFunction('attrGenHelper85_closureArg');
+        $groups = AttributeGroupsGenerator::fromReflector($func);
+        $this->assertCount(1, $groups);
+        $output = $this->generateGroups($groups);
+        $this->assertStringContainsString('static function (int $x) : int', str_replace('):', ') :', $output));
+        $this->assertStringContainsString('$x * 2', $output);
+    }
+
+    /**
+     * Returns the stubs namespace parsed through parser-reflection (with NameResolver),
+     * so reflection objects expose their AST nodes via getNode().
+     */
+    private function getParserReflectionNamespace(?string $file = null): ReflectionFileNamespace
+    {
+        return new ReflectionFileNamespace(
+            $file ?? __DIR__ . '/Stubs/AttributeGroupsGeneratorStubs.php',
+            self::STUBS_NS
+        );
     }
 }

--- a/tests/Proxy/Generator/Stubs/AttributeGroupsGenerator85Stubs.php
+++ b/tests/Proxy/Generator/Stubs/AttributeGroupsGenerator85Stubs.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+/*
+ * Go! AOP framework
+ *
+ * @copyright Copyright 2026, Lisachenko Alexander <lisachenko.it@gmail.com>
+ *
+ * This source file is subject to the license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+// PHP 8.5-only syntax (closures and first-class callables in constant expressions).
+// This file is intentionally NOT autoloaded/eagerly loaded — it must only be
+// require_once'd from tests gated with #[RequiresPhp('>= 8.5.0')].
+
+namespace Go\Proxy\Generator\Stubs;
+
+#[TestRichAttr(strlen(...))]
+function attrGenHelper85_fccArg(): void {}
+
+#[TestRichAttr(static function (int $x): int { return $x * 2; })]
+function attrGenHelper85_closureArg(): void {}

--- a/tests/Proxy/Generator/Stubs/AttributeGroupsGeneratorStubs.php
+++ b/tests/Proxy/Generator/Stubs/AttributeGroupsGeneratorStubs.php
@@ -59,3 +59,42 @@ class AttrGenHelperClass
 
     public function methodWithAttrParam(#[TestNoArgsAttr] string $name): void {}
 }
+
+enum TestStatusEnum: string
+{
+    case Active = 'active';
+    case Disabled = 'disabled';
+}
+
+#[Attribute(Attribute::TARGET_ALL)]
+class TestRichAttr
+{
+    public function __construct(
+        public mixed $value = null,
+        public mixed $extra = null,
+    ) {}
+}
+
+#[TestRichAttr(TestStatusEnum::Active)]
+function attrGenHelper_enumArg(): void {}
+
+#[TestRichAttr(new \ArrayObject([1, 2]))]
+function attrGenHelper_objectArg(): void {}
+
+#[TestRichAttr(PHP_INT_MAX)]
+function attrGenHelper_globalConstArg(): void {}
+
+class AttrGenRichHelperClass
+{
+    #[TestRichAttr(TestStatusEnum::Disabled, 123)]
+    public function tagged(#[TestRichAttr(TestStatusEnum::Active)] int $x = 8): int
+    {
+        return $x;
+    }
+
+    #[TestRichAttr(PHP_INT_MAX)]
+    public function limited(): int
+    {
+        return PHP_INT_MAX;
+    }
+}


### PR DESCRIPTION
## Summary

Proxy generation crashed (aborting the whole weave) whenever an attribute on a woven class/method/parameter/property carried a non-scalar or non-foldable argument:

- enum case args — `#[RichAttr(Status::Active)]` — and new-in-initializer args — `#[RichAttr(new \ArrayObject([1, 2]))]` → `LogicException: Invalid value` (#601)
- PHP 8.5 closures / first-class callables in attribute args — `#[ExprAttr(strlen(...))]`, `#[ExprAttr(static function (int $x): int { return $x * 2; })]` → same crash (#601)
- global constants — `#[ExprAttr(PHP_INT_MAX)]` on a method of a namespaced class → `Go\ParserReflection\ReflectionException: Namespace  was not found in the file ...` (#602)

Even when it did not crash, argument expressions were constant-folded (e.g. `Foo::BAR` became its literal value) in the generated proxy.

## Root cause

`AttributeGroupsGenerator::fromReflectionAttributes()` copied attributes by feeding runtime `ReflectionAttribute::getArguments()` into `BuilderFactory::args()` / `BuilderHelpers::normalizeValue()`, which throws for any value without a plain PHP-code representation. For #602 the crash happened even earlier: calling `getAttributes()` on a parser-reflection reflector evaluates every argument expression through `NodeExpressionResolver`, which cannot resolve global constants in namespaced files (upstream parser-reflection 4.0.0 issue).

## Approach

`AttributeGroupsGenerator` gains an AST-first `fromReflector()` entry point:

- When the reflection element exposes its PhpParser node (duck-typed `getNode()` / `getTypeNode()`, i.e. the `Go\ParserReflection` classes used during weaving), attribute groups are cloned straight from the original AST: the attribute name is fully qualified via the `resolvedName` attribute set by parser-reflection's NameResolver (fallback: name as written), and argument expressions are deep-cloned verbatim with resolved names inside them fully qualified too. **No argument expression is ever evaluated at weave time** — `getAttributes()`/`getArguments()` are not called at all on the parser-reflection path.
- `MethodGenerator`, `ParameterGenerator`, `FunctionGenerator`, `ClassProxyGenerator` and `AbstractInterceptedPropertyGenerator` all go through `fromReflector()` now.
- The value-based `fromReflectionAttributes()` path stays as the fallback for native reflection. It now benefits from php-parser's enum normalization and skips attributes with unrepresentable argument values best-effort instead of aborting the whole proxy generation.

A woven `#[ExprAttr(PHP_INT_MAX)]` proxy now preserves the constant fetch (`PHP_INT_MAX`, unqualified with global fallback semantics — never folded to `9223372036854775807`), and enum cases / `new` expressions / closures are emitted exactly as written in the source.

## Tests

- `tests/Proxy/Generator/AttributeGroupsGeneratorTest.php`: new unit tests for both paths — native (enum-case args, best-effort skip of object args) and AST (enum cases, `new \ArrayObject([1, 2])`, `PHP_INT_MAX`, plus PHP 8.5-gated FCC/closure cases using a stub file that is only `require_once`'d inside `#[RequiresPhp('>= 8.5.0')]` tests).
- `tests/Instrument/Transformer/WeavingTransformerTest.php` + `_files/php81-attr-args{,-woven,-proxy}.php`: end-to-end golden weave of a class with enum-case, new-in-initializer and global-constant attribute args on methods/parameters.

Known limitations (out of scope here):
- Class-level attributes still break the token-based class→trait conversion — tracked separately in #598 (the fixture deliberately keeps attributes on methods/parameters).
- `AttributePointcut` matching still calls parser-reflection's `getAttributes()`, so a project that uses an *attribute pointcut* to match an element which also carries a global-constant attribute arg can still hit the upstream parser-reflection resolver bug. The weave/proxy-generation path reported in #602 no longer evaluates attribute arguments at all.

## Test evidence

PHP 8.5.10 (`php8.5 vendor/bin/phpunit`):
```
OK, but there were issues!
Tests: 2504, Assertions: 2995, Deprecations: 1.
```
PHP 8.4 (`php8.4 vendor/bin/phpunit`):
```
OK, but there were issues!
Tests: 2504, Assertions: 2987, Deprecations: 1, Skipped: 3.
```
PHP 8.6.0beta2 (informational):
```
OK, but there were issues!
Tests: 2504, Assertions: 2995, Deprecations: 1.
```
(The single deprecation pre-exists on master and is unrelated to this change.)

PHPStan level 10 (`php8.5 vendor/bin/phpstan analyze --memory-limit=1G`):
```
[OK] No errors
```

Fixes #601
Fixes #602

---
_Generated by [Claude Code](https://claude.ai/code/session_01WFMYyvE4hYRUoMS8mtKrHP)_