### PR TITLE
PHP 8.4 modernization batch: native lazy objects, property hooks, str_*/array_any + latent strpos bug fixes

### DIFF
--- a/docs/php84-limitations.md
+++ b/docs/php84-limitations.md
@@ -33,7 +33,9 @@ Asymmetric visibility on **non-readonly** properties _is_ preserved in generated
 
 ## Lazy Objects
 
-PHP 8.4 introduced `ReflectionClass::newLazyProxy()` and `ReflectionClass::newLazyGhost()` for [lazy object initialization](https://wiki.php.net/rfc/lazy-objects). While the framework's `Container` uses lazy objects internally, **lazy object initialization itself is not interceptable** by the framework. There is no join point for the moment a lazy proxy materializes its backing instance.
+PHP 8.4 introduced `ReflectionClass::newLazyProxy()` and `ReflectionClass::newLazyGhost()` for [lazy object initialization](https://wiki.php.net/rfc/lazy-objects). The framework's `Container` uses native lazy proxies for its own deferred services and for aspects registered by class name: retrieving such a service hands out a typed, `instanceof`-correct `newLazyProxy()` instance, and the registered factory only runs on the first real interaction with that object (classes PHP cannot make lazy — internal classes and their non-`stdClass` subclasses, abstract classes, enums, and readonly classes before PHP 8.5 — fall back to eager construction).
+
+However, **lazy object initialization itself is not interceptable** by the framework. There is no join point for the moment a lazy proxy materializes its backing instance.
 
 ## Summary Table
 

--- a/src/Aop/Pointcut/AndPointcut.php
+++ b/src/Aop/Pointcut/AndPointcut.php
@@ -56,13 +56,10 @@ final readonly class AndPointcut implements Pointcut
         ReflectionClass|ReflectionFileNamespace                $context,
         ReflectionMethod|ReflectionProperty|ReflectionFunction|null $reflector = null
     ): bool {
-        foreach ($this->pointcuts as $singlePointcut) {
-            if (!$singlePointcut->matches($context, $reflector)) {
-                return false;
-            }
-        }
-
-        return true;
+        return array_all(
+            $this->pointcuts,
+            fn(Pointcut $singlePointcut): bool => $singlePointcut->matches($context, $reflector)
+        );
     }
 
     public function getKind(): int

--- a/src/Aop/Pointcut/OrPointcut.php
+++ b/src/Aop/Pointcut/OrPointcut.php
@@ -53,13 +53,10 @@ final readonly class OrPointcut implements Pointcut
         ReflectionClass|ReflectionFileNamespace                $context,
         ReflectionMethod|ReflectionProperty|ReflectionFunction|null $reflector = null
     ): bool {
-        foreach ($this->pointcuts as $singlePointcut) {
-            if ($singlePointcut->matches($context, $reflector)) {
-                return true;
-            }
-        }
-
-        return false;
+        return array_any(
+            $this->pointcuts,
+            fn(Pointcut $singlePointcut): bool => $singlePointcut->matches($context, $reflector)
+        );
     }
 
     public function getKind(): int

--- a/src/Core/AdviceMatcher.php
+++ b/src/Core/AdviceMatcher.php
@@ -87,7 +87,7 @@ class AdviceMatcher implements AdviceMatcherInterface
         $parentClass  = $class->getParentClass();
 
         $originalClass = $class;
