### PR TITLE
Finish audit process cleanup: retire extract() idiom, harden cache flushing

### DIFF
--- a/src/Instrument/ClassLoading/CachePathManager.php
+++ b/src/Instrument/ClassLoading/CachePathManager.php
@@ -148,6 +148,11 @@ class CachePathManager
                 $this->cacheStateLoaded = true;
             }
         }
+
+        // Flush pending cache records while the runtime environment is still fully
+        // intact: object destruction order during shutdown is unspecified, so relying
+        // on __destruct() alone can run the write after collaborators are torn down
+        register_shutdown_function($this->flushSilently(...));
     }
 
     /**
@@ -302,11 +307,28 @@ class CachePathManager
     /**
      * Automatic destructor saves all new changes into the cache
      *
+     * Safety net for managers released before shutdown; the shutdown function
+     * registered in the constructor has usually flushed already, making this a no-op.
      * This implementation is not thread-safe, so be care
      */
     public function __destruct()
     {
-        $this->flushCacheState();
+        $this->flushSilently();
+    }
+
+    /**
+     * Flushes without ever propagating an error out of shutdown/destruction
+     *
+     * Losing one cache write is recoverable (the next request simply re-weaves);
+     * an exception escaping a destructor or shutdown function is not.
+     */
+    private function flushSilently(): void
+    {
+        try {
+            $this->flushCacheState();
+        } catch (\Throwable) {
+            // Deliberately swallowed, see above
+        }
     }
 
     /**

--- a/src/Instrument/Transformer/FilterInjectorTransformer.php
+++ b/src/Instrument/Transformer/FilterInjectorTransformer.php
@@ -108,10 +108,8 @@ class FilterInjectorTransformer implements SourceTransformer
     {
         self::ensureConfigured();
 
-        static $appDir, $cacheDir, $debug;
-        if ($appDir === null) {
-            extract(self::$options, EXTR_IF_EXISTS);
-        }
+        $cacheDir = self::$options['cacheDir'];
+        $debug    = self::$options['debug'];
 
         $resource = $originalResource;
         if ($resource[0] !== '/') {

--- a/src/Instrument/Transformer/MagicConstantTransformer.php
+++ b/src/Instrument/Transformer/MagicConstantTransformer.php
@@ -27,6 +27,8 @@ use PhpParser\NodeVisitor\FindingVisitor;
  * Transformer that replaces magic __DIR__ and __FILE__ constants in the source code
  *
  * Additionally, ReflectionClass->getFileName() is also wrapped into normalizer method call
+ *
+ * @phpstan-import-type KernelOptions from AspectKernel
  */
 class MagicConstantTransformer extends BaseSourceTransformer
 {
@@ -46,8 +48,18 @@ class MagicConstantTransformer extends BaseSourceTransformer
     public function __construct(AspectKernel $kernel)
     {
         parent::__construct($kernel);
-        self::$rootPath      = $this->options['appDir'];
-        self::$rewriteToPath = $this->options['cacheDir'] ?? '';
+        self::configurePaths($this->options);
+    }
+
+    /**
+     * Remembers the path mapping used by resolveFileName()
+     *
+     * @phpstan-param KernelOptions $options
+     */
+    private static function configurePaths(array $options): void
+    {
+        self::$rootPath      = $options['appDir'];
+        self::$rewriteToPath = $options['cacheDir'] ?? '';
     }
 
     /**
@@ -71,9 +83,7 @@ class MagicConstantTransformer extends BaseSourceTransformer
     public static function resolveFileName(string $fileName): string
     {
         if (self::$rootPath === '') {
-            $options             = AspectKernel::getInstance()->getOptions();
-            self::$rootPath      = $options['appDir'];
-            self::$rewriteToPath = $options['cacheDir'] ?? '';
+            self::configurePaths(AspectKernel::getInstance()->getOptions());
         }
         if (self::$rewriteToPath !== '' && str_starts_with($fileName, self::$rewriteToPath)) {
             $fileName = str_replace(self::$rewriteToPath, self::$rootPath, $fileName);


### PR DESCRIPTION
# Summary

The remaining process-cleanup items from the PHP 8.5 audit (one commit).

- **`FilterInjectorTransformer::rewrite()`**: the `static $appDir, $cacheDir, $debug;` locals populated via `extract(self::$options, EXTR_IF_EXISTS)` are replaced with typed array reads of the set-once `self::$options` (`KernelOptions` shape guarantees the keys) — analyzable by PHPStan, no variable materialization magic.
- **`MagicConstantTransformer`**: the duplicated constructor / on-demand path bootstrap is deduplicated into one `configurePaths()` helper; behavior identical (the on-demand path is still required because `resolveFileName()` runs from woven code where no transformer object exists).
- **`CachePathManager`**: pending cache records are now flushed from a **shutdown function registered at construction**, which runs while the runtime environment is still fully intact — instead of relying solely on `__destruct()`, whose ordering during shutdown is unspecified. The destructor remains as a safety net for managers released mid-request, and both teardown paths go through `flushSilently()`: an exception escaping a destructor or shutdown callback would be fatal, while losing one cache write just means the next request re-weaves. Explicit `flushCacheState()` calls keep their normal error behavior.
- `SourceTransformingLoader`'s set-once statics were reviewed and left as-is: a PHP stream filter is instantiated by the engine itself, so static collaborators wired in `ensureRegistered()` are inherent to the mechanism, and they are already typed and documented.

Issue #618 (lazy-ghost evaluation for constructor interception) is deliberately **not** part of this PR — it stays open as a decision item with an evaluation plan on the issue.

# Test evidence

| Gate | Result |
|---|---|
| `php8.5 vendor/bin/phpunit` | OK — 2584 tests, 3147 assertions |
| `php8.4 vendor/bin/phpunit` | OK — 2584 tests, 10 skipped (8.5-only) |
| `php8.5` / `php8.4 vendor/bin/phpstan analyze` (level 10) | No errors |
| `php8.6 vendor/bin/phpunit` (informational, 8.6.0beta2) | OK — 2584 tests |

Fixes #610