-        if ($parentClass && strpos($parentClass->name, AspectContainer::AOP_PROXIED_SUFFIX) !== false) {
+        if ($parentClass && str_contains($parentClass->name, AspectContainer::AOP_PROXIED_SUFFIX)) {
             $originalClass = $parentClass;
         }
 

--- a/src/Core/AspectContainer.php
+++ b/src/Core/AspectContainer.php
@@ -69,7 +69,8 @@ interface AspectContainer
     /**
      * Returns a service from the container.
      *
-     * Services registered via addLazyService() are constructed by their factory on first retrieval.
+     * Services registered via addLazyService() are returned as typed, instanceof-correct
+     * native lazy objects where possible; their factory runs on first actual use.
      *
      * @param class-string<T> $className Class-name of service to retrieve from the container
      * @return T
@@ -113,10 +114,11 @@ interface AspectContainer
      * Passing an aspect instance registers it immediately, exactly as before.
      *
      * Passing a class-name defers construction until the aspect is first needed (first
-     * advice hit, or aspect enumeration during weaving), keeping it off the hot boot path.
+     * advice hit, or first real interaction with the lazy object handed out during aspect
+     * enumeration on the weaving path), keeping it off the hot boot path.
      * An aspect with required constructor arguments must also pass a factory closure that
      * creates the instance; without a factory the class must be default-constructible,
-     * which is validated when the aspect materializes.
+     * which is validated when the aspect materializes into its lazy object.
      *
      * @param Aspect|class-string<Aspect> $aspectOrClassName Aspect instance or its class-name
      * @param null|Closure(AspectContainer $container): Aspect $aspectFactory Factory for deferred
@@ -142,9 +144,11 @@ interface AspectContainer
     /**
      * Adds a deferred service definition to the container.
      *
-     * Nothing is autoloaded or constructed at registration time: the factory closure is
-     * invoked once, on the first retrieval of the service (or when the service matches a
-     * getServicesByInterface() query), and the result is stored as a regular container entry.
+     * Nothing is autoloaded or constructed at registration time. On the first retrieval of
+     * the service (or when the service matches a getServicesByInterface() query) the entry
+     * materializes as a native lazy object of the service class, and the factory closure is
+     * invoked once, on the first actual interaction with that object. For classes that PHP
+     * cannot make lazy the factory is invoked at materialization time instead.
      *
      * @param class-string<T> $id Identifier of value to store, must be equal to the class-name
      * @param Closure(AspectContainer $container): T $lazyInitializationClosure

--- a/src/Core/CachedAspectLoader.php
+++ b/src/Core/CachedAspectLoader.php
@@ -12,8 +12,6 @@ declare(strict_types = 1);
 
 namespace Go\Core;
 
-use AllowDynamicProperties;
-use RuntimeException;
 use Go\Aop\Advisor;
 use Go\Aop\Aspect;
 use Go\Aop\Features;
@@ -23,12 +21,17 @@ use ReflectionClass;
 /**
  * Cached loader is responsible for faster initialization of pointcuts/advisors for concrete aspect
  *
- * @property AspectLoader $loader
  * @phpstan-import-type KernelOptions from AspectKernel
  */
-#[AllowDynamicProperties]
 class CachedAspectLoader extends AspectLoader
 {
+    /**
+     * Original loader, resolved from the container on first access and memoized in the backing store
+     */
+    private AspectLoader $loader {
+        get => $this->loader ??= $this->container->getService($this->loaderId);
+    }
+
     /**
      * Path to the cache directory
      */
@@ -98,17 +101,6 @@ class CachedAspectLoader extends AspectLoader
 
         return $loadedItems;
     }
-
-    public function __get(string $name): AspectLoader
-    {
-        if ($name === 'loader') {
-            $this->loader = $this->container->getService($this->loaderId);
-
-            return $this->loader;
-        }
-        throw new RuntimeException('Not implemented');
-    }
-
 
     /**
      * Loads pointcuts and advisors from the file

--- a/src/Core/Container.php
+++ b/src/Core/Container.php
@@ -39,6 +39,12 @@ class Container implements AspectContainer
     private array $factories = [];
 
     /**
+     * @var array<class-string, Closure(): void> Optional eager validators for deferred services, run when the
+     *      lazy object is created (first retrieval) - before the factory itself runs (first actual use)
+     */
+    private array $factoryValidators = [];
+
+    /**
      * @var array<class-string, list<string>> Holds information about mapping of interface tags into identifiers
      */
     private array $tags = [];
@@ -113,11 +119,19 @@ class Container implements AspectContainer
         }
 
         // Deferred registration by class-name: the aspect is constructed on first use
-        // (first advice hit, or aspect enumeration on the weaving path), so a hot-cache
-        // request never pays for aspects it does not touch.
+        // (first advice hit, or first real interaction with the lazy object handed out
+        // on the weaving path), so a hot-cache request never pays for aspects it does
+        // not touch.
         $this->addLazyService($aspectOrClassName, function () use ($aspectOrClassName, $aspectFactory): Aspect {
             return $this->materializeAspect($aspectOrClassName, $aspectFactory);
         });
+
+        // Cheap aspect declaration checks (implements Aspect, constructibility) run as soon
+        // as the service materializes into a lazy object, so misconfiguration surfaces on
+        // retrieval - construction itself stays deferred until first actual use.
+        $this->factoryValidators[$aspectOrClassName] = function () use ($aspectOrClassName, $aspectFactory): void {
+            $this->validateAspectRegistration($aspectOrClassName, $aspectFactory);
+        };
 
         // In debug mode the aspect's source file must be tracked as a resource right away:
         // SourceTransformingLoader consults resource freshness before any aspect materializes.
@@ -142,9 +156,9 @@ class Container implements AspectContainer
      */
     private function materializeAspect(string $aspectClassName, ?Closure $aspectFactory): Aspect
     {
-        if (!is_subclass_of($aspectClassName, Aspect::class)) {
-            throw new AspectException("Aspect class $aspectClassName must implement " . Aspect::class);
-        }
+        $this->validateAspectRegistration($aspectClassName, $aspectFactory);
+        assert(is_subclass_of($aspectClassName, Aspect::class));
+
         if ($aspectFactory !== null) {
             $aspect = $aspectFactory($this);
             if (!$aspect instanceof $aspectClassName) {
@@ -154,15 +168,30 @@ class Container implements AspectContainer
             return $aspect;
         }
 
-        $constructor = (new ReflectionClass($aspectClassName))->getConstructor();
-        if ($constructor !== null && $constructor->getNumberOfRequiredParameters() > 0) {
-            throw new AspectException(
-                "Aspect $aspectClassName has required constructor arguments, "
-                . "pass a factory closure to registerAspect() to create it"
-            );
-        }
-
         return new $aspectClassName();
+    }
+
+    /**
+     * Validates a deferred aspect registration without constructing the aspect
+     *
+     * @param null|Closure(AspectContainer): Aspect $aspectFactory
+     *
+     * @throws AspectException if the class is not an aspect or cannot be default-constructed
+     */
+    private function validateAspectRegistration(string $aspectClassName, ?Closure $aspectFactory): void
+    {
+        if (!is_subclass_of($aspectClassName, Aspect::class)) {
+            throw new AspectException("Aspect class $aspectClassName must implement " . Aspect::class);
+        }
+        if ($aspectFactory === null) {
+            $constructor = (new ReflectionClass($aspectClassName))->getConstructor();
+            if ($constructor !== null && $constructor->getNumberOfRequiredParameters() > 0) {
+                throw new AspectException(
+                    "Aspect $aspectClassName has required constructor arguments, "
+                    . "pass a factory closure to registerAspect() to create it"
+                );
+            }
+        }
     }
 
     /**
@@ -203,6 +232,7 @@ class Container implements AspectContainer
             throw new AspectException("Lazy service id must be a valid class name, \"$id\" given");
         }
         $this->factories[$id] = $lazyInitializationClosure;
+        unset($this->factoryValidators[$id]);
     }
 
     final public function getService(string $className): object
@@ -240,10 +270,10 @@ class Container implements AspectContainer
 
     final public function getServicesByInterface(string $interfaceTagClassName): array
     {
-        // Deferred services are only tagged once constructed, so materialize the
-        // pending ones that implement the requested interface first. This path is
-        // only taken during weaving/console runs, never on a hot request.
-        // Both the is_subclass_of() autoload and the factory invocation can re-enter
+        // Deferred services are only tagged once materialized (as lazy objects), so
+        // materialize the pending ones that implement the requested interface first.
+        // This path is only taken during weaving/console runs, never on a hot request.
+        // The is_subclass_of() autoload (and an eager fallback factory) can re-enter
         // this method (an aspect class autoloaded here goes through the weaving
         // pipeline, which enumerates aspects again), consuming pending factories from
         // under this loop - hence the existence re-check and the tolerant materialization.
@@ -262,7 +292,14 @@ class Container implements AspectContainer
     }
 
     /**
-     * Constructs a deferred service from its registered factory and stores it in the container
+     * Materializes a deferred service into a container entry and tags it by its interfaces.
+     *
+     * Where the class supports it, the entry becomes a native lazy proxy
+     * ({@see ReflectionClass::newLazyProxy()}): a typed, instanceof-correct instance of the
+     * service class whose factory only runs on first actual interaction with the object.
+     * Classes that PHP cannot make lazy (internal classes and their non-stdClass subclasses,
+     * abstract classes, enums, readonly classes before PHP 8.5) and ids that are not loadable
+     * classes fall back to invoking the factory eagerly, as before.
      */
     private function materializeService(string $id): void
     {
@@ -271,9 +308,78 @@ class Container implements AspectContainer
             // Already materialized by a re-entrant call (e.g. triggered through autoloading)
             return;
         }
-        // Unset before invoking the factory so a re-entrant lookup cannot run it twice
+        // Unset before touching the class: autoloading (class_exists/reflection below) or an
+        // eager fallback factory can re-enter the container and must not materialize $id twice
         unset($this->factories[$id]);
-        $this->add($id, $factory($this));
+
+        $validator = $this->factoryValidators[$id] ?? null;
+        unset($this->factoryValidators[$id]);
+        $validator?->__invoke();
+
+        $this->add($id, $this->createLazyService($id, $factory));
+    }
+
+    /**
+     * Creates the container entry for a deferred service: a native lazy proxy when possible,
+     * otherwise the eagerly invoked factory result
+     *
+     * @param Closure(AspectContainer): object $factory
+     */
+    private function createLazyService(string $id, Closure $factory): object
+    {
+        if (!class_exists($id)) {
+            return $factory($this);
+        }
+        $reflection = new ReflectionClass($id);
+        if (!self::isLazyProxyCompatible($reflection)) {
+            return $factory($this);
+        }
+
+        return $reflection->newLazyProxy(function () use ($id, $factory): object {
+            $instance = $factory($this);
+            if (!$instance instanceof $id) {
+                throw new AspectException("Service $id is not properly registered");
+            }
+
+            return $instance;
+        });
+    }
+
+    /**
+     * Whether PHP can create a native lazy proxy for the given class
+     *
+     * @param ReflectionClass<object> $reflection
+     */
+    private static function isLazyProxyCompatible(ReflectionClass $reflection): bool
+    {
+        if ($reflection->isInternal() || $reflection->isAbstract() || $reflection->isEnum()) {
+            return false;
+        }
+        // Lazy objects for readonly classes are only supported since PHP 8.5
+        if (PHP_VERSION_ID < 80500 && $reflection->isReadOnly()) {
+            return false;
+        }
+        // PHP creates lazy objects of classes without instance properties as already
+        // initialized, so the initializer (and with it the service factory) would never
+        // run - such services keep the eager construction path
+        $hasInstanceProperties = false;
+        foreach ($reflection->getProperties() as $property) {
+            if (!$property->isStatic() && !$property->isVirtual()) {
+                $hasInstanceProperties = true;
+                break;
+            }
+        }
+        if (!$hasInstanceProperties) {
+            return false;
+        }
+        // Subclasses of internal classes (other than stdClass) cannot be lazy
+        for ($parent = $reflection->getParentClass(); $parent !== false; $parent = $parent->getParentClass()) {
+            if ($parent->isInternal()) {
+                return $parent->getName() === 'stdClass';
+            }
+        }
+
+        return true;
     }
 
     final public function hasAnyResourceChangedSince(int $timestamp): bool

--- a/src/Core/LazyAdvisorAccessor.php
+++ b/src/Core/LazyAdvisorAccessor.php
@@ -12,7 +12,6 @@ declare(strict_types = 1);
 
 namespace Go\Core;
 
-use AllowDynamicProperties;
 use Go\Aop\Advisor;
 use Go\Aop\Aspect;
 use Go\Aop\AspectException;
@@ -22,36 +21,37 @@ use InvalidArgumentException;
 /**
  * Provides an interface for loading of advisors from the container
  */
-#[AllowDynamicProperties]
 final class LazyAdvisorAccessor
 {
+    /**
+     * @var array<string, Interceptor> Resolved interceptors, keyed by advisor identifier
+     */
+    private array $interceptors = [];
+
     /**
      * Accessor constructor
      */
     public function __construct(
-        protected readonly AspectContainer $container,
-        protected readonly AspectLoader $loader
+        private readonly AspectContainer $container,
+        private readonly AspectLoader $loader
     ) {}
 
     /**
-     * Returns the Interceptor for the given advisor name, loading and caching it on first access.
-     *
-     * Prefer this over the magic property accessor when the name is a variable — PHP's `__get()` is
-     * identical in behaviour, but static-analysis tools cannot track its return type for variable keys.
+     * Returns the Interceptor for the given advisor name, loading and caching it on first access
      *
      * @throws InvalidArgumentException if referenced value is not an advisor or its advice is not an Interceptor
      */
     public function getInterceptor(string $name): Interceptor
     {
-        return $this->__get($name);
+        return $this->interceptors[$name] ??= $this->loadInterceptor($name);
     }
 
     /**
-     * Magic advice accessor
+     * Resolves an interceptor from the container, loading the owning aspect on demand
      *
      * @throws InvalidArgumentException if referenced value is not an advisor or its advice is not an Interceptor
      */
-    public function __get(string $name): Interceptor
+    private function loadInterceptor(string $name): Interceptor
     {
         if (!$this->container->has($name)) {
             [$aspectName] = explode('->', $name, 2);
@@ -60,7 +60,6 @@ final class LazyAdvisorAccessor
             }
             $aspectInstance = $this->container->getService($aspectName);
             $this->loader->loadAndRegister($aspectInstance);
-
         }
         $advisor = $this->container->getValue($name);
         if (!$advisor instanceof Advisor) {
@@ -70,8 +69,7 @@ final class LazyAdvisorAccessor
         if (!$advice instanceof Interceptor) {
             throw new InvalidArgumentException("Advice {$name} is not an Interceptor");
         }
-        $this->$name = $advice;
 
-        return $this->$name;
+        return $advice;
     }
 }

--- a/src/Instrument/FileSystem/Enumerator.php
+++ b/src/Instrument/FileSystem/Enumerator.php
@@ -81,7 +81,7 @@ class Enumerator
         $iterator = $finder->getIterator();
 
         // on Windows platform the default iterator is unable to rewind, not sure why
-        if (strpos(PHP_OS, 'WIN') === 0) {
+        if (PHP_OS_FAMILY === 'Windows') {
             $iterator = new ArrayIterator(iterator_to_array($iterator));
         }
 
@@ -105,30 +105,17 @@ class Enumerator
 
             $fullPath = $this->getFileFullPath($file);
             // Do not touch files that not under rootDirectory
-            if (strpos($fullPath, $rootDirectory) !== 0) {
+            if (!str_starts_with($fullPath, $rootDirectory)) {
                 return false;
             }
 
-            if (!empty($includePaths)) {
-                $found = false;
-                foreach ($includePaths as $includePattern) {
-                    if (fnmatch("{$includePattern}*", $fullPath, FNM_NOESCAPE)) {
-                        $found = true;
-                        break;
-                    }
-                }
-                if (!$found) {
-                    return false;
-                }
+            $matchesPattern = fn(string $pattern): bool => fnmatch("{$pattern}*", $fullPath, FNM_NOESCAPE);
+
+            if (!empty($includePaths) && !array_any($includePaths, $matchesPattern)) {
+                return false;
             }
 
-            foreach ($excludePaths as $excludePattern) {
-                if (fnmatch("{$excludePattern}*", $fullPath, FNM_NOESCAPE)) {
-                    return false;
-                }
-            }
-
-            return true;
+            return !array_any($excludePaths, $matchesPattern);
         };
     }
 
@@ -155,7 +142,9 @@ class Enumerator
         $inPaths = [];
 
         foreach ($this->includePaths as $path) {
-            if (strpos($path, $this->rootDirectory, 0) === false) {
+            // Include paths must be below the root directory: this is a prefix check,
+            // a path merely containing the root somewhere else must be rejected
+            if (!str_starts_with($path, $this->rootDirectory)) {
                 throw new UnexpectedValueException(sprintf('Path %s is not in %s', $path, $this->rootDirectory));
             }
 

--- a/src/Instrument/PathResolver.php
+++ b/src/Instrument/PathResolver.php
@@ -63,7 +63,7 @@ class PathResolver
 
         // resolve path parts (single dot, double dot and double delimiters)
         $path = str_replace(['/', '\\'], DIRECTORY_SEPARATOR, $path);
-        if (strpos($path, '.') !== false) {
+        if (str_contains($path, '.')) {
             $parts     = explode(DIRECTORY_SEPARATOR, $path);
             $absolutes = [];
             foreach ($parts as $part) {

--- a/src/Instrument/Transformer/StreamMetaData.php
+++ b/src/Instrument/Transformer/StreamMetaData.php
@@ -21,11 +21,33 @@ use function is_array, is_resource;
 
 /**
  * Stream metadata object
- *
- * @property-read string $source
  */
 class StreamMetaData
 {
+    /**
+     * Source code represented by the token stream.
+     *
+     * Reading rebuilds the source directly from {@see self::$tokenStream}. Writing is
+     * deprecated: it re-tokenizes the given source into the token stream instead - use
+     * {@see self::setTokenStreamFromRawTokens()} directly.
+     */
+    public string $source {
+        get {
+            $transformedSource = '';
+            foreach ($this->tokenStream as $token) {
+                if ($token->id !== 0) {
+                    $transformedSource .= $token->text;
+                }
+            }
+
+            return $transformedSource;
+        }
+        set {
+            trigger_error('Setting StreamMetaData->source is deprecated, use tokenStream instead', E_USER_DEPRECATED);
+            $this->setTokenStreamFromRawTokens(...PhpToken::tokenize($value));
+        }
+    }
+
     /**
      * Mapping between array keys and properties
      *
@@ -105,57 +127,6 @@ class StreamMetaData
         }
         $this->syntaxTree = ReflectionEngine::parseFile($this->uri, $source);
         $this->setTokenStreamFromRawTokens(...ReflectionEngine::getParser()->getTokens());
-    }
-
-    /**
-     * @inheritDoc
-     */
-    public function __get(string $name): mixed
-    {
-        if ($name === 'source') {
-            return $this->getSource();
-        }
-
-        return null;
-    }
-
-    /**
-     * @inheritDoc
-     */
-    public function __set(string $name, mixed $value): void
-    {
-        if ($name === 'source' && is_string($value)) {
-            trigger_error('Setting StreamMetaData->source is deprecated, use tokenStream instead', E_USER_DEPRECATED);
-            $this->setSource($value);
-        }
-    }
-
-    /**
-     * Returns source code directly from tokens
-     */
-    private function getSource(): string
-    {
-        $transformedSource = '';
-        foreach ($this->tokenStream as $token) {
-            if ($token->id !== 0) {
-                $transformedSource .= $token->text;
-            }
-        }
-
-        return $transformedSource;
-    }
-
-    /**
-     * Sets the new source for this file
-     *
-     * @TODO: Unfortunately, AST won't be changed, so please be accurate during transformation
-     *
-     * @param string $newSource
-     */
-    private function setSource(string $newSource): void
-    {
-        $rawTokens = PhpToken::tokenize($newSource);
-        $this->setTokenStreamFromRawTokens(...$rawTokens);
     }
 
     /**

--- a/src/Lang/Attribute/AbstractAttribute.php
+++ b/src/Lang/Attribute/AbstractAttribute.php
@@ -12,8 +12,6 @@ declare(strict_types=1);
 
 namespace Go\Lang\Attribute;
 
-use BadMethodCallException;
-
 abstract class AbstractAttribute
 {
     /**
@@ -24,26 +22,4 @@ abstract class AbstractAttribute
         readonly public string $expression = '',
         readonly public int    $order = 0,
     ) {}
-
-    /**
-     * Error handler for unknown property accessor in attribute class.
-     */
-    public function __get(string $name): never
-    {
-        throw new BadMethodCallException(
-            sprintf("Unknown property '%s' on attribute '%s'.", $name, static::class)
-        );
-    }
-
-    /**
-     * Error handler for unknown property mutator in attribute class.
-     *
-     * @param mixed $value Property value
-     */
-    public function __set(string $name, mixed $value): never
-    {
-        throw new BadMethodCallException(
-            sprintf("Unknown property '%s' on attribute '%s'.", $name, static::class)
-        );
-    }
 }

--- a/src/Proxy/Part/AbstractInterceptedPropertyGenerator.php
+++ b/src/Proxy/Part/AbstractInterceptedPropertyGenerator.php
@@ -98,11 +98,10 @@ abstract class AbstractInterceptedPropertyGenerator implements PropertyNodeProvi
             return $type->getName() === 'array';
         }
         if ($type instanceof ReflectionUnionType) {
-            foreach ($type->getTypes() as $unionType) {
-                if ($unionType instanceof ReflectionNamedType && $unionType->getName() === 'array') {
-                    return true;
-                }
-            }
+            return array_any(
+                $type->getTypes(),
+                fn($unionType): bool => $unionType instanceof ReflectionNamedType && $unionType->getName() === 'array'
+            );
         }
 
         return false;

--- a/tests/Core/ContainerTest.php
+++ b/tests/Core/ContainerTest.php
@@ -178,7 +178,7 @@ class ContainerTest extends TestCase
         $this->container->getService(First::class);
     }
 
-    public function testLazyServiceIsNotConstructedUntilFirstRetrieval(): void
+    public function testLazyServiceIsNotConstructedUntilFirstUse(): void
     {
         $initialized = false;
         $container = new Container();
@@ -191,10 +191,17 @@ class ContainerTest extends TestCase
         $this->assertTrue($container->has(PointcutLexer::class));
         $this->assertFalse($initialized, 'Factory should not have been called yet');
 
-        // First retrieval constructs the service exactly once
+        // Retrieval hands out a typed, instanceof-correct lazy proxy without running the factory
         $value = $container->getService(PointcutLexer::class);
         $this->assertInstanceOf(PointcutLexer::class, $value);
-        $this->assertTrue($initialized, 'Factory should have been called on first retrieval');
+        $this->assertFalse($initialized, 'Factory should not run on retrieval');
+        $this->assertTrue((new \ReflectionClass(PointcutLexer::class))->isUninitializedLazyObject($value));
+        $this->assertSame($value, $container->getService(PointcutLexer::class));
+
+        // First real interaction with the object runs the factory exactly once
+        $value->lex('public');
+        $this->assertTrue($initialized, 'Factory should have been called on first use');
+        $this->assertFalse((new \ReflectionClass(PointcutLexer::class))->isUninitializedLazyObject($value));
         $this->assertSame($value, $container->getService(PointcutLexer::class));
     }
 
@@ -226,8 +233,13 @@ class ContainerTest extends TestCase
         $this->assertTrue($this->container->has(LoggingAspect::class));
         $this->assertFalse($constructed, 'Aspect should not have been constructed at registration');
 
+        // Retrieval returns an instanceof-correct lazy object, construction is still deferred
         $aspect = $this->container->getService(LoggingAspect::class);
         $this->assertInstanceOf(LoggingAspect::class, $aspect);
+        $this->assertFalse($constructed, 'Aspect should not have been constructed by retrieval');
+
+        // First real interaction with the aspect object triggers the factory
+        (new \ReflectionClass(LoggingAspect::class))->initializeLazyObject($aspect);
         $this->assertTrue($constructed);
     }
 
@@ -238,6 +250,52 @@ class ContainerTest extends TestCase
         $aspects = $this->container->getServicesByInterface(Aspect::class);
         $this->assertArrayHasKey(DoSomethingAspect::class, $aspects);
         $this->assertInstanceOf(DoSomethingAspect::class, $aspects[DoSomethingAspect::class]);
+    }
+
+    public function testLazyAspectEnumerationHandsOutUninitializedLazyObjects(): void
+    {
+        $constructed = false;
+        $this->container->registerAspect(
+            StatefulTestAspect::class,
+            function () use (&$constructed): StatefulTestAspect {
+                $constructed = true;
+
+                return new StatefulTestAspect(42);
+            }
+        );
+
+        $aspects = $this->container->getServicesByInterface(Aspect::class);
+        $aspect  = $aspects[StatefulTestAspect::class];
+
+        // instanceof is correct before initialization, and the factory has not run yet
+        $this->assertInstanceOf(Aspect::class, $aspect);
+        $this->assertInstanceOf(StatefulTestAspect::class, $aspect);
+        $this->assertTrue((new \ReflectionClass(StatefulTestAspect::class))->isUninitializedLazyObject($aspect));
+        $this->assertFalse($constructed, 'Enumeration should not construct the aspect');
+
+        // A real method call transparently initializes the lazy object and delegates to it
+        $this->assertSame(42, $aspect->getState());
+        $this->assertTrue($constructed, 'First method call should construct the aspect');
+        $this->assertFalse((new \ReflectionClass(StatefulTestAspect::class))->isUninitializedLazyObject($aspect));
+    }
+
+    public function testPropertylessServiceFallsBackToEagerConstruction(): void
+    {
+        // PHP creates lazy objects of property-less classes as already initialized,
+        // which would silently skip the factory - the container must construct these eagerly
+        $constructed = false;
+        $this->container->registerAspect(
+            DoSomethingAspect::class,
+            function () use (&$constructed): DoSomethingAspect {
+                $constructed = true;
+
+                return new DoSomethingAspect();
+            }
+        );
+
+        $aspect = $this->container->getService(DoSomethingAspect::class);
+        $this->assertInstanceOf(DoSomethingAspect::class, $aspect);
+        $this->assertTrue($constructed, 'Factory of a property-less service must run at materialization');
     }
 
     public function testLazyAspectWithRequiredConstructorArgsNeedsFactory(): void
@@ -275,6 +333,8 @@ class ContainerTest extends TestCase
 
         $aspects = $this->container->getServicesByInterface(Aspect::class);
         $this->assertSame([DoSomethingAspect::class, EnumMethodAspect::class], array_keys($aspects));
+        // DoSomethingAspect has no instance properties, so it materializes eagerly
+        // through the re-registered factory (see testPropertylessServiceFallsBackToEagerConstruction)
         $this->assertTrue($replaced, 'Re-registered factory should have been used');
     }
 
@@ -296,5 +356,18 @@ class ContainerTest extends TestCase
         $aspects = $this->container->getServicesByInterface(Aspect::class);
         $this->assertArrayHasKey(DoSomethingAspect::class, $aspects);
         $this->assertArrayHasKey(EnumMethodAspect::class, $aspects);
+    }
+}
+
+/**
+ * Stateful aspect fixture: has an instance property, so PHP can create a true lazy proxy for it
+ */
+class StatefulTestAspect implements Aspect
+{
+    public function __construct(private readonly int $state) {}
+
+    public function getState(): int
+    {
+        return $this->state;
     }
 }

--- a/tests/Functional/ReflectionFilenameTest.php
+++ b/tests/Functional/ReflectionFilenameTest.php
@@ -46,7 +46,8 @@ class ReflectionFilenameTest extends BaseFunctionalTestCase
         parent::tearDown();
         $reflectedClass    = new \ReflectionClass(FilterInjectorTransformer::class);
         $reflectedProperty = $reflectedClass->getProperty('kernel');
-        $reflectedProperty->setValue(null);
+        // Static property: the two-argument form (null object) is the non-deprecated way
+        $reflectedProperty->setValue(null, null);
     }
 
     public function testReflectionFilenameIsCorrect()

--- a/tests/Instrument/FileSystem/EnumeratorTest.php
+++ b/tests/Instrument/FileSystem/EnumeratorTest.php
@@ -125,4 +125,33 @@ class EnumeratorTest extends TestCase
 
         $this->assertEquals($expectedPaths, $testPaths);
     }
+
+    /**
+     * Regression test: the include-path check must be a prefix test.
+     *
+     * The former `strpos($path, $rootDirectory, 0) === false` was a substring-anywhere
+     * test, so an include path that merely CONTAINED the root directory somewhere in the
+     * middle (here: '/somewhere/base/other' contains root '/base') was wrongly accepted
+     * instead of being rejected as outside the root.
+     */
+    public function testIncludePathMerelyContainingRootDirectoryIsRejected(): void
+    {
+        $enumerator = new Enumerator('/base', ['/somewhere/base/other']);
+
+        $this->expectException(\UnexpectedValueException::class);
+        $this->expectExceptionMessage('Path /somewhere/base/other is not in /base');
+        $enumerator->enumerate();
+    }
+
+    /**
+     * Sanity check for the fixed prefix test: include paths below the root are accepted
+     * (no UnexpectedValueException; Finder then fails on the nonexistent directory itself)
+     */
+    public function testIncludePathBelowRootDirectoryPassesTheRootCheck(): void
+    {
+        $enumerator = new Enumerator('vfs://base', ['vfs://base/sub']);
+
+        $files = iterator_to_array($enumerator->enumerate());
+        $this->assertNotEmpty($files);
+    }
 }

--- a/tests/Instrument/Transformer/StreamMetaDataTest.php
+++ b/tests/Instrument/Transformer/StreamMetaDataTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types = 1);
+/*
+ * Go! AOP framework
+ *
+ * @copyright Copyright 2026, Lisachenko Alexander <lisachenko.it@gmail.com>
+ *
+ * This source file is subject to the license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Go\Instrument\Transformer;
+
+use PHPUnit\Framework\TestCase;
+
+class StreamMetaDataTest extends TestCase
+{
+    public function testSourceIsRebuiltFromTokenStream(): void
+    {
+        $source   = '<?php echo "hello world"; ?>';
+        $metadata = new StreamMetaData(fopen('php://input', 'rb'), $source);
+
+        $this->assertSame($source, $metadata->source);
+
+        // Mutating the token stream is reflected by subsequent reads
+        foreach ($metadata->tokenStream as $token) {
+            $token->text = str_replace('hello', 'brave new', $token->text);
+        }
+        $this->assertSame('<?php echo "brave new world"; ?>', $metadata->source);
+    }
+
+    public function testSettingSourceIsDeprecatedButRetokenizes(): void
+    {
+        $metadata = new StreamMetaData(fopen('php://input', 'rb'), '<?php echo "old"; ?>');
+
+        $deprecations = [];
+        set_error_handler(function (int $errno, string $errstr) use (&$deprecations): bool {
+            $deprecations[] = $errstr;
+
+            return true;
+        }, E_USER_DEPRECATED);
+        try {
+            $metadata->source = '<?php echo "new"; ?>';
+        } finally {
+            restore_error_handler();
+        }
+
+        $this->assertSame(['Setting StreamMetaData->source is deprecated, use tokenStream instead'], $deprecations);
+        $this->assertSame('<?php echo "new"; ?>', $metadata->source);
+    }
+}

--- a/tests/Instrument/Transformer/WeavingTransformerTest.php
+++ b/tests/Instrument/Transformer/WeavingTransformerTest.php
@@ -133,7 +133,8 @@ class WeavingTransformerTest extends TestCase
         $this->assertEquals($expected, $actual);
 
         $proxyContent = file_get_contents($this->cachePathManager->getCacheDir() . '/Transformer/_files/class-typehint.php');
-        $this->assertFalse(strpos($proxyContent, '\\\\Exception'));
+        $this->assertNotFalse($proxyContent);
+        $this->assertStringNotContainsString('\\\\Exception', $proxyContent);
     }
 
     /**


### PR DESCRIPTION
# Modernization batch (issues #606, #607, #609)

Three commits, one per issue. Gates on every commit: `php8.5 vendor/bin/phpunit` green, `php8.4 vendor/bin/phpunit` green, PHPStan level 10 clean (no new baseline entries).

## Task 1 — native lazy objects (Partially fixes #606)

**`Container`**: `materializeService()` now materializes services registered via `addLazyService()` as native lazy proxies (`ReflectionClass::newLazyProxy()`). Retrieval hands out a typed, `instanceof`-correct instance of the service class; the registered factory only runs on the first real interaction with the object. `registerAspect()` by class name gains an eager validation step (implements `Aspect`, default-constructibility) that runs when the entry materializes, so misconfiguration still surfaces on retrieval while construction stays deferred.

**`CachedAspectLoader`**: the `@property` + `__get('loader')` ghost pattern becomes a hooked property that memoizes the container lookup in its backing store; the magic method, its `RuntimeException` fallthrough and `#[AllowDynamicProperties]` are removed.

**Behavior-parity notes for the lazy-object change:**
- Public API unchanged (`add`/`addLazyService`/`getService`/`getValue`/`has`/`getServicesByInterface`/`registerAspect`); `has()` and interface/tag introspection behave as before — materialization still tags by interface and registers the class file as a resource, without running the factory.
- Nothing is autoloaded or constructed at registration time, exactly as before.
- Classes PHP cannot make lazy fall back to the previous eager construction path: internal classes and their non-`stdClass` subclasses, abstract classes, enums, readonly classes before PHP 8.5, non-class ids — and notably **classes without instance properties**, because PHP creates lazy objects of property-less classes as already initialized, which would silently skip the factory (covered by a dedicated test).
- Invalid aspect registrations (`registerAspect(stdClass::class)`, missing factory for required ctor args) still throw `AspectException` on retrieval, not later.
- A factory returning an incompatible object still surfaces as `AspectException` ("is not properly registered" / "returned an incompatible object"), now at initialization time.
- Timing shifts by design: factory side effects (e.g. `FilterInjectorTransformer` registering the stream filter, `CachedAspectLoader` reading kernel options) run at first use of the service instead of first retrieval — always before the service can do anything.

**Item 3 of #606 (`ReflectionConstructorInvocation::proceed()`) was evaluated and skipped**, as the issue anticipated: a lazy-ghost sequence there would either have to be initialized immediately (no gain over the current explicit sequence) or defer constructor side effects and change observable behavior around `getThis()`/Before advices; `newLazyGhost()` also rejects classes (internal, property-less) that `newInstanceWithoutConstructor()` + explicit ctor invoke handles today. Left for a follow-up, hence "Partially fixes".

`docs/php84-limitations.md` now accurately describes what the container does with lazy objects.

**Tests**: `ContainerTest` gained laziness-semantics coverage — factory not run at registration/retrieval/enumeration, `instanceof` and `isUninitializedLazyObject()` correct before initialization, first method call initializes and delegates, property-less services construct eagerly through their (possibly re-registered) factory.

## Task 2 — property hooks instead of internal `__get`/`__set` (Fixes #607)

- **`StreamMetaData`**: the magic `source` pair becomes a native hooked property — `get` still rebuilds the source from the token stream, `set` still triggers the existing `E_USER_DEPRECATED` notice and re-tokenizes. `@property-read` docblock removed; all in-repo accesses are reads and pass unchanged; new `StreamMetaDataTest` covers both hook paths.
- **`LazyAdvisorAccessor`**: `#[AllowDynamicProperties]` + `__get` dynamic-property cache replaced by a typed `array<string, Interceptor>` cache behind the existing `getInterceptor()`; its only call site (`InterceptorInjector`) already used `getInterceptor()`, no `->{$name}` magic access exists in the repo.
- **`AbstractAttribute`**: `__get`/`__set` existed only to throw `BadMethodCallException`; nothing in the repo relies on that, both removed.
- `CachedAspectLoader.__get` was intentionally handled in Task 1 (per issue scoping).

## Task 3 — `str_*`/`array_any`/`array_all` + latent strpos bugs (Fixes #609)

**Bug fixes with regression tests:**
- `Enumerator::getInPaths()` used `strpos($path, $root, 0) === false` — a substring-*anywhere* test — as a prefix check, so an include path merely *containing* the root elsewhere (e.g. `/somewhere/base/other` for root `/base`) was wrongly accepted. Now `!str_starts_with(...)`; `EnumeratorTest::testIncludePathMerelyContainingRootDirectoryIsRejected` proves the fixed behavior (plus a positive prefix sanity test).
- `WeavingTransformerTest` `assertFalse(strpos($proxyContent, '\\\\Exception'))` (also passes on a match at offset 0) → `assertStringNotContainsString()`.

**Modernizations:** `PHP_OS` `'WIN'` sniff → `PHP_OS_FAMILY === 'Windows'`; `Enumerator` filter prefix check → `str_starts_with()`; include/exclude `fnmatch` loops → `array_any()`; `PathResolver`/`AdviceMatcher` → `str_contains()`; `OrPointcut`/`AndPointcut` `matches()` → `array_any()`/`array_all()`; `AbstractInterceptedPropertyGenerator` union-type scan → `array_any()`.

**Deprecation cleanup:** `ReflectionFilenameTest` single-argument `ReflectionProperty::setValue()` → two-argument form for the static property.

> **Note:** `src/Instrument/Transformer/WeavingTransformer.php` is deliberately untouched — it is being rewritten on another branch, so its `array_find`/`end()`/`strpos` sites are excluded from this PR by design.

## Test evidence

| Gate | Result |
|---|---|
| `php8.4 vendor/bin/phpunit` | OK — 2500 tests, 2987 assertions, 0 deprecations (1 pre-existing skip: a PHP ≥ 8.5 feature test) |
| `php8.5 vendor/bin/phpunit` | OK — 2500 tests, 2990 assertions, 0 deprecations |
| `php8.6 (8.6.0beta2) vendor/bin/phpunit` (informational) | OK — 2500 tests, 2990 assertions, 0 deprecations |
| `php8.5 vendor/bin/phpstan analyze` (level 10) | No errors, no new baseline entries |

Before this batch the suite ended with 1 deprecation (the `setValue()` call); it now ends with zero on all three PHP versions.

Partially fixes #606 (items 1, 2, 4; item 3 evaluated and deliberately skipped)
Fixes #607
Fixes #609

---
_Generated by [Claude Code](https://claude.ai/code/session_01WFMYyvE4hYRUoMS8mtKrHP)